### PR TITLE
feat: Vercel 배포 GitHub Actions workflow 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,40 @@
+name: Deploy to Vercel
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: '배포 환경'
+        required: true
+        default: 'preview'
+        type: choice
+        options:
+          - preview
+          - production
+
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Vercel CLI
+        run: npm install -g vercel@latest
+
+      - name: Deploy to Vercel
+        id: deploy
+        run: |
+          if [ "${{ inputs.environment }}" = "production" ]; then
+            url=$(vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }})
+          else
+            url=$(vercel deploy --token=${{ secrets.VERCEL_TOKEN }})
+          fi
+          echo "url=$url" >> $GITHUB_OUTPUT
+
+      - name: Output Deployment URL
+        run: echo "Deployed to ${{ steps.deploy.outputs.url }}"


### PR DESCRIPTION
## Summary
- `workflow_dispatch`로 수동 트리거
- 배포 환경 선택 (preview / production)
- Vercel CLI를 통한 배포

## 필요한 GitHub Secrets
- `VERCEL_TOKEN`
- `VERCEL_ORG_ID`
- `VERCEL_PROJECT_ID`

## 사용 방법
1. GitHub Actions 탭 → "Deploy to Vercel" workflow
2. "Run workflow" 클릭
3. 환경 선택 (preview / production)
4. 실행

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)