### PR TITLE
feat: 가구 설정 페이지 구현

### DIFF
--- a/app/(main)/household/page.tsx
+++ b/app/(main)/household/page.tsx
@@ -1,6 +1,7 @@
 import { ArrowLeft } from "lucide-react";
 import Link from "next/link";
 import { AcceptInvitation } from "@/components/household/AcceptInvitation";
+import { HouseholdSettings } from "@/components/household/HouseholdSettings";
 import { InvitationCode } from "@/components/household/InvitationCode";
 import { MemberList } from "@/components/household/MemberList";
 import { Button } from "@/components/ui/button";
@@ -31,19 +32,34 @@ export default async function HouseholdPage() {
         </div>
 
         {household ? (
-          household.members.length === 1 ? (
-            <>
-              {/* 단독 가구: 초대 수락을 먼저 보여줌 */}
-              <AcceptInvitation />
-              <InvitationCode />
-            </>
-          ) : (
-            <>
-              {/* 다중 가구: 구성원 목록 + 초대 코드 생성 */}
-              <MemberList members={household.members} currentUserId={user.id} />
-              <InvitationCode />
-            </>
-          )
+          <>
+            {/* 가구 설정 */}
+            <HouseholdSettings
+              householdId={household.id}
+              householdName={household.name}
+              isOwner={
+                household.members.find((m) => m.userId === user.id)?.role ===
+                "owner"
+              }
+            />
+
+            {household.members.length === 1 ? (
+              <>
+                {/* 단독 가구: 초대 수락을 먼저 보여줌 */}
+                <AcceptInvitation />
+                <InvitationCode />
+              </>
+            ) : (
+              <>
+                {/* 다중 가구: 구성원 목록 + 초대 코드 생성 */}
+                <MemberList
+                  members={household.members}
+                  currentUserId={user.id}
+                />
+                <InvitationCode />
+              </>
+            )}
+          </>
         ) : (
           <div className="text-center py-12">
             <p className="text-gray-500">가구 정보를 찾을 수 없습니다.</p>

--- a/app/api/households/[id]/route.ts
+++ b/app/api/households/[id]/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import { updateHouseholdName } from "@/lib/api/household";
+import { createClient } from "@/lib/supabase/server";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+const updateHouseholdSchema = z.object({
+  name: z
+    .string()
+    .min(1, "가구 이름을 입력해주세요.")
+    .max(50, "가구 이름은 50자 이하로 입력해주세요."),
+});
+
+/**
+ * PATCH /api/households/[id]
+ * 가구 정보 수정 (현재는 이름만)
+ */
+export async function PATCH(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const supabase = await createClient();
+
+    // 인증 확인
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    // 요청 바디 파싱 및 검증
+    const body = await request.json();
+    const parsed = updateHouseholdSchema.safeParse(body);
+
+    if (!parsed.success) {
+      throw new APIError(
+        "VALIDATION_ERROR",
+        parsed.error.issues[0].message,
+        400,
+      );
+    }
+
+    // 가구 이름 수정
+    const result = await updateHouseholdName(
+      supabase,
+      id,
+      user.id,
+      parsed.data.name,
+    );
+
+    return NextResponse.json({ data: result });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    if (error instanceof Error) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "HOUSEHOLD_ERROR",
+            message: error.message,
+          },
+        },
+        { status: 400 },
+      );
+    }
+
+    console.error("Household update error:", error);
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "서버 오류가 발생했습니다.",
+        },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/components/household/HouseholdSettings.tsx
+++ b/components/household/HouseholdSettings.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { Check, Pencil, Settings, X } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { useUpdateHouseholdName } from "@/hooks/use-household";
+
+interface HouseholdSettingsProps {
+  householdId: string;
+  householdName: string;
+  isOwner: boolean;
+}
+
+export function HouseholdSettings({
+  householdId,
+  householdName,
+  isOwner,
+}: HouseholdSettingsProps) {
+  const router = useRouter();
+  const [isEditing, setIsEditing] = useState(false);
+  const [name, setName] = useState(householdName);
+  const { mutate: updateName, isPending } = useUpdateHouseholdName();
+
+  const handleSave = () => {
+    if (!name.trim()) return;
+
+    updateName(
+      { householdId, name: name.trim() },
+      {
+        onSuccess: () => {
+          setIsEditing(false);
+          router.refresh();
+        },
+        onError: (error) => {
+          alert(error.message);
+        },
+      },
+    );
+  };
+
+  const handleCancel = () => {
+    setName(householdName);
+    setIsEditing(false);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Settings className="size-5" />
+          가구 설정
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <p className="text-sm text-gray-500">가구 이름</p>
+          {isEditing ? (
+            <div className="flex items-center gap-2">
+              <Input
+                id="household-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="가구 이름"
+                className="flex-1"
+                maxLength={50}
+                disabled={isPending}
+              />
+              <Button
+                size="icon"
+                variant="ghost"
+                onClick={handleSave}
+                disabled={isPending || !name.trim()}
+              >
+                <Check className="size-4 text-green-600" />
+              </Button>
+              <Button
+                size="icon"
+                variant="ghost"
+                onClick={handleCancel}
+                disabled={isPending}
+              >
+                <X className="size-4 text-gray-500" />
+              </Button>
+            </div>
+          ) : (
+            <div className="flex items-center justify-between p-3 bg-gray-50 rounded-xl">
+              <span className="font-medium text-gray-900">{householdName}</span>
+              {isOwner && (
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  onClick={() => setIsEditing(true)}
+                >
+                  <Pencil className="size-4 text-gray-500" />
+                </Button>
+              )}
+            </div>
+          )}
+        </div>
+
+        {!isOwner && (
+          <p className="text-xs text-gray-400">
+            가구 이름은 관리자만 변경할 수 있습니다.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/hooks/use-household.ts
+++ b/hooks/use-household.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { useMutation } from "@tanstack/react-query";
+
+interface UpdateHouseholdNameParams {
+  householdId: string;
+  name: string;
+}
+
+interface UpdateHouseholdNameResponse {
+  data: {
+    id: string;
+    name: string;
+  };
+}
+
+async function updateHouseholdName({
+  householdId,
+  name,
+}: UpdateHouseholdNameParams): Promise<UpdateHouseholdNameResponse> {
+  const response = await fetch(`/api/households/${householdId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name }),
+  });
+
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(error.error?.message || "가구 이름 변경에 실패했습니다.");
+  }
+
+  return response.json();
+}
+
+export function useUpdateHouseholdName() {
+  return useMutation({
+    mutationFn: updateHouseholdName,
+  });
+}


### PR DESCRIPTION
## Summary
- 가구 이름 수정 API (`PATCH /api/households/[id]`) 추가
- `updateHouseholdName` 함수로 owner 권한 검증 후 이름 수정
- `HouseholdSettings` 컴포넌트로 가구 이름 편집 UI 제공
- `useUpdateHouseholdName` 훅으로 React Query mutation 연동
- owner만 가구 이름 변경 가능, 그 외 사용자에게 안내 메시지 표시

## Test plan
- [x] `pnpm type-check` 통과
- [x] `pnpm check` (biome) 통과

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)