### PR TITLE
feat: 로그인 페이지 구현

### DIFF
--- a/app/(auth)/login/actions.ts
+++ b/app/(auth)/login/actions.ts
@@ -1,0 +1,32 @@
+"use server";
+
+import { signIn } from "@/lib/supabase/auth";
+
+interface SignInActionInput {
+  email: string;
+  password: string;
+}
+
+interface SignInActionResult {
+  error?: string;
+}
+
+export async function signInAction(
+  input: SignInActionInput,
+): Promise<SignInActionResult> {
+  try {
+    await signIn(input.email, input.password);
+    return {};
+  } catch (error) {
+    if (error instanceof Error) {
+      if (error.message.includes("Invalid login credentials")) {
+        return { error: "이메일 또는 비밀번호가 올바르지 않습니다" };
+      }
+      if (error.message.includes("Email not confirmed")) {
+        return { error: "이메일 인증이 완료되지 않았습니다" };
+      }
+      return { error: error.message };
+    }
+    return { error: "로그인에 실패했습니다. 다시 시도해주세요." };
+  }
+}

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,0 +1,19 @@
+import { SignInForm } from "@/components/auth/SignInForm";
+
+export default function LoginPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+      <div className="w-full max-w-md space-y-8">
+        <div className="text-center">
+          <h1 className="text-3xl font-bold text-gray-900">oat</h1>
+          <p className="mt-2 text-gray-500">가족 자산 통합 관리</p>
+        </div>
+
+        <div className="bg-white rounded-2xl shadow-lg p-8">
+          <h2 className="text-xl font-semibold text-gray-900 mb-6">로그인</h2>
+          <SignInForm />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/auth/SignInForm.tsx
+++ b/components/auth/SignInForm.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { signInAction } from "@/app/(auth)/login/actions";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { type SignInFormData, signInSchema } from "@/lib/schemas/auth";
+
+export function SignInForm() {
+  const router = useRouter();
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<SignInFormData>({
+    resolver: zodResolver(signInSchema),
+    defaultValues: {
+      email: "",
+      password: "",
+    },
+  });
+
+  const onSubmit = async (data: SignInFormData) => {
+    setServerError(null);
+
+    const result = await signInAction({
+      email: data.email,
+      password: data.password,
+    });
+
+    if (result.error) {
+      setServerError(result.error);
+      return;
+    }
+
+    router.push("/dashboard");
+    router.refresh();
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+      <div className="space-y-2">
+        <Label htmlFor="email" className="text-gray-700">
+          이메일
+        </Label>
+        <Input
+          id="email"
+          type="email"
+          placeholder="example@email.com"
+          className="h-12 rounded-xl"
+          aria-invalid={!!errors.email}
+          {...register("email")}
+        />
+        {errors.email && (
+          <p className="text-sm text-destructive">{errors.email.message}</p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="password" className="text-gray-700">
+          비밀번호
+        </Label>
+        <Input
+          id="password"
+          type="password"
+          placeholder="비밀번호를 입력해주세요"
+          className="h-12 rounded-xl"
+          aria-invalid={!!errors.password}
+          {...register("password")}
+        />
+        {errors.password && (
+          <p className="text-sm text-destructive">{errors.password.message}</p>
+        )}
+      </div>
+
+      {serverError && (
+        <p className="text-sm text-destructive text-center">{serverError}</p>
+      )}
+
+      <Button
+        type="submit"
+        className="w-full h-12 rounded-xl text-base font-semibold"
+        disabled={isSubmitting}
+      >
+        {isSubmitting ? "로그인 중..." : "로그인"}
+      </Button>
+
+      <div className="space-y-2 text-center text-sm">
+        <p className="text-gray-500">
+          계정이 없으신가요?{" "}
+          <Link href="/signup" className="text-primary hover:underline">
+            회원가입
+          </Link>
+        </p>
+        <p>
+          <Link
+            href="/reset-password"
+            className="text-gray-500 hover:underline"
+          >
+            비밀번호를 잊으셨나요?
+          </Link>
+        </p>
+      </div>
+    </form>
+  );
+}

--- a/lib/schemas/auth.ts
+++ b/lib/schemas/auth.ts
@@ -22,3 +22,10 @@ export const signUpSchema = z
   });
 
 export type SignUpFormData = z.infer<typeof signUpSchema>;
+
+export const signInSchema = z.object({
+  email: z.email("올바른 이메일 형식이 아닙니다"),
+  password: z.string().min(1, "비밀번호를 입력해주세요"),
+});
+
+export type SignInFormData = z.infer<typeof signInSchema>;


### PR DESCRIPTION
## Summary
- `/login` 페이지 및 `SignInForm` 컴포넌트 생성
- react-hook-form + zod 기반 로그인 폼 검증
- Supabase `signInWithPassword` 연동
- 에러 처리 (잘못된 이메일/비밀번호, 이메일 미인증)

## Test plan
- [x] `pnpm type-check` 통과
- [x] `pnpm check` (biome) 통과
- [x] 로그인 폼 유효성 검사 동작 확인
- [x] 잘못된 이메일/비밀번호 에러 메시지 표시 확인
- [x] 로그인 성공 시 /dashboard 리다이렉트 확인

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)