### PR TITLE
feat: 초대 코드 생성 기능

### DIFF
--- a/app/(main)/dashboard/page.tsx
+++ b/app/(main)/dashboard/page.tsx
@@ -1,4 +1,5 @@
 import { LogoutButton } from "@/components/auth/LogoutButton";
+import { InvitationCode } from "@/components/household/InvitationCode";
 import { getUser } from "@/lib/supabase/auth";
 
 export default async function DashboardPage() {
@@ -16,6 +17,8 @@ export default async function DashboardPage() {
           <p className="text-gray-500 text-sm">로그인된 사용자</p>
           <p className="text-lg font-medium text-gray-900">{user?.email}</p>
         </div>
+
+        <InvitationCode />
 
         <p className="text-center text-gray-400 text-sm">
           대시보드는 추후 구현 예정입니다

--- a/app/api/invitations/route.ts
+++ b/app/api/invitations/route.ts
@@ -1,0 +1,122 @@
+import { NextResponse } from "next/server";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import {
+  createInvitation,
+  getActiveInvitation,
+  getUserHouseholdId,
+} from "@/lib/api/invitation";
+import { createClient } from "@/lib/supabase/server";
+
+/**
+ * POST /api/invitations
+ * 초대 코드 생성
+ */
+export async function POST() {
+  try {
+    const supabase = await createClient();
+
+    // 인증 확인
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    // 사용자의 가구 조회
+    const householdId = await getUserHouseholdId(supabase, user.id);
+
+    if (!householdId) {
+      throw new APIError(
+        "HOUSEHOLD_NOT_FOUND",
+        "가구 정보를 찾을 수 없습니다.",
+        404,
+      );
+    }
+
+    // 기존 활성 초대 코드 확인
+    const existingInvitation = await getActiveInvitation(supabase, householdId);
+
+    if (existingInvitation) {
+      // 기존 활성 코드가 있으면 반환
+      return NextResponse.json({ data: existingInvitation });
+    }
+
+    // 새 초대 코드 생성
+    const invitation = await createInvitation(supabase, householdId, user.id);
+
+    return NextResponse.json({ data: invitation }, { status: 201 });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    console.error("Invitation creation error:", error);
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "서버 오류가 발생했습니다.",
+        },
+      },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * GET /api/invitations
+ * 현재 활성 초대 코드 조회
+ */
+export async function GET() {
+  try {
+    const supabase = await createClient();
+
+    // 인증 확인
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    // 사용자의 가구 조회
+    const householdId = await getUserHouseholdId(supabase, user.id);
+
+    if (!householdId) {
+      throw new APIError(
+        "HOUSEHOLD_NOT_FOUND",
+        "가구 정보를 찾을 수 없습니다.",
+        404,
+      );
+    }
+
+    // 활성 초대 코드 조회
+    const invitation = await getActiveInvitation(supabase, householdId);
+
+    return NextResponse.json({ data: invitation });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    console.error("Invitation fetch error:", error);
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "서버 오류가 발생했습니다.",
+        },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/components/household/InvitationCode.tsx
+++ b/components/household/InvitationCode.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { Check, Copy, RefreshCw, UserPlus } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { useCreateInvitation, useInvitation } from "@/hooks/use-invitation";
+import { formatInvitationCode, formatRemainingTime } from "@/lib/utils/format";
+
+export function InvitationCode() {
+  const [copied, setCopied] = useState(false);
+  const { data: invitation, isLoading, error } = useInvitation();
+  const createMutation = useCreateInvitation();
+
+  const handleCreateCode = () => {
+    createMutation.mutate();
+  };
+
+  const handleCopyCode = async () => {
+    if (!invitation) return;
+
+    try {
+      await navigator.clipboard.writeText(invitation.code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // 클립보드 복사 실패 시 무시
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <UserPlus className="size-5" />
+            파트너 초대
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="h-20 animate-pulse bg-gray-100 rounded-xl" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <UserPlus className="size-5" />
+            파트너 초대
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-destructive">{error.message}</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <UserPlus className="size-5" />
+          파트너 초대
+        </CardTitle>
+        <CardDescription>
+          초대 코드를 공유하여 파트너를 가구에 추가하세요
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {invitation ? (
+          <>
+            <div className="flex items-center justify-center gap-3 p-4 bg-gray-50 rounded-xl">
+              <span className="text-3xl font-bold tracking-wider text-gray-900">
+                {formatInvitationCode(invitation.code)}
+              </span>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={handleCopyCode}
+                className="shrink-0"
+              >
+                {copied ? (
+                  <Check className="size-5 text-green-600" />
+                ) : (
+                  <Copy className="size-5" />
+                )}
+              </Button>
+            </div>
+            <p className="text-center text-sm text-gray-500">
+              {formatRemainingTime(invitation.expires_at)}
+            </p>
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={handleCreateCode}
+              disabled={createMutation.isPending}
+            >
+              {createMutation.isPending ? (
+                <RefreshCw className="size-4 animate-spin" />
+              ) : (
+                <RefreshCw className="size-4" />
+              )}
+              새 코드 생성
+            </Button>
+          </>
+        ) : (
+          <>
+            <p className="text-center text-sm text-gray-500">
+              초대 코드가 없습니다
+            </p>
+            <Button
+              className="w-full"
+              onClick={handleCreateCode}
+              disabled={createMutation.isPending}
+            >
+              {createMutation.isPending ? (
+                <RefreshCw className="size-4 animate-spin" />
+              ) : (
+                <UserPlus className="size-4" />
+              )}
+              초대 코드 생성
+            </Button>
+          </>
+        )}
+        {createMutation.error && (
+          <p className="text-sm text-center text-destructive">
+            {createMutation.error.message}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/hooks/use-invitation.ts
+++ b/hooks/use-invitation.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { Invitation } from "@/types";
+
+interface InvitationResponse {
+  data: Invitation | null;
+}
+
+interface InvitationError {
+  error: {
+    code: string;
+    message: string;
+  };
+}
+
+async function fetchInvitation(): Promise<Invitation | null> {
+  const response = await fetch("/api/invitations");
+  const json = await response.json();
+
+  if (!response.ok) {
+    const error = json as InvitationError;
+    throw new Error(error.error.message);
+  }
+
+  return (json as InvitationResponse).data;
+}
+
+async function createInvitation(): Promise<Invitation> {
+  const response = await fetch("/api/invitations", {
+    method: "POST",
+  });
+  const json = await response.json();
+
+  if (!response.ok) {
+    const error = json as InvitationError;
+    throw new Error(error.error.message);
+  }
+
+  return (json as InvitationResponse).data as Invitation;
+}
+
+export function useInvitation() {
+  return useQuery({
+    queryKey: ["invitation"],
+    queryFn: fetchInvitation,
+    staleTime: 1000 * 60 * 5, // 5분
+  });
+}
+
+export function useCreateInvitation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: createInvitation,
+    onSuccess: (data) => {
+      queryClient.setQueryData(["invitation"], data);
+    },
+  });
+}

--- a/lib/api/error.ts
+++ b/lib/api/error.ts
@@ -1,0 +1,35 @@
+/**
+ * API 에러 클래스
+ */
+export class APIError extends Error {
+  constructor(
+    public code: string,
+    public override message: string,
+    public statusCode: number = 400,
+  ) {
+    super(message);
+    this.name = "APIError";
+  }
+}
+
+/**
+ * 에러 응답 타입
+ */
+export interface ErrorResponse {
+  error: {
+    code: string;
+    message: string;
+  };
+}
+
+/**
+ * APIError를 에러 응답 형식으로 변환
+ */
+export function toErrorResponse(error: APIError): ErrorResponse {
+  return {
+    error: {
+      code: error.code,
+      message: error.message,
+    },
+  };
+}

--- a/lib/api/invitation.ts
+++ b/lib/api/invitation.ts
@@ -1,0 +1,104 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database, Invitation } from "@/types";
+
+const CODE_LENGTH = 6;
+const CODE_CHARS = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"; // 혼동되는 문자 제외 (O,0,1,I)
+const EXPIRY_HOURS = 24;
+
+/**
+ * 6자리 초대 코드 생성
+ */
+export function generateInvitationCode(): string {
+  let code = "";
+  for (let i = 0; i < CODE_LENGTH; i++) {
+    code += CODE_CHARS.charAt(Math.floor(Math.random() * CODE_CHARS.length));
+  }
+  return code;
+}
+
+/**
+ * 만료 시간 계산 (24시간 후)
+ */
+export function getExpiryTime(): string {
+  const expiry = new Date();
+  expiry.setHours(expiry.getHours() + EXPIRY_HOURS);
+  return expiry.toISOString();
+}
+
+/**
+ * 사용자의 household_id 조회
+ */
+export async function getUserHouseholdId(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+): Promise<string | null> {
+  const { data } = await supabase
+    .from("household_members")
+    .select("household_id")
+    .eq("user_id", userId)
+    .single();
+
+  return data?.household_id ?? null;
+}
+
+/**
+ * 초대 코드 생성 및 저장
+ */
+export async function createInvitation(
+  supabase: SupabaseClient<Database>,
+  householdId: string,
+  createdBy: string,
+): Promise<Invitation> {
+  // 고유한 코드 생성 (충돌 시 재시도)
+  let code = generateInvitationCode();
+  let retries = 0;
+  const maxRetries = 5;
+
+  while (retries < maxRetries) {
+    const { data, error } = await supabase
+      .from("invitations")
+      .insert({
+        household_id: householdId,
+        code,
+        created_by: createdBy,
+        expires_at: getExpiryTime(),
+      })
+      .select()
+      .single();
+
+    if (!error && data) {
+      return data;
+    }
+
+    // 코드 중복 에러인 경우 재시도
+    if (error?.code === "23505") {
+      code = generateInvitationCode();
+      retries++;
+      continue;
+    }
+
+    throw error;
+  }
+
+  throw new Error("초대 코드 생성에 실패했습니다. 잠시 후 다시 시도해주세요.");
+}
+
+/**
+ * 가구의 활성 초대 코드 조회 (만료되지 않고 사용되지 않은)
+ */
+export async function getActiveInvitation(
+  supabase: SupabaseClient<Database>,
+  householdId: string,
+): Promise<Invitation | null> {
+  const { data } = await supabase
+    .from("invitations")
+    .select("*")
+    .eq("household_id", householdId)
+    .is("used_by", null)
+    .gt("expires_at", new Date().toISOString())
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .single();
+
+  return data;
+}

--- a/lib/utils/format.ts
+++ b/lib/utils/format.ts
@@ -59,3 +59,35 @@ export function formatDateShort(date: Date | string): string {
     .replace(/\. /g, ".")
     .replace(/\.$/, "");
 }
+
+/**
+ * 남은 시간을 한국어 형식으로 포맷
+ */
+export function formatRemainingTime(targetDate: Date | string): string {
+  const target =
+    typeof targetDate === "string" ? new Date(targetDate) : targetDate;
+  const now = new Date();
+  const diffMs = target.getTime() - now.getTime();
+
+  if (diffMs <= 0) {
+    return "만료됨";
+  }
+
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const diffMinutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
+
+  if (diffHours > 0) {
+    return `${diffHours}시간 ${diffMinutes}분 후 만료`;
+  }
+  return `${diffMinutes}분 후 만료`;
+}
+
+/**
+ * 초대 코드를 포맷 (예: ABC123 -> ABC-123)
+ */
+export function formatInvitationCode(code: string): string {
+  if (code.length === 6) {
+    return `${code.slice(0, 3)}-${code.slice(3)}`;
+  }
+  return code;
+}


### PR DESCRIPTION
## Summary
- 파트너 초대를 위한 6자리 초대 코드 생성 기능 구현
- 초대 코드 생성/조회 API (`POST/GET /api/invitations`)
- 초대 코드 표시 및 복사 UI (대시보드에 배치)

## 구현 내용
- 6자리 영문+숫자 랜덤 코드 (혼동되는 문자 O,0,1,I 제외)
- 24시간 유효기간 설정
- `invitations` 테이블에 저장
- 코드 충돌 시 자동 재생성 (최대 5회)
- 기존 활성 코드가 있으면 재사용

## Test plan
- [x] `pnpm type-check` 통과
- [x] `pnpm check` (biome) 통과

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)