### PR TITLE
feat: stock_master.exchange NOT NULL 제약 추가

### DIFF
--- a/scripts/lib/parse-overseas.ts
+++ b/scripts/lib/parse-overseas.ts
@@ -1,7 +1,7 @@
 import { getChoseong } from "es-hangul";
 import iconv from "iconv-lite";
 import { US_STOCK_TYPE_MAPPINGS } from "./mappings";
-import type { ParsedStock } from "./types";
+import type { ExchangeType, ParsedStock } from "./types";
 
 /**
  * 해외 주식 마스터파일 파싱
@@ -12,7 +12,7 @@ import type { ParsedStock } from "./types";
  */
 export function parseOverseasFile(
   buffer: Buffer,
-  exchange: string,
+  exchange: ExchangeType,
 ): ParsedStock[] {
   const content = iconv.decode(buffer, "cp949");
   const lines = content.split("\n").filter((line) => line.trim());

--- a/scripts/lib/types.ts
+++ b/scripts/lib/types.ts
@@ -3,13 +3,15 @@ import type { Database } from "../../types/supabase";
 export type StockInsert =
   Database["public"]["Tables"]["stock_master"]["Insert"];
 
+export type ExchangeType = Database["public"]["Enums"]["exchange_type"];
+
 export interface ParsedStock {
   code: string;
   name: string;
   name_en: string | null;
   choseong: string | null;
   market: "KR" | "US";
-  exchange: string;
+  exchange: ExchangeType;
   stock_type_code: string | null;
   stock_type_name: string | null;
   stock_type_category:

--- a/supabase/migrations/20260104142228_add_stock_master_exchange_not_null.sql
+++ b/supabase/migrations/20260104142228_add_stock_master_exchange_not_null.sql
@@ -1,0 +1,33 @@
+-- stock_master.exchange 컬럼을 enum 타입으로 변경하고 NOT NULL 제약 추가
+-- 모든 상장 주식은 거래소(exchange)가 반드시 존재함
+
+-- 1. exchange_type enum 생성
+create type exchange_type as enum (
+  'KOSPI',
+  'KOSDAQ',
+  'NYSE',
+  'NASDAQ',
+  'AMEX'
+);
+
+-- 2. 기존 데이터 검증 (NULL 또는 유효하지 않은 값 체크)
+do $$
+begin
+  -- NULL 체크
+  if exists (select 1 from public.stock_master where exchange is null) then
+    raise exception 'stock_master 테이블에 exchange가 NULL인 데이터가 존재합니다.';
+  end if;
+
+  -- 유효하지 않은 값 체크
+  if exists (
+    select 1 from public.stock_master
+    where exchange not in ('KOSPI', 'KOSDAQ', 'NYSE', 'NASDAQ', 'AMEX')
+  ) then
+    raise exception 'stock_master 테이블에 유효하지 않은 exchange 값이 존재합니다.';
+  end if;
+end $$;
+
+-- 3. 컬럼 타입 변경 (text -> exchange_type, NOT NULL)
+alter table public.stock_master
+  alter column exchange type exchange_type using exchange::exchange_type,
+  alter column exchange set not null;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -274,7 +274,7 @@ export type Database = {
         Row: {
           choseong: string | null;
           code: string;
-          exchange: string | null;
+          exchange: Database["public"]["Enums"]["exchange_type"];
           id: string;
           is_active: boolean | null;
           is_suspended: boolean | null;
@@ -291,7 +291,7 @@ export type Database = {
         Insert: {
           choseong?: string | null;
           code: string;
-          exchange?: string | null;
+          exchange: Database["public"]["Enums"]["exchange_type"];
           id?: string;
           is_active?: boolean | null;
           is_suspended?: boolean | null;
@@ -308,7 +308,7 @@ export type Database = {
         Update: {
           choseong?: string | null;
           code?: string;
-          exchange?: string | null;
+          exchange?: Database["public"]["Enums"]["exchange_type"];
           id?: string;
           is_active?: boolean | null;
           is_suspended?: boolean | null;
@@ -519,7 +519,7 @@ export type Database = {
         Returns: {
           choseong: string | null;
           code: string;
-          exchange: string | null;
+          exchange: Database["public"]["Enums"]["exchange_type"];
           id: string;
           is_active: boolean | null;
           is_suspended: boolean | null;
@@ -561,6 +561,7 @@ export type Database = {
         | "crypto"
         | "alternative";
       currency_type: "KRW" | "USD";
+      exchange_type: "KOSPI" | "KOSDAQ" | "NYSE" | "NASDAQ" | "AMEX";
       household_role: "owner" | "member";
       market_type: "KR" | "US" | "OTHER";
       risk_level: "safe" | "moderate" | "aggressive";
@@ -726,6 +727,7 @@ export const Constants = {
         "alternative",
       ],
       currency_type: ["KRW", "USD"],
+      exchange_type: ["KOSPI", "KOSDAQ", "NYSE", "NASDAQ", "AMEX"],
       household_role: ["owner", "member"],
       market_type: ["KR", "US", "OTHER"],
       risk_level: ["safe", "moderate", "aggressive"],


### PR DESCRIPTION
## Summary
- `exchange_type` enum 생성 (KOSPI, KOSDAQ, NYSE, NASDAQ, AMEX)
- `stock_master.exchange` 컬럼 타입을 `text`에서 `exchange_type`으로 변경
- NOT NULL 제약 추가
- 동기화 스크립트에서 DB enum 타입 사용 (Single Source of Truth)

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `supabase/migrations/...` | enum 생성 + 컬럼 타입 변경 |
| `types/supabase.ts` | 타입 재생성 |
| `scripts/lib/types.ts` | `ExchangeType` 타입 export |
| `scripts/lib/parse-overseas.ts` | enum 타입 사용 |

## Test plan
- [x] `pnpm supabase db reset` 마이그레이션 적용 확인
- [x] `pnpm type-check` 통과
- [x] `pnpm check` (biome) 통과

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)