### PR TITLE
feat: 구성원 목록 조회 및 가구 관리 페이지 구현

### DIFF
--- a/app/(main)/dashboard/page.tsx
+++ b/app/(main)/dashboard/page.tsx
@@ -1,6 +1,7 @@
+import { Users } from "lucide-react";
+import Link from "next/link";
 import { LogoutButton } from "@/components/auth/LogoutButton";
-import { AcceptInvitation } from "@/components/household/AcceptInvitation";
-import { InvitationCode } from "@/components/household/InvitationCode";
+import { Button } from "@/components/ui/button";
 import { getUser } from "@/lib/supabase/auth";
 
 export default async function DashboardPage() {
@@ -19,9 +20,21 @@ export default async function DashboardPage() {
           <p className="text-lg font-medium text-gray-900">{user?.email}</p>
         </div>
 
-        <div className="grid gap-6 md:grid-cols-2">
-          <InvitationCode />
-          <AcceptInvitation />
+        <div className="bg-white rounded-2xl shadow-sm p-6">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <div className="flex items-center justify-center size-10 bg-primary/10 rounded-full">
+                <Users className="size-5 text-primary" />
+              </div>
+              <div>
+                <p className="font-medium text-gray-900">가구 관리</p>
+                <p className="text-sm text-gray-500">구성원 관리 및 초대</p>
+              </div>
+            </div>
+            <Button asChild>
+              <Link href="/household">관리하기</Link>
+            </Button>
+          </div>
         </div>
 
         <p className="text-center text-gray-400 text-sm">

--- a/app/(main)/household/page.tsx
+++ b/app/(main)/household/page.tsx
@@ -1,0 +1,55 @@
+import { ArrowLeft } from "lucide-react";
+import Link from "next/link";
+import { AcceptInvitation } from "@/components/household/AcceptInvitation";
+import { InvitationCode } from "@/components/household/InvitationCode";
+import { MemberList } from "@/components/household/MemberList";
+import { Button } from "@/components/ui/button";
+import { getHouseholdWithMembers } from "@/lib/api/household";
+import { requireUser } from "@/lib/supabase/auth";
+import { createClient } from "@/lib/supabase/server";
+
+export default async function HouseholdPage() {
+  const user = await requireUser();
+  const supabase = await createClient();
+  const household = await getHouseholdWithMembers(supabase, user.id);
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-4">
+      <div className="max-w-2xl mx-auto space-y-6">
+        <div className="flex items-center gap-4">
+          <Button variant="ghost" size="icon" asChild>
+            <Link href="/dashboard">
+              <ArrowLeft className="size-5" />
+            </Link>
+          </Button>
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">가구 관리</h1>
+            {household && (
+              <p className="text-sm text-gray-500">{household.name}</p>
+            )}
+          </div>
+        </div>
+
+        {household ? (
+          household.members.length === 1 ? (
+            <>
+              {/* 단독 가구: 초대 수락을 먼저 보여줌 */}
+              <AcceptInvitation />
+              <InvitationCode />
+            </>
+          ) : (
+            <>
+              {/* 다중 가구: 구성원 목록 + 초대 코드 생성 */}
+              <MemberList members={household.members} currentUserId={user.id} />
+              <InvitationCode />
+            </>
+          )
+        ) : (
+          <div className="text-center py-12">
+            <p className="text-gray-500">가구 정보를 찾을 수 없습니다.</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/household/MemberList.tsx
+++ b/components/household/MemberList.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { Crown, User } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { HouseholdMemberInfo } from "@/lib/api/household";
+
+interface MemberListProps {
+  members: HouseholdMemberInfo[];
+  currentUserId: string;
+}
+
+export function MemberList({ members, currentUserId }: MemberListProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <User className="size-5" />
+          구성원 ({members.length}명)
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-3">
+          {members.map((member) => (
+            <li
+              key={member.userId}
+              className="flex items-center justify-between p-3 bg-gray-50 rounded-xl"
+            >
+              <div className="flex items-center gap-3">
+                <div className="flex items-center justify-center size-10 bg-gray-200 rounded-full">
+                  {member.role === "owner" ? (
+                    <Crown className="size-5 text-amber-500" />
+                  ) : (
+                    <User className="size-5 text-gray-500" />
+                  )}
+                </div>
+                <div>
+                  <p className="font-medium text-gray-900">
+                    {member.name}
+                    {member.userId === currentUserId && (
+                      <span className="ml-2 text-xs text-primary">(나)</span>
+                    )}
+                  </p>
+                  <p className="text-sm text-gray-500">{member.email}</p>
+                </div>
+              </div>
+              <span
+                className={`text-xs px-2 py-1 rounded-full ${
+                  member.role === "owner"
+                    ? "bg-amber-100 text-amber-700"
+                    : "bg-gray-200 text-gray-600"
+                }`}
+              >
+                {member.role === "owner" ? "관리자" : "구성원"}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/lib/api/household.ts
+++ b/lib/api/household.ts
@@ -1,0 +1,87 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database, HouseholdRole } from "@/types";
+
+/**
+ * 구성원 정보 타입
+ */
+export interface HouseholdMemberInfo {
+  userId: string;
+  name: string;
+  email: string;
+  role: HouseholdRole;
+  joinedAt: string;
+}
+
+/**
+ * 가구 정보 타입
+ */
+export interface HouseholdInfo {
+  id: string;
+  name: string;
+  members: HouseholdMemberInfo[];
+}
+
+/**
+ * 사용자의 가구 정보 및 구성원 목록 조회
+ */
+export async function getHouseholdWithMembers(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+): Promise<HouseholdInfo | null> {
+  // 1. 사용자의 가구 조회
+  const { data: membership } = await supabase
+    .from("household_members")
+    .select("household_id")
+    .eq("user_id", userId)
+    .single();
+
+  if (!membership) {
+    return null;
+  }
+
+  const householdId = membership.household_id;
+
+  // 2. 가구 정보 조회
+  const { data: household } = await supabase
+    .from("households")
+    .select("id, name")
+    .eq("id", householdId)
+    .single();
+
+  if (!household) {
+    return null;
+  }
+
+  // 3. 구성원 목록 조회 (프로필 정보와 함께)
+  const { data: members } = await supabase
+    .from("household_members")
+    .select(
+      `
+      user_id,
+      role,
+      joined_at,
+      profiles (
+        name,
+        email
+      )
+    `,
+    )
+    .eq("household_id", householdId)
+    .order("joined_at", { ascending: true });
+
+  if (!members) {
+    return null;
+  }
+
+  return {
+    id: household.id,
+    name: household.name,
+    members: members.map((m) => ({
+      userId: m.user_id,
+      name: (m.profiles as { name: string; email: string })?.name || "",
+      email: (m.profiles as { name: string; email: string })?.email || "",
+      role: m.role,
+      joinedAt: m.joined_at,
+    })),
+  };
+}


### PR DESCRIPTION
## Summary
- 가구 관리 페이지 (`/household`) 신규 생성
- `getHouseholdWithMembers` API로 가구 및 구성원 정보 조회
- `MemberList` 컴포넌트로 구성원 역할 및 정보 표시
- 단독 가구: 초대 수락 UI 먼저 표시 (가구 합류 유도)
- 다중 가구: 구성원 목록 + 초대 코드 생성
- 대시보드에서 초대 컴포넌트 제거, 가구 관리 링크로 대체

## Test plan
- [x] `pnpm type-check` 통과
- [x] `pnpm check` (biome) 통과

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)