### PR TITLE
feat: RLS 정책 및 보안 설정 구성

### DIFF
--- a/supabase/migrations/20260101044518_create_rls_helpers.sql
+++ b/supabase/migrations/20260101044518_create_rls_helpers.sql
@@ -1,0 +1,37 @@
+-- RLS Helper Functions
+-- 가구 단위 데이터 격리를 위한 헬퍼 함수들
+
+-- 사용자가 속한 household_id 목록 조회
+create or replace function get_user_household_ids()
+returns setof uuid as $$
+  select household_id
+  from public.household_members
+  where user_id = (select auth.uid())
+$$ language sql security definer stable set search_path = '';
+
+-- 사용자가 특정 가구의 멤버인지 확인
+create or replace function is_household_member(hh_id uuid)
+returns boolean as $$
+  select exists (
+    select 1 from public.household_members
+    where household_id = hh_id and user_id = (select auth.uid())
+  )
+$$ language sql security definer stable set search_path = '';
+
+-- 사용자가 특정 가구의 owner인지 확인
+create or replace function is_household_owner(hh_id uuid)
+returns boolean as $$
+  select exists (
+    select 1 from public.household_members
+    where household_id = hh_id and user_id = (select auth.uid()) and role = 'owner'
+  )
+$$ language sql security definer stable set search_path = '';
+
+-- 사용자가 admin인지 확인
+create or replace function is_admin()
+returns boolean as $$
+  select exists (
+    select 1 from public.profiles
+    where id = (select auth.uid()) and role = 'admin'
+  )
+$$ language sql security definer stable set search_path = '';

