### PR TITLE
feat: 초대 수락 기능

### DIFF
--- a/app/(main)/dashboard/page.tsx
+++ b/app/(main)/dashboard/page.tsx
@@ -1,4 +1,5 @@
 import { LogoutButton } from "@/components/auth/LogoutButton";
+import { AcceptInvitation } from "@/components/household/AcceptInvitation";
 import { InvitationCode } from "@/components/household/InvitationCode";
 import { getUser } from "@/lib/supabase/auth";
 
@@ -18,7 +19,10 @@ export default async function DashboardPage() {
           <p className="text-lg font-medium text-gray-900">{user?.email}</p>
         </div>
 
-        <InvitationCode />
+        <div className="grid gap-6 md:grid-cols-2">
+          <InvitationCode />
+          <AcceptInvitation />
+        </div>
 
         <p className="text-center text-gray-400 text-sm">
           대시보드는 추후 구현 예정입니다

--- a/app/api/invitations/[code]/accept/route.ts
+++ b/app/api/invitations/[code]/accept/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import { acceptInvitation } from "@/lib/api/invitation";
+import { createClient } from "@/lib/supabase/server";
+
+interface RouteParams {
+  params: Promise<{ code: string }>;
+}
+
+/**
+ * POST /api/invitations/[code]/accept
+ * 초대 코드 수락
+ */
+export async function POST(_request: Request, { params }: RouteParams) {
+  try {
+    const { code } = await params;
+    const supabase = await createClient();
+
+    // 인증 확인
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    // 초대 수락 처리
+    const result = await acceptInvitation(supabase, code, user.id);
+
+    return NextResponse.json({ data: result });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    // acceptInvitation에서 던진 일반 Error
+    if (error instanceof Error) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "INVITATION_ERROR",
+            message: error.message,
+          },
+        },
+        { status: 400 },
+      );
+    }
+
+    console.error("Invitation accept error:", error);
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "서버 오류가 발생했습니다.",
+        },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/components/household/AcceptInvitation.tsx
+++ b/components/household/AcceptInvitation.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { Loader2, UserPlus2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useAcceptInvitation } from "@/hooks/use-invitation";
+
+export function AcceptInvitation() {
+  const router = useRouter();
+  const [code, setCode] = useState("");
+  const acceptMutation = useAcceptInvitation();
+
+  const handleCodeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    // 입력값 정규화: 대문자, 숫자만 허용, 최대 7자 (하이픈 포함)
+    let value = e.target.value.toUpperCase().replace(/[^A-Z0-9-]/g, "");
+
+    // 3자리 입력 후 자동 하이픈 추가
+    if (value.length === 3 && !value.includes("-")) {
+      value = `${value}-`;
+    }
+
+    // 최대 7자 (ABC-123)
+    if (value.length <= 7) {
+      setCode(value);
+    }
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (code.replace("-", "").length !== 6) {
+      return;
+    }
+
+    acceptMutation.mutate(code, {
+      onSuccess: () => {
+        // 성공 시 대시보드로 이동 (새로고침하여 가구 정보 갱신)
+        router.refresh();
+      },
+    });
+  };
+
+  const isValidCode = code.replace("-", "").length === 6;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <UserPlus2 className="size-5" />
+          초대 코드 입력
+        </CardTitle>
+        <CardDescription>
+          파트너에게 받은 초대 코드를 입력하세요
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="invitation-code">초대 코드</Label>
+            <Input
+              id="invitation-code"
+              type="text"
+              placeholder="ABC-123"
+              value={code}
+              onChange={handleCodeChange}
+              className="text-center text-xl tracking-wider font-mono"
+              disabled={acceptMutation.isPending}
+            />
+          </div>
+
+          {acceptMutation.error && (
+            <p className="text-sm text-center text-destructive">
+              {acceptMutation.error.message}
+            </p>
+          )}
+
+          {acceptMutation.isSuccess && (
+            <p className="text-sm text-center text-green-600">
+              가구에 성공적으로 합류했습니다!
+            </p>
+          )}
+
+          <Button
+            type="submit"
+            className="w-full"
+            disabled={!isValidCode || acceptMutation.isPending}
+          >
+            {acceptMutation.isPending ? (
+              <>
+                <Loader2 className="size-4 animate-spin" />
+                처리 중...
+              </>
+            ) : (
+              "초대 수락"
+            )}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/household/InvitationCode.tsx
+++ b/components/household/InvitationCode.tsx
@@ -18,8 +18,8 @@ export function InvitationCode() {
   const { data: invitation, isLoading, error } = useInvitation();
   const createMutation = useCreateInvitation();
 
-  const handleCreateCode = () => {
-    createMutation.mutate();
+  const handleCreateCode = (regenerate = false) => {
+    createMutation.mutate({ regenerate });
   };
 
   const handleCopyCode = async () => {
@@ -103,7 +103,7 @@ export function InvitationCode() {
             <Button
               variant="outline"
               className="w-full"
-              onClick={handleCreateCode}
+              onClick={() => handleCreateCode(true)}
               disabled={createMutation.isPending}
             >
               {createMutation.isPending ? (
@@ -121,7 +121,7 @@ export function InvitationCode() {
             </p>
             <Button
               className="w-full"
-              onClick={handleCreateCode}
+              onClick={() => handleCreateCode(false)}
               disabled={createMutation.isPending}
             >
               {createMutation.isPending ? (

--- a/lib/api/invitation.ts
+++ b/lib/api/invitation.ts
@@ -102,3 +102,224 @@ export async function getActiveInvitation(
 
   return data;
 }
+
+/**
+ * 초대 코드 검증 에러 타입
+ */
+export type InvitationErrorCode =
+  | "NOT_FOUND"
+  | "EXPIRED"
+  | "ALREADY_USED"
+  | "SAME_HOUSEHOLD"
+  | "HAS_MEMBERS";
+
+/**
+ * 초대 코드 검증 결과
+ */
+export interface InvitationValidation {
+  valid: boolean;
+  invitation: Invitation | null;
+  error?: InvitationErrorCode;
+}
+
+/**
+ * 초대 코드로 초대 정보 조회 (코드 유효성만 검증, 사용자 상태는 별도)
+ */
+export async function getInvitationByCode(
+  supabase: SupabaseClient<Database>,
+  code: string,
+): Promise<Invitation | null> {
+  // 코드 정규화 (대문자, 하이픈 제거)
+  const normalizedCode = code.toUpperCase().replace(/-/g, "");
+
+  const { data } = await supabase
+    .from("invitations")
+    .select("*")
+    .eq("code", normalizedCode)
+    .single();
+
+  return data;
+}
+
+/**
+ * 초대 코드 유효성 검증
+ */
+export async function validateInvitationCode(
+  supabase: SupabaseClient<Database>,
+  code: string,
+  userId: string,
+): Promise<InvitationValidation> {
+  const invitation = await getInvitationByCode(supabase, code);
+
+  if (!invitation) {
+    return { valid: false, invitation: null, error: "NOT_FOUND" };
+  }
+
+  if (invitation.used_by) {
+    return { valid: false, invitation, error: "ALREADY_USED" };
+  }
+
+  if (new Date(invitation.expires_at) < new Date()) {
+    return { valid: false, invitation, error: "EXPIRED" };
+  }
+
+  // 이미 같은 가구에 속해있는지 확인
+  const userHouseholdId = await getUserHouseholdId(supabase, userId);
+  if (userHouseholdId === invitation.household_id) {
+    return { valid: false, invitation, error: "SAME_HOUSEHOLD" };
+  }
+
+  return { valid: true, invitation };
+}
+
+/**
+ * 가구 구성원 수 조회
+ */
+export async function getHouseholdMemberCount(
+  supabase: SupabaseClient<Database>,
+  householdId: string,
+): Promise<number> {
+  const { count } = await supabase
+    .from("household_members")
+    .select("*", { count: "exact", head: true })
+    .eq("household_id", householdId);
+
+  return count ?? 0;
+}
+
+/**
+ * 사용자 데이터를 새 가구로 마이그레이션
+ */
+async function migrateUserDataToNewHousehold(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+  oldHouseholdId: string,
+  newHouseholdId: string,
+): Promise<void> {
+  // 1. transactions 이동
+  await supabase
+    .from("transactions")
+    .update({ household_id: newHouseholdId })
+    .eq("household_id", oldHouseholdId)
+    .eq("owner_id", userId);
+
+  // 2. household_stock_settings 이동 (사용자의 거래에 연결된 종목만)
+  // 먼저 사용자의 거래에서 사용된 ticker 목록 조회
+  const { data: userTickers } = await supabase
+    .from("transactions")
+    .select("ticker")
+    .eq("household_id", newHouseholdId)
+    .eq("owner_id", userId);
+
+  if (userTickers && userTickers.length > 0) {
+    const tickers = [...new Set(userTickers.map((t) => t.ticker))];
+
+    // 기존 가구의 종목 설정 조회
+    const { data: oldSettings } = await supabase
+      .from("household_stock_settings")
+      .select("*")
+      .eq("household_id", oldHouseholdId)
+      .in("ticker", tickers);
+
+    if (oldSettings && oldSettings.length > 0) {
+      // 새 가구에 종목 설정 upsert
+      for (const setting of oldSettings) {
+        await supabase.from("household_stock_settings").upsert(
+          {
+            household_id: newHouseholdId,
+            ticker: setting.ticker,
+            name: setting.name,
+            asset_type: setting.asset_type,
+            market: setting.market,
+            currency: setting.currency,
+            risk_level: setting.risk_level,
+          },
+          { onConflict: "household_id,ticker" },
+        );
+      }
+    }
+  }
+}
+
+/**
+ * 초대 수락 처리
+ */
+export async function acceptInvitation(
+  supabase: SupabaseClient<Database>,
+  code: string,
+  userId: string,
+): Promise<{ householdId: string }> {
+  // 1. 초대 코드 유효성 검증
+  const validation = await validateInvitationCode(supabase, code, userId);
+
+  if (!validation.valid || !validation.invitation) {
+    const errorMessages: Record<InvitationErrorCode, string> = {
+      NOT_FOUND: "유효하지 않은 초대 코드입니다.",
+      EXPIRED: "만료된 초대 코드입니다.",
+      ALREADY_USED: "이미 사용된 초대 코드입니다.",
+      SAME_HOUSEHOLD: "이미 해당 가구의 구성원입니다.",
+      HAS_MEMBERS: "이미 다른 가구에 소속되어 있습니다.",
+    };
+    throw new Error(
+      errorMessages[validation.error!] || "초대 수락에 실패했습니다.",
+    );
+  }
+
+  const invitation = validation.invitation;
+  const newHouseholdId = invitation.household_id;
+
+  // 2. 사용자의 현재 가구 확인
+  const currentHouseholdId = await getUserHouseholdId(supabase, userId);
+
+  if (currentHouseholdId) {
+    // 3. 현재 가구의 구성원 수 확인
+    const memberCount = await getHouseholdMemberCount(
+      supabase,
+      currentHouseholdId,
+    );
+
+    // 다른 구성원이 있으면 에러
+    if (memberCount > 1) {
+      throw new Error("이미 다른 가구에 소속되어 있습니다.");
+    }
+
+    // 4. 단독 가구인 경우 데이터 마이그레이션
+    await migrateUserDataToNewHousehold(
+      supabase,
+      userId,
+      currentHouseholdId,
+      newHouseholdId,
+    );
+
+    // 5. 기존 가구에서 이탈 및 삭제
+    await supabase
+      .from("household_members")
+      .delete()
+      .eq("household_id", currentHouseholdId)
+      .eq("user_id", userId);
+
+    await supabase.from("households").delete().eq("id", currentHouseholdId);
+  }
+
+  // 6. 새 가구에 member 역할로 추가
+  const { error: joinError } = await supabase.from("household_members").insert({
+    household_id: newHouseholdId,
+    user_id: userId,
+    role: "member",
+  });
+
+  if (joinError) {
+    throw new Error("새 가구에 합류하는 데 실패했습니다.");
+  }
+
+  // 7. 초대 코드 사용 처리
+  await supabase
+    .from("invitations")
+    .update({
+      used_by: userId,
+      used_at: new Date().toISOString(),
+    })
+    .eq("id", invitation.id);
+
+  return { householdId: newHouseholdId };
+}


### PR DESCRIPTION
## Summary
- 파트너가 보낸 초대 코드를 입력하여 가구에 합류하는 기능 구현
- 1인 1가구 원칙: 단독 가구일 때만 수락 가능

## 구현 내용

### API
- `POST /api/invitations/[code]/accept`: 초대 수락 API

### 유효성 검증
- 코드 존재 여부
- 만료 여부 (24시간)
- 사용 여부 (used_by 확인)
- 이미 같은 가구인지 확인
- 다른 구성원이 있는 가구인지 확인 (있으면 에러)

### 데이터 마이그레이션
- 단독 가구에서 이동 시 사용자의 데이터를 새 가구로 이동
- `transactions.household_id` 업데이트
- `household_stock_settings` UPSERT

### UI
- `AcceptInvitation` 컴포넌트: 초대 코드 입력 폼
- 3자리 입력 후 자동 하이픈 추가
- 실시간 에러 표시

### 문서
- DATABASE.md에 초대 수락 플로우 추가

## Test plan
- [x] `pnpm type-check` 통과
- [x] `pnpm check` (biome) 통과

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)