### PR TITLE
feat: stock_prices 테이블 추가 및 stock_master 스키마 정리

### DIFF
--- a/supabase/migrations/20260102010548_add_stock_prices_table.sql
+++ b/supabase/migrations/20260102010548_add_stock_prices_table.sql
@@ -1,0 +1,27 @@
+-- stock_prices 테이블 추가 및 stock_master 스키마 정리
+-- KIS 마스터파일에 가격 정보가 없어 별도 테이블로 분리
+
+-- 1. stock_master에서 base_price 컬럼 제거
+alter table public.stock_master drop column if exists base_price;
+
+-- 2. stock_prices 테이블 생성 (가격 캐싱용)
+create table public.stock_prices (
+  market market_type not null,           -- KR, US
+  code text not null,                    -- 종목코드
+  price numeric(18, 4) not null,         -- 현재가
+  change_rate numeric(8, 4),             -- 등락률 (%)
+  fetched_at timestamptz not null,       -- 조회 시각
+
+  primary key (market, code)
+);
+
+-- 인덱스: 캐시 만료 확인용
+create index stock_prices_fetched_at_idx on public.stock_prices(fetched_at);
+
+-- 코멘트
+comment on table public.stock_prices is '주식 가격 캐시 테이블 (KIS API 조회 결과)';
+comment on column public.stock_prices.market is '시장 구분 (KR, US)';
+comment on column public.stock_prices.code is '종목코드';
+comment on column public.stock_prices.price is '현재가';
+comment on column public.stock_prices.change_rate is '등락률 (%)';
+comment on column public.stock_prices.fetched_at is 'KIS API 조회 시각 (캐시 버킷 판단용)';

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -272,7 +272,6 @@ export type Database = {
       };
       stock_master: {
         Row: {
-          base_price: number | null;
           choseong: string | null;
           code: string;
           exchange: string | null;
@@ -287,7 +286,6 @@ export type Database = {
           synced_at: string | null;
         };
         Insert: {
-          base_price?: number | null;
           choseong?: string | null;
           code: string;
           exchange?: string | null;
@@ -302,7 +300,6 @@ export type Database = {
           synced_at?: string | null;
         };
         Update: {
-          base_price?: number | null;
           choseong?: string | null;
           code?: string;
           exchange?: string | null;
@@ -315,6 +312,30 @@ export type Database = {
           name_en?: string | null;
           sector?: string | null;
           synced_at?: string | null;
+        };
+        Relationships: [];
+      };
+      stock_prices: {
+        Row: {
+          change_rate: number | null;
+          code: string;
+          fetched_at: string;
+          market: Database["public"]["Enums"]["market_type"];
+          price: number;
+        };
+        Insert: {
+          change_rate?: number | null;
+          code: string;
+          fetched_at: string;
+          market: Database["public"]["Enums"]["market_type"];
+          price: number;
+        };
+        Update: {
+          change_rate?: number | null;
+          code?: string;
+          fetched_at?: string;
+          market?: Database["public"]["Enums"]["market_type"];
+          price?: number;
         };
         Relationships: [];
       };


### PR DESCRIPTION
## Summary
- `stock_master`에서 `base_price` 컬럼 제거 (KIS 마스터파일에 가격 정보 없음)
- `stock_prices` 테이블 추가 (KIS API 가격 캐싱용)
- 1시간 버킷 단위 캐싱 정책 적용

## 변경사항
| 파일 | 변경 내용 |
|------|-----------|
| `supabase/migrations/...` | 마이그레이션 추가 |
| `.claude/docs/DATABASE.md` | 문서 업데이트 |
| `types/supabase.ts` | 타입 재생성 |

## 배경
KIS 마스터파일에 종가(base_price) 데이터가 포함되지 않아, 가격은 KIS API로 실시간 조회 후 DB에 캐싱하는 방식으로 변경.

## Test plan
- [x] `pnpm supabase db reset` 성공
- [x] `pnpm supabase:types` 타입 생성 확인
- [x] `stock_prices` 테이블 생성 확인
- [x] `stock_master`에서 `base_price` 컬럼 제거 확인

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)