--- a/supabase/migrations/20260101044605_create_rls_policies.sql
+++ b/supabase/migrations/20260101044605_create_rls_policies.sql
@@ -1,0 +1,206 @@
+-- RLS Policies
+-- 테이블별 Row Level Security 정책 설정
+-- 성능 최적화: auth.uid()를 (select auth.uid())로 사용하여 매 행 재평가 방지
+-- 중복 permissive 정책 통합: 같은 action에 여러 정책 대신 OR 조건으로 통합
+
+-- ============================================================================
+-- profiles
+-- ============================================================================
+alter table public.profiles enable row level security;
+
+-- SELECT: 본인, 같은 가구 멤버, Admin 통합
+create policy "Users can view profiles"
+  on public.profiles for select
+  using (
+    (select auth.uid()) = id
+    or id in (
+      select user_id from public.household_members
+      where household_id in (select get_user_household_ids())
+    )
+    or is_admin()
+  );
+
+-- UPDATE: 본인만
+create policy "Users can update own profile"
+  on public.profiles for update
+  using ((select auth.uid()) = id);
+
+-- ============================================================================
+-- households
+-- ============================================================================
+alter table public.households enable row level security;
+
+-- SELECT: 멤버, Admin 통합
+create policy "Users can view households"
+  on public.households for select
+  using (is_household_member(id) or is_admin());
+
+create policy "Users can create household"
+  on public.households for insert
+  with check (true);
+
+create policy "Owners can update household"
+  on public.households for update
+  using (is_household_owner(id));
+
+create policy "Owners can delete household"
+  on public.households for delete
+  using (is_household_owner(id));
+
+-- ============================================================================
+-- household_members
+-- ============================================================================
+alter table public.household_members enable row level security;
+
+create policy "Users can view household members"
+  on public.household_members for select
+  using (is_household_member(household_id));
+
+create policy "Owners can add members"
+  on public.household_members for insert
+  with check (is_household_owner(household_id) or user_id = (select auth.uid()));
+
+create policy "Owners can remove members or self"
+  on public.household_members for delete
+  using (is_household_owner(household_id) or user_id = (select auth.uid()));
+
+-- ============================================================================
+-- household_stock_settings
+-- ============================================================================
+alter table public.household_stock_settings enable row level security;
+
+create policy "Users can view household stock settings"
+  on public.household_stock_settings for select
+  using (is_household_member(household_id));
+
+create policy "Users can insert household stock settings"
+  on public.household_stock_settings for insert
+  with check (is_household_member(household_id));
+
+create policy "Users can update household stock settings"
+  on public.household_stock_settings for update
+  using (is_household_member(household_id));
+
+create policy "Users can delete household stock settings"
+  on public.household_stock_settings for delete
+  using (is_household_member(household_id));
+
+-- ============================================================================
+-- transactions
+-- ============================================================================
+alter table public.transactions enable row level security;
+
+create policy "Users can view household transactions"
+  on public.transactions for select
+  using (is_household_member(household_id));
+
+create policy "Users can insert household transactions"
+  on public.transactions for insert
+  with check (is_household_member(household_id));
+
+create policy "Users can update own transactions"
+  on public.transactions for update
+  using (is_household_member(household_id) and owner_id = (select auth.uid()));
+
+create policy "Users can delete own transactions"
+  on public.transactions for delete
+  using (is_household_member(household_id) and owner_id = (select auth.uid()));
+
+-- ============================================================================
+-- invitations
+-- ============================================================================
+alter table public.invitations enable row level security;
+
+-- SELECT: 가구 멤버이거나 누구나 (코드로 조회 가능) 통합
+-- 주의: using(true)는 모든 조회를 허용하므로 보안상 주의 필요
+-- 추후 코드 기반 필터링으로 개선 고려
+create policy "Anyone can view invitations"
+  on public.invitations for select
+  using (true);
+
+create policy "Users can create household invitations"
+  on public.invitations for insert
+  with check (is_household_member(household_id));
+
+-- ============================================================================
+-- tags
+-- ============================================================================
+alter table public.tags enable row level security;
+
+create policy "Users can view household tags"
+  on public.tags for select
+  using (is_household_member(household_id));
+
+create policy "Users can insert household tags"
+  on public.tags for insert
+  with check (is_household_member(household_id));
+
+create policy "Users can update household tags"
+  on public.tags for update
+  using (is_household_member(household_id));
+
+create policy "Users can delete household tags"
+  on public.tags for delete
+  using (is_household_member(household_id));
+
+-- ============================================================================
+-- holding_tags
+-- ============================================================================
+alter table public.holding_tags enable row level security;
+
+create policy "Users can view household holding_tags"
+  on public.holding_tags for select
+  using (is_household_member(household_id));
+
+create policy "Users can insert household holding_tags"
+  on public.holding_tags for insert
+  with check (is_household_member(household_id));
+
+create policy "Users can update household holding_tags"
+  on public.holding_tags for update
+  using (is_household_member(household_id));
+
+create policy "Users can delete household holding_tags"
+  on public.holding_tags for delete
+  using (is_household_member(household_id));
+
+-- ============================================================================
+-- target_allocations
+-- ============================================================================
+alter table public.target_allocations enable row level security;
+
+create policy "Users can view household targets"
+  on public.target_allocations for select
+  using (is_household_member(household_id));
+
+create policy "Users can insert household targets"
+  on public.target_allocations for insert
+  with check (is_household_member(household_id));
+
+create policy "Users can update household targets"
+  on public.target_allocations for update
+  using (is_household_member(household_id));
+
+create policy "Users can delete household targets"
+  on public.target_allocations for delete
+  using (is_household_member(household_id));
+
+-- ============================================================================
+-- stock_master (시스템 테이블 - 읽기 전용)
+-- ============================================================================
+alter table public.stock_master enable row level security;
+
+-- 모든 인증된 사용자가 조회 가능 (종목 검색용)
+create policy "Anyone can view stock_master"
+  on public.stock_master for select
+  using (true);
+
+-- ============================================================================
+-- exchange_rates (시스템 테이블 - 읽기 전용)
+-- ============================================================================
+alter table public.exchange_rates enable row level security;
+
+-- 모든 인증된 사용자가 조회 가능 (환율 조회용)
+create policy "Anyone can view exchange_rates"
+  on public.exchange_rates for select
+  using (true);

--- a/supabase/migrations/20260101050335_fix_holdings_view_security.sql
+++ b/supabase/migrations/20260101050335_fix_holdings_view_security.sql
@@ -1,0 +1,45 @@
+-- Fix holdings view SECURITY DEFINER issue
+-- security_invoker = on으로 설정하여 조회하는 사용자의 RLS 정책을 적용
+
+drop view if exists public.holdings;
+
+create view public.holdings
+with (security_invoker = on)
+as
+select
+  t.household_id,
+  t.owner_id,
+  t.ticker,
+  s.name,
+  s.asset_type,
+  s.market,
+  s.currency,
+  s.risk_level,
+  -- 현재 보유 수량
+  sum(case when t.type = 'buy' then t.quantity else -t.quantity end) as quantity,
+  -- 평균 매수가 (매수 거래만 계산)
+  case
+    when sum(case when t.type = 'buy' then t.quantity else 0 end) > 0
+    then sum(case when t.type = 'buy' then t.quantity * t.price else 0 end) /
+         sum(case when t.type = 'buy' then t.quantity else 0 end)
+    else 0
+  end as avg_price,
+  -- 총 매수 금액
+  sum(case when t.type = 'buy' then t.quantity * t.price else 0 end) as total_invested,
+  -- 최초 거래일
+  min(t.transacted_at) as first_transaction_at,
+  -- 최근 거래일
+  max(t.transacted_at) as last_transaction_at
+from public.transactions t
+join public.household_stock_settings s
+  on t.household_id = s.household_id and t.ticker = s.ticker
+group by
+  t.household_id,
+  t.owner_id,
+  t.ticker,
+  s.name,
+  s.asset_type,
+  s.market,
+  s.currency,
+  s.risk_level
+having sum(case when t.type = 'buy' then t.quantity else -t.quantity end) > 0;

--- a/supabase/migrations/20260101050725_fix_handle_new_user_search_path.sql
+++ b/supabase/migrations/20260101050725_fix_handle_new_user_search_path.sql
@@ -1,0 +1,11 @@
+-- Fix handle_new_user function search_path
+-- security definer 함수에 search_path 설정 추가
+
+create or replace function public.handle_new_user()
+returns trigger as $$
+begin
+  insert into public.profiles (id, email, name)
+  values (new.id, new.email, coalesce(new.raw_user_meta_data->>'name', ''));
+  return new;
+end;
+$$ language plpgsql security definer set search_path = '';

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -476,6 +476,10 @@ export type Database = {
       };
     };
     Functions: {
+      get_user_household_ids: { Args: never; Returns: string[] };
+      is_admin: { Args: never; Returns: boolean };
+      is_household_member: { Args: { hh_id: string }; Returns: boolean };
+      is_household_owner: { Args: { hh_id: string }; Returns: boolean };
       show_limit: { Args: never; Returns: number };
       show_trgm: { Args: { "": string }; Returns: string[] };
     };


### PR DESCRIPTION
## Summary
- RLS 헬퍼 함수 생성 (`get_user_household_ids`, `is_household_member`, `is_household_owner`, `is_admin`)
- 9개 테이블에 RLS 정책 적용 (가구 단위 데이터 격리)
- 시스템 테이블(`stock_master`, `exchange_rates`) RLS 활성화 (SELECT만 허용)
- 성능 최적화: `auth.uid()` → `(select auth.uid())`로 변경
- 중복 permissive 정책 OR 조건으로 통합
- `holdings` 뷰 `security_invoker = on` 설정
- `handle_new_user` 함수 `search_path` 설정

## 생성된 마이그레이션 파일
- `20260101044518_create_rls_helpers.sql`
- `20260101044605_create_rls_policies.sql`
- `20260101050335_fix_holdings_view_security.sql`
- `20260101050725_fix_handle_new_user_search_path.sql`

## Test plan
- [x] `pnpm supabase db reset` 성공
- [x] `pnpm type-check` 통과
- [x] `pnpm check` (biome) 통과

## 관련 이슈
Closes #33, #42, #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)