### PR TITLE
feat: GitHub Actions 종목 마스터 동기화 구현

### DIFF
--- a/.github/workflows/sync-stock-master.yml
+++ b/.github/workflows/sync-stock-master.yml
@@ -1,0 +1,36 @@
+name: Sync Stock Master
+
+on:
+  schedule:
+    # 매일 08:00 KST (23:00 UTC)
+    - cron: '0 23 * * *'
+  workflow_dispatch:
+    # 수동 실행 가능
+
+env:
+  SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+  SUPABASE_SECRET_KEY: ${{ secrets.SUPABASE_SECRET_KEY }}
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run sync script
+        run: pnpm sync:stocks

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ next-env.d.ts
 
 # claude code
 .claude/settings.local.json
+
+# temp files
+/tmp

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "supabase:start": "supabase start",
     "supabase:stop": "supabase stop",
     "supabase:types": "supabase gen types typescript --local > types/supabase.ts",
+    "sync:stocks": "tsx scripts/sync-stock-master.ts",
     "prepare": "husky"
   },
   "dependencies": {
@@ -42,10 +43,15 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "dotenv": "^17.2.3",
+    "es-hangul": "^2.3.8",
     "husky": "^9.1.7",
+    "iconv-lite": "^0.7.1",
+    "jszip": "^3.10.1",
     "lint-staged": "^16.2.7",
     "supabase": "^2.70.5",
     "tailwindcss": "^4",
+    "tsx": "^4.21.0",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,9 +81,21 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.7)
+      dotenv:
+        specifier: ^17.2.3
+        version: 17.2.3
+      es-hangul:
+        specifier: ^2.3.8
+        version: 2.3.8
       husky:
         specifier: ^9.1.7
         version: 9.1.7
+      iconv-lite:
+        specifier: ^0.7.1
+        version: 0.7.1
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
       lint-staged:
         specifier: ^16.2.7
         version: 16.2.7
@@ -93,6 +105,9 @@ importers:
       tailwindcss:
         specifier: ^4
         version: 4.1.18
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
@@ -161,6 +176,162 @@ packages:
 
   '@emnapi/runtime@1.7.1':
     resolution: {integrity: sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==}
+
+  '@esbuild/aix-ppc64@0.27.2':
+    resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.2':
+    resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.2':
+    resolution: {integrity: sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.2':
+    resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.2':
+    resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.2':
+    resolution: {integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.2':
+    resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.2':
+    resolution: {integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.2':
+    resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.2':
+    resolution: {integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.2':
+    resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.2':
+    resolution: {integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.2':
+    resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.2':
+    resolution: {integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.2':
+    resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.2':
+    resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.2':
+    resolution: {integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.2':
+    resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.2':
+    resolution: {integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.2':
+    resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.2':
+    resolution: {integrity: sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.2':
+    resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.2':
+    resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.2':
+    resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.2':
+    resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.2':
+    resolution: {integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@hookform/resolvers@5.2.2':
     resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
@@ -636,6 +807,9 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -656,6 +830,10 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  dotenv@17.2.3:
+    resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
+    engines: {node: '>=12'}
+
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
@@ -666,6 +844,14 @@ packages:
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
+
+  es-hangul@2.3.8:
+    resolution: {integrity: sha512-VrJuqYBC7W04aKYjCnswomuJNXQRc0q33SG1IltVrRofi2YEE6FwVDPlsEJIdKbHwsOpbBL/mk9sUaBxVpbd+w==}
+
+  esbuild@0.27.2:
+    resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
@@ -682,9 +868,17 @@ packages:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
 
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   get-east-asian-width@1.4.0:
     resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
     engines: {node: '>=18'}
+
+  get-tsconfig@4.13.0:
+    resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -702,9 +896,19 @@ packages:
     resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
     engines: {node: '>=20.0.0'}
 
+  iconv-lite@0.7.1:
+    resolution: {integrity: sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw==}
+    engines: {node: '>=0.10.0'}
+
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   is-fullwidth-code-point@5.1.0:
     resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
@@ -714,9 +918,18 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lightningcss-android-arm64@1.30.2:
     resolution: {integrity: sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==}
@@ -875,6 +1088,9 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -898,6 +1114,9 @@ packages:
   proc-log@6.1.0:
     resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
   react-dom@19.2.3:
     resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
@@ -924,12 +1143,24 @@ packages:
     resolution: {integrity: sha512-1zM5HuOfagXCBWMN83fuFI/x+T/UhZ7k+KIzhrHXcQoeX5+7gmaDYjELQHmmzIodumBHeByBJT4QYS7ufAgs7A==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -938,6 +1169,9 @@ packages:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
     engines: {node: '>=10'}
     hasBin: true
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -966,6 +1200,9 @@ packages:
   string-width@8.1.0:
     resolution: {integrity: sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==}
     engines: {node: '>=20'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   strip-ansi@7.1.2:
     resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
@@ -1010,6 +1247,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
@@ -1020,6 +1262,9 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
@@ -1117,6 +1362,84 @@ snapshots:
   '@emnapi/runtime@1.7.1':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/android-arm@0.27.2':
+    optional: true
+
+  '@esbuild/android-x64@0.27.2':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.2':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.2':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.2':
     optional: true
 
   '@hookform/resolvers@5.2.2(react-hook-form@7.69.0(react@19.2.3))':
@@ -1500,6 +1823,8 @@ snapshots:
 
   cookie@1.1.1: {}
 
+  core-util-is@1.0.3: {}
+
   csstype@3.2.3: {}
 
   data-uri-to-buffer@4.0.1: {}
@@ -1510,6 +1835,8 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
+  dotenv@17.2.3: {}
+
   emoji-regex@10.6.0: {}
 
   enhanced-resolve@5.18.4:
@@ -1518,6 +1845,37 @@ snapshots:
       tapable: 2.3.0
 
   environment@1.1.0: {}
+
+  es-hangul@2.3.8: {}
+
+  esbuild@0.27.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.2
+      '@esbuild/android-arm': 0.27.2
+      '@esbuild/android-arm64': 0.27.2
+      '@esbuild/android-x64': 0.27.2
+      '@esbuild/darwin-arm64': 0.27.2
+      '@esbuild/darwin-x64': 0.27.2
+      '@esbuild/freebsd-arm64': 0.27.2
+      '@esbuild/freebsd-x64': 0.27.2
+      '@esbuild/linux-arm': 0.27.2
+      '@esbuild/linux-arm64': 0.27.2
+      '@esbuild/linux-ia32': 0.27.2
+      '@esbuild/linux-loong64': 0.27.2
+      '@esbuild/linux-mips64el': 0.27.2
+      '@esbuild/linux-ppc64': 0.27.2
+      '@esbuild/linux-riscv64': 0.27.2
+      '@esbuild/linux-s390x': 0.27.2
+      '@esbuild/linux-x64': 0.27.2
+      '@esbuild/netbsd-arm64': 0.27.2
+      '@esbuild/netbsd-x64': 0.27.2
+      '@esbuild/openbsd-arm64': 0.27.2
+      '@esbuild/openbsd-x64': 0.27.2
+      '@esbuild/openharmony-arm64': 0.27.2
+      '@esbuild/sunos-x64': 0.27.2
+      '@esbuild/win32-arm64': 0.27.2
+      '@esbuild/win32-ia32': 0.27.2
+      '@esbuild/win32-x64': 0.27.2
 
   eventemitter3@5.0.1: {}
 
@@ -1534,7 +1892,14 @@ snapshots:
     dependencies:
       fetch-blob: 3.2.0
 
+  fsevents@2.3.3:
+    optional: true
+
   get-east-asian-width@1.4.0: {}
+
+  get-tsconfig@4.13.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   graceful-fs@4.2.11: {}
 
@@ -1549,7 +1914,15 @@ snapshots:
 
   iceberg-js@0.8.1: {}
 
+  iconv-lite@0.7.1:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  immediate@3.0.6: {}
+
   imurmurhash@0.1.4: {}
+
+  inherits@2.0.4: {}
 
   is-fullwidth-code-point@5.1.0:
     dependencies:
@@ -1557,7 +1930,20 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  isarray@1.0.0: {}
+
   jiti@2.6.1: {}
+
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lightningcss-android-arm64@1.30.2:
     optional: true
@@ -1700,6 +2086,8 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
+  pako@1.0.11: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -1720,6 +2108,8 @@ snapshots:
 
   proc-log@6.1.0: {}
 
+  process-nextick-args@2.0.1: {}
+
   react-dom@19.2.3(react@19.2.3):
     dependencies:
       react: 19.2.3
@@ -1738,6 +2128,18 @@ snapshots:
 
   read-cmd-shim@6.0.0: {}
 
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
+  resolve-pkg-maps@1.0.0: {}
+
   restore-cursor@5.1.0:
     dependencies:
       onetime: 7.0.0
@@ -1745,10 +2147,16 @@ snapshots:
 
   rfdc@1.4.1: {}
 
+  safe-buffer@5.1.2: {}
+
+  safer-buffer@2.1.2: {}
+
   scheduler@0.27.0: {}
 
   semver@7.7.3:
     optional: true
+
+  setimmediate@1.0.5: {}
 
   sharp@0.34.5:
     dependencies:
@@ -1804,6 +2212,10 @@ snapshots:
       get-east-asian-width: 1.4.0
       strip-ansi: 7.1.2
 
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
   strip-ansi@7.1.2:
     dependencies:
       ansi-regex: 6.2.2
@@ -1842,11 +2254,20 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.2
+      get-tsconfig: 4.13.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   tw-animate-css@1.4.0: {}
 
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
+
+  util-deprecate@1.0.2: {}
 
   web-streams-polyfill@3.3.3: {}
 

--- a/scripts/lib/download.ts
+++ b/scripts/lib/download.ts
@@ -1,0 +1,26 @@
+import JSZip from "jszip";
+
+/**
+ * ZIP 파일 다운로드 및 압축 해제
+ */
+export async function downloadAndUnzip(url: string): Promise<Buffer> {
+  console.log(`  다운로드 중: ${url}`);
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`다운로드 실패: ${url} (${response.status})`);
+  }
+  const zipBuffer = await response.arrayBuffer();
+  const zip = await JSZip.loadAsync(zipBuffer);
+
+  // ZIP 내 첫 번째 파일 추출 (디렉토리 제외)
+  const fileNames = Object.keys(zip.files).filter(
+    (name) => !zip.files[name].dir,
+  );
+  if (fileNames.length === 0) {
+    throw new Error(`ZIP 파일이 비어있음: ${url}`);
+  }
+
+  const firstFile = zip.files[fileNames[0]];
+  const content = await firstFile.async("nodebuffer");
+  return content;
+}

--- a/scripts/lib/mappings.ts
+++ b/scripts/lib/mappings.ts
@@ -1,0 +1,35 @@
+import type { Database } from "../../types/supabase";
+
+type StockTypeCategory = Database["public"]["Enums"]["stock_type_category"];
+
+interface StockTypeMapping {
+  name: string;
+  category: StockTypeCategory;
+}
+
+// 국내 그룹코드 매핑
+export const KR_STOCK_TYPE_MAPPINGS: Record<string, StockTypeMapping> = {
+  ST: { name: "주권", category: "stock" },
+  MF: { name: "증권투자회사", category: "fund" },
+  RT: { name: "부동산투자회사", category: "reit" },
+  SC: { name: "선박투자회사", category: "fund" },
+  IF: { name: "사회간접자본투융자회사", category: "fund" },
+  DR: { name: "주식예탁증서", category: "stock" },
+  SW: { name: "신주인수권증권", category: "warrant" },
+  SR: { name: "신주인수권증서", category: "warrant" },
+  EW: { name: "주식워런트증권", category: "warrant" },
+  PF: { name: "수익증권", category: "fund" },
+  EF: { name: "ETF", category: "etf" },
+  EN: { name: "ETN", category: "etn" },
+  BC: { name: "수익증권", category: "fund" },
+  FE: { name: "해외ETF", category: "etf" },
+  FS: { name: "외국주권", category: "stock" },
+};
+
+// 해외 증권유형 매핑
+export const US_STOCK_TYPE_MAPPINGS: Record<string, StockTypeMapping> = {
+  "1": { name: "지수", category: "index" },
+  "2": { name: "주식", category: "stock" },
+  "3": { name: "ETF", category: "etf" },
+  "4": { name: "워런트", category: "warrant" },
+};

--- a/scripts/lib/parse-kosdaq.ts
+++ b/scripts/lib/parse-kosdaq.ts
@@ -1,0 +1,78 @@
+import { getChoseong } from "es-hangul";
+import iconv from "iconv-lite";
+import { KR_STOCK_TYPE_MAPPINGS } from "./mappings";
+import type { ParsedStock } from "./types";
+
+/**
+ * KOSDAQ 마스터파일 파싱
+ *
+ * 파일 형식: 고정폭 (바이트 단위, CP949 인코딩)
+ * - Part 1: 단축코드(9) + 표준코드(12) + 한글명(가변)
+ * - Part 2: 마지막 221바이트 (KOSPI와 다름!)
+ *   - offset 0-1: 그룹코드 (ST, EF, EN 등)
+ */
+export function parseKosdaqFile(buffer: Buffer): ParsedStock[] {
+  const lines = splitLines(buffer);
+  const records: ParsedStock[] = [];
+
+  for (const lineBuffer of lines) {
+    if (lineBuffer.length < 250) continue;
+
+    // Part 1: 처음부터 마지막 221바이트 전까지
+    const part1Buffer = lineBuffer.subarray(0, lineBuffer.length - 221);
+    const part1 = iconv.decode(part1Buffer, "cp949");
+
+    // Part 2: 마지막 221바이트
+    const part2Buffer = lineBuffer.subarray(-221);
+    const part2 = iconv.decode(part2Buffer, "cp949");
+
+    // Part 1에서 종목코드, 종목명 추출
+    const shortCode = part1.substring(0, 9).trim();
+    const name = part1.substring(21).trim();
+
+    // Part 2에서 그룹코드 추출
+    const groupCode = part2.substring(0, 2).trim();
+
+    // 종목코드가 숫자 6자리인 경우만 처리
+    if (!/^\d{6}$/.test(shortCode)) continue;
+
+    // 종목유형 매핑
+    const mapping = KR_STOCK_TYPE_MAPPINGS[groupCode];
+    if (!mapping && groupCode) {
+      console.warn(
+        `  [KOSDAQ] 알 수 없는 그룹코드: ${groupCode} (${shortCode})`,
+      );
+    }
+
+    records.push({
+      code: shortCode,
+      name,
+      name_en: null,
+      choseong: getChoseong(name),
+      market: "KR",
+      exchange: "KOSDAQ",
+      stock_type_code: groupCode || null,
+      stock_type_name: mapping?.name || null,
+      stock_type_category: mapping?.category || null,
+      is_active: true,
+      is_suspended: false,
+    });
+  }
+
+  return records;
+}
+
+function splitLines(buffer: Buffer): Buffer[] {
+  const lines: Buffer[] = [];
+  let start = 0;
+  for (let i = 0; i < buffer.length; i++) {
+    if (buffer[i] === 0x0a) {
+      lines.push(buffer.subarray(start, i));
+      start = i + 1;
+    }
+  }
+  if (start < buffer.length) {
+    lines.push(buffer.subarray(start));
+  }
+  return lines;
+}

--- a/scripts/lib/parse-kospi.ts
+++ b/scripts/lib/parse-kospi.ts
@@ -1,0 +1,78 @@
+import { getChoseong } from "es-hangul";
+import iconv from "iconv-lite";
+import { KR_STOCK_TYPE_MAPPINGS } from "./mappings";
+import type { ParsedStock } from "./types";
+
+/**
+ * KOSPI 마스터파일 파싱
+ *
+ * 파일 형식: 고정폭 (바이트 단위, CP949 인코딩)
+ * - Part 1: 단축코드(9) + 표준코드(12) + 한글명(가변)
+ * - Part 2: 마지막 227바이트 (고정폭 데이터)
+ *   - offset 0-1: 그룹코드 (ST, EF, EN 등)
+ */
+export function parseKospiFile(buffer: Buffer): ParsedStock[] {
+  const lines = splitLines(buffer);
+  const records: ParsedStock[] = [];
+
+  for (const lineBuffer of lines) {
+    if (lineBuffer.length < 250) continue;
+
+    // Part 1: 처음부터 마지막 227바이트 전까지
+    const part1Buffer = lineBuffer.subarray(0, lineBuffer.length - 227);
+    const part1 = iconv.decode(part1Buffer, "cp949");
+
+    // Part 2: 마지막 227바이트
+    const part2Buffer = lineBuffer.subarray(-227);
+    const part2 = iconv.decode(part2Buffer, "cp949");
+
+    // Part 1에서 종목코드, 종목명 추출
+    const shortCode = part1.substring(0, 9).trim();
+    const name = part1.substring(21).trim();
+
+    // Part 2에서 그룹코드 추출
+    const groupCode = part2.substring(0, 2).trim();
+
+    // 종목코드가 숫자 6자리인 경우만 처리
+    if (!/^\d{6}$/.test(shortCode)) continue;
+
+    // 종목유형 매핑
+    const mapping = KR_STOCK_TYPE_MAPPINGS[groupCode];
+    if (!mapping && groupCode) {
+      console.warn(
+        `  [KOSPI] 알 수 없는 그룹코드: ${groupCode} (${shortCode})`,
+      );
+    }
+
+    records.push({
+      code: shortCode,
+      name,
+      name_en: null,
+      choseong: getChoseong(name),
+      market: "KR",
+      exchange: "KOSPI",
+      stock_type_code: groupCode || null,
+      stock_type_name: mapping?.name || null,
+      stock_type_category: mapping?.category || null,
+      is_active: true,
+      is_suspended: false,
+    });
+  }
+
+  return records;
+}
+
+function splitLines(buffer: Buffer): Buffer[] {
+  const lines: Buffer[] = [];
+  let start = 0;
+  for (let i = 0; i < buffer.length; i++) {
+    if (buffer[i] === 0x0a) {
+      lines.push(buffer.subarray(start, i));
+      start = i + 1;
+    }
+  }
+  if (start < buffer.length) {
+    lines.push(buffer.subarray(start));
+  }
+  return lines;
+}

--- a/scripts/lib/parse-overseas.ts
+++ b/scripts/lib/parse-overseas.ts
@@ -1,0 +1,60 @@
+import { getChoseong } from "es-hangul";
+import iconv from "iconv-lite";
+import { US_STOCK_TYPE_MAPPINGS } from "./mappings";
+import type { ParsedStock } from "./types";
+
+/**
+ * 해외 주식 마스터파일 파싱
+ *
+ * 파일 형식: 탭 구분자 (CP949 인코딩)
+ * 컬럼: 국가(0), 시장타입(1), 거래소코드(2), 거래소명(3),
+ *       심볼(4), 종목코드(5), 한글명(6), 영문명(7), 증권유형(8), ...
+ */
+export function parseOverseasFile(
+  buffer: Buffer,
+  exchange: string,
+): ParsedStock[] {
+  const content = iconv.decode(buffer, "cp949");
+  const lines = content.split("\n").filter((line) => line.trim());
+  const records: ParsedStock[] = [];
+
+  for (const line of lines) {
+    const fields = line.split("\t");
+    if (fields.length < 9) continue;
+
+    const symbol = fields[4]?.trim();
+    const nameKr = fields[6]?.trim();
+    const nameEn = fields[7]?.trim();
+    const securityType = fields[8]?.trim();
+
+    if (!symbol || !nameKr) continue;
+
+    // 한글 이름이 있으면 초성 생성
+    const hasKorean = /[가-힣]/.test(nameKr);
+    const choseong = hasKorean ? getChoseong(nameKr) : null;
+
+    // 종목유형 매핑
+    const mapping = US_STOCK_TYPE_MAPPINGS[securityType];
+    if (!mapping && securityType) {
+      console.warn(
+        `  [${exchange}] 알 수 없는 증권유형: ${securityType} (${symbol})`,
+      );
+    }
+
+    records.push({
+      code: symbol,
+      name: nameKr,
+      name_en: nameEn || null,
+      choseong,
+      market: "US",
+      exchange,
+      stock_type_code: securityType || null,
+      stock_type_name: mapping?.name || null,
+      stock_type_category: mapping?.category || null,
+      is_active: true,
+      is_suspended: false,
+    });
+  }
+
+  return records;
+}

--- a/scripts/lib/types.ts
+++ b/scripts/lib/types.ts
@@ -1,0 +1,20 @@
+import type { Database } from "../../types/supabase";
+
+export type StockInsert =
+  Database["public"]["Tables"]["stock_master"]["Insert"];
+
+export interface ParsedStock {
+  code: string;
+  name: string;
+  name_en: string | null;
+  choseong: string | null;
+  market: "KR" | "US";
+  exchange: string;
+  stock_type_code: string | null;
+  stock_type_name: string | null;
+  stock_type_category:
+    | Database["public"]["Enums"]["stock_type_category"]
+    | null;
+  is_active: boolean;
+  is_suspended: boolean;
+}

--- a/scripts/sync-stock-master.ts
+++ b/scripts/sync-stock-master.ts
@@ -1,0 +1,161 @@
+/**
+ * KIS 마스터파일을 다운로드하여 stock_master 테이블에 동기화하는 스크립트
+ *
+ * 사용법:
+ *   pnpm sync:stocks
+ *
+ * 환경변수 (fallback 지원):
+ *   SUPABASE_URL 또는 NEXT_PUBLIC_SUPABASE_URL
+ *   SUPABASE_SECRET_KEY
+ */
+
+import { createClient } from "@supabase/supabase-js";
+import { config } from "dotenv";
+
+// 로컬 환경에서 .env.local 로드 (GitHub Actions에서는 이미 환경변수가 설정됨)
+config({ path: ".env.local" });
+
+import type { Database } from "../types/supabase";
+import { downloadAndUnzip } from "./lib/download";
+import { parseKosdaqFile } from "./lib/parse-kosdaq";
+import { parseKospiFile } from "./lib/parse-kospi";
+import { parseOverseasFile } from "./lib/parse-overseas";
+import type { StockInsert } from "./lib/types";
+
+// 환경변수 (fallback 지원)
+const SUPABASE_URL =
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_SECRET_KEY = process.env.SUPABASE_SECRET_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_SECRET_KEY) {
+  console.error(
+    "환경변수가 필요합니다: SUPABASE_URL (또는 NEXT_PUBLIC_SUPABASE_URL), SUPABASE_SECRET_KEY",
+  );
+  process.exit(1);
+}
+
+const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_SECRET_KEY);
+
+// 다운로드 URL 설정
+const SOURCES = [
+  {
+    url: "https://new.real.download.dws.co.kr/common/master/kospi_code.mst.zip",
+    exchange: "KOSPI",
+    parser: parseKospiFile,
+  },
+  {
+    url: "https://new.real.download.dws.co.kr/common/master/kosdaq_code.mst.zip",
+    exchange: "KOSDAQ",
+    parser: parseKosdaqFile,
+  },
+  {
+    url: "https://new.real.download.dws.co.kr/common/master/nasmst.cod.zip",
+    exchange: "NASDAQ",
+    parser: (buf: Buffer) => parseOverseasFile(buf, "NASDAQ"),
+  },
+  {
+    url: "https://new.real.download.dws.co.kr/common/master/nysmst.cod.zip",
+    exchange: "NYSE",
+    parser: (buf: Buffer) => parseOverseasFile(buf, "NYSE"),
+  },
+  {
+    url: "https://new.real.download.dws.co.kr/common/master/amsmst.cod.zip",
+    exchange: "AMEX",
+    parser: (buf: Buffer) => parseOverseasFile(buf, "AMEX"),
+  },
+];
+
+/**
+ * 단일 소스 다운로드 및 파싱
+ */
+async function processSource(source: (typeof SOURCES)[0]) {
+  const buffer = await downloadAndUnzip(source.url);
+  const records = source.parser(buffer);
+  console.log(`  ${source.exchange}: ${records.length}개`);
+  return { exchange: source.exchange, records };
+}
+
+/**
+ * Supabase에 UPSERT (배치 처리)
+ */
+async function upsertToSupabase(records: StockInsert[]): Promise<void> {
+  if (records.length === 0) return;
+
+  const batchSize = 1000;
+  for (let i = 0; i < records.length; i += batchSize) {
+    const batch = records.slice(i, i + batchSize);
+    const { error } = await supabase.from("stock_master").upsert(
+      batch.map((r) => ({
+        ...r,
+        synced_at: new Date().toISOString(),
+      })),
+      { onConflict: "market,code" },
+    );
+
+    if (error) {
+      console.error(`  UPSERT 오류 (batch ${i / batchSize + 1}):`, error);
+      throw error;
+    }
+
+    console.log(`  UPSERT 완료: ${i + batch.length}/${records.length}`);
+  }
+}
+
+/**
+ * 메인 함수
+ */
+async function main() {
+  console.log("=== 종목 마스터 동기화 시작 ===\n");
+  console.log("[다운로드 및 파싱] (병렬 처리)");
+
+  // 모든 소스 병렬 다운로드 및 파싱
+  const results = await Promise.allSettled(SOURCES.map(processSource));
+
+  // 결과 집계
+  const allRecords: StockInsert[] = [];
+  const summary: { exchange: string; count: number; success: boolean }[] = [];
+
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i];
+    const exchange = SOURCES[i].exchange;
+
+    if (result.status === "fulfilled") {
+      allRecords.push(...result.value.records);
+      summary.push({
+        exchange,
+        count: result.value.records.length,
+        success: true,
+      });
+    } else {
+      console.error(`  ${exchange} 실패:`, result.reason);
+      summary.push({ exchange, count: 0, success: false });
+    }
+  }
+
+  // Supabase UPSERT
+  console.log(`\n[Supabase UPSERT] 총 ${allRecords.length}개`);
+  await upsertToSupabase(allRecords);
+
+  // 결과 요약
+  console.log("\n=== 결과 요약 ===");
+  const krCount = summary
+    .filter((r) => ["KOSPI", "KOSDAQ"].includes(r.exchange))
+    .reduce((sum, r) => sum + r.count, 0);
+  const usCount = summary
+    .filter((r) => ["NASDAQ", "NYSE", "AMEX"].includes(r.exchange))
+    .reduce((sum, r) => sum + r.count, 0);
+  const failedCount = summary.filter((r) => !r.success).length;
+
+  console.log(`국내: ${krCount}개 (KOSPI + KOSDAQ)`);
+  console.log(`해외: ${usCount}개 (NASDAQ + NYSE + AMEX)`);
+  console.log(`총계: ${allRecords.length}개`);
+  if (failedCount > 0) {
+    console.log(`실패: ${failedCount}개 거래소`);
+  }
+  console.log("\n=== 종목 마스터 동기화 완료 ===");
+}
+
+main().catch((error) => {
+  console.error("동기화 실패:", error);
+  process.exit(1);
+});

--- a/supabase/migrations/20260102023307_refactor_system_tables.sql
+++ b/supabase/migrations/20260102023307_refactor_system_tables.sql
@@ -1,0 +1,31 @@
+-- 시스템 테이블 리팩토링
+-- stock_master에서 market_cap_size, sector 삭제, 종목유형 컬럼 추가
+
+-- ============================================================================
+-- 종목유형 카테고리 enum 생성
+-- ============================================================================
+create type stock_type_category as enum (
+  'stock',    -- 주식
+  'etf',      -- ETF
+  'etn',      -- ETN
+  'fund',     -- 펀드/수익증권
+  'reit',     -- 리츠
+  'warrant',  -- 워런트
+  'index'     -- 지수
+);
+
+-- ============================================================================
+-- stock_master 컬럼 변경
+-- ============================================================================
+
+-- 기존 컬럼 삭제
+alter table public.stock_master drop column if exists market_cap_size;
+alter table public.stock_master drop column if exists sector;
+
+-- 종목유형 컬럼 추가
+alter table public.stock_master add column stock_type_code text;                    -- 원본 코드 (KR: 'ST','EF' / US: '2','3')
+alter table public.stock_master add column stock_type_name text;                    -- 한글명 ('주권', 'ETF')
+alter table public.stock_master add column stock_type_category stock_type_category; -- 통합 카테고리
+
+-- 인덱스 추가 (카테고리별 필터링용)
+create index stock_master_stock_type_category_idx on public.stock_master(stock_type_category);

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -279,10 +279,13 @@ export type Database = {
           is_active: boolean | null;
           is_suspended: boolean | null;
           market: Database["public"]["Enums"]["market_type"];
-          market_cap_size: string | null;
           name: string;
           name_en: string | null;
-          sector: string | null;
+          stock_type_category:
+            | Database["public"]["Enums"]["stock_type_category"]
+            | null;
+          stock_type_code: string | null;
+          stock_type_name: string | null;
           synced_at: string | null;
         };
         Insert: {
@@ -293,10 +296,13 @@ export type Database = {
           is_active?: boolean | null;
           is_suspended?: boolean | null;
           market: Database["public"]["Enums"]["market_type"];
-          market_cap_size?: string | null;
           name: string;
           name_en?: string | null;
-          sector?: string | null;
+          stock_type_category?:
+            | Database["public"]["Enums"]["stock_type_category"]
+            | null;
+          stock_type_code?: string | null;
+          stock_type_name?: string | null;
           synced_at?: string | null;
         };
         Update: {
@@ -307,10 +313,13 @@ export type Database = {
           is_active?: boolean | null;
           is_suspended?: boolean | null;
           market?: Database["public"]["Enums"]["market_type"];
-          market_cap_size?: string | null;
           name?: string;
           name_en?: string | null;
-          sector?: string | null;
+          stock_type_category?:
+            | Database["public"]["Enums"]["stock_type_category"]
+            | null;
+          stock_type_code?: string | null;
+          stock_type_name?: string | null;
           synced_at?: string | null;
         };
         Relationships: [];
@@ -525,6 +534,14 @@ export type Database = {
       household_role: "owner" | "member";
       market_type: "KR" | "US" | "OTHER";
       risk_level: "safe" | "moderate" | "aggressive";
+      stock_type_category:
+        | "stock"
+        | "etf"
+        | "etn"
+        | "fund"
+        | "reit"
+        | "warrant"
+        | "index";
       transaction_type: "buy" | "sell";
       user_role: "user" | "admin";
     };
@@ -682,6 +699,15 @@ export const Constants = {
       household_role: ["owner", "member"],
       market_type: ["KR", "US", "OTHER"],
       risk_level: ["safe", "moderate", "aggressive"],
+      stock_type_category: [
+        "stock",
+        "etf",
+        "etn",
+        "fund",
+        "reit",
+        "warrant",
+        "index",
+      ],
       transaction_type: ["buy", "sell"],
       user_role: ["user", "admin"],
     },


### PR DESCRIPTION
## Summary
- KIS 마스터파일 다운로드 및 stock_master 테이블 동기화 스크립트 구현
- stock_master 스키마 변경: `stock_type_code`, `stock_type_name`, `stock_type_category` 컬럼 추가
- GitHub Actions workflow로 매일 08:00 KST 자동 동기화

## Changes
### 동기화 스크립트 (`scripts/`)
- `sync-stock-master.ts`: 메인 스크립트 (Promise.all 병렬 처리)
- `lib/parse-kospi.ts`: KOSPI 파서 (Part 2: 227 bytes)
- `lib/parse-kosdaq.ts`: KOSDAQ 파서 (Part 2: 221 bytes)
- `lib/parse-overseas.ts`: 해외 주식 파서 (NASDAQ/NYSE/AMEX)
- `lib/mappings.ts`: 종목유형 매핑 (그룹코드 → 카테고리)

### 스키마 변경
- `market_cap_size`, `sector` 컬럼 삭제
- `stock_type_category` enum 추가: stock, etf, etn, fund, reit, warrant, index
- 국내/해외 ETF 통합 조회 가능 (`WHERE stock_type_category = 'etf'`)

### GitHub Actions
- `.github/workflows/sync-stock-master.yml`
- 스케줄: 매일 23:00 UTC (08:00 KST)
- 수동 실행 지원

## Test plan
- [x] `pnpm type-check` 통과
- [x] `pnpm sync:stocks` 로컬 테스트 완료 (15,438개 종목)
- [x] KOSPI/KOSDAQ stock_type_code 정상 파싱 확인
- [x] stock_type_category enum 정상 동작 확인

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)