### PR TITLE
feat: 거래 저장 API 구현

### DIFF
--- a/app/api/transactions/route.ts
+++ b/app/api/transactions/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from "next/server";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import { getUserHouseholdId } from "@/lib/api/invitation";
+import { createTransaction } from "@/lib/api/transaction";
+import { createClient } from "@/lib/supabase/server";
+import { createTransactionSchema } from "@/schemas/transaction";
+
+/**
+ * POST /api/transactions
+ * 거래 기록 생성
+ */
+export async function POST(request: Request) {
+  try {
+    const supabase = await createClient();
+
+    // 인증 확인
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    // 요청 body 파싱 및 검증
+    const body = await request.json();
+    const result = createTransactionSchema.safeParse(body);
+
+    if (!result.success) {
+      const firstError = result.error.issues[0];
+      throw new APIError(
+        "VALIDATION_ERROR",
+        firstError?.message ?? "유효하지 않은 요청입니다.",
+        400,
+      );
+    }
+
+    const input = result.data;
+
+    // 사용자의 가구 조회
+    const householdId = await getUserHouseholdId(supabase, user.id);
+
+    if (!householdId) {
+      throw new APIError(
+        "HOUSEHOLD_NOT_FOUND",
+        "가구 정보를 찾을 수 없습니다.",
+        404,
+      );
+    }
+
+    // 거래 생성
+    const transaction = await createTransaction(supabase, {
+      householdId,
+      ownerId: user.id,
+      ticker: input.ticker,
+      type: input.type,
+      quantity: input.quantity,
+      price: input.price,
+      transactedAt: input.transactedAt,
+      memo: input.memo,
+      stock: {
+        name: input.stock.name,
+        market: input.stock.market,
+        currency: input.stock.currency,
+        assetType: input.stock.assetType,
+      },
+    });
+
+    return NextResponse.json({ data: transaction }, { status: 201 });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    console.error("Transaction creation error:", error);
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "서버 오류가 발생했습니다.",
+        },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/hooks/use-transaction.ts
+++ b/hooks/use-transaction.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { queries } from "@/lib/queries/keys";
+import type { CreateTransactionInput } from "@/schemas/transaction";
+import type { Transaction } from "@/types";
+
+interface TransactionResponse {
+  data: Transaction;
+}
+
+interface TransactionError {
+  error: {
+    code: string;
+    message: string;
+  };
+}
+
+async function createTransaction(
+  input: CreateTransactionInput,
+): Promise<Transaction> {
+  const response = await fetch("/api/transactions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(input),
+  });
+  const json = await response.json();
+
+  if (!response.ok) {
+    const error = json as TransactionError;
+    throw new Error(error.error.message);
+  }
+
+  return (json as TransactionResponse).data;
+}
+
+export function useCreateTransaction() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: createTransaction,
+    onSuccess: () => {
+      // 관련 캐시 무효화
+      queryClient.invalidateQueries({ queryKey: queries.transactions._def });
+      queryClient.invalidateQueries({ queryKey: queries.holdings._def });
+      queryClient.invalidateQueries({ queryKey: queries.dashboard._def });
+    },
+  });
+}

--- a/lib/api/transaction.ts
+++ b/lib/api/transaction.ts
@@ -1,0 +1,145 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type {
+  AssetType,
+  CurrencyType,
+  Database,
+  MarketType,
+  Transaction,
+  TransactionType,
+} from "@/types";
+import { APIError } from "./error";
+
+export interface CreateTransactionParams {
+  householdId: string;
+  ownerId: string;
+  ticker: string;
+  type: TransactionType;
+  quantity: number;
+  price: number;
+  transactedAt: string;
+  memo?: string;
+  stock: {
+    name: string;
+    market: MarketType;
+    currency: CurrencyType;
+    assetType?: AssetType;
+  };
+}
+
+/**
+ * 거래 생성
+ * 1. 종목 설정이 없으면 자동 생성 (UPSERT)
+ * 2. 매도 시 보유 수량 검증
+ * 3. 거래 기록 INSERT
+ */
+export async function createTransaction(
+  supabase: SupabaseClient<Database>,
+  params: CreateTransactionParams,
+): Promise<Transaction> {
+  const {
+    householdId,
+    ownerId,
+    ticker,
+    type,
+    quantity,
+    price,
+    transactedAt,
+    memo,
+    stock,
+  } = params;
+
+  // 1. household_stock_settings UPSERT (첫 거래 시 자동 생성)
+  // risk_level은 null로 저장 → asset_type 기반 기본값 사용 (Application 레벨)
+  const { error: settingsError } = await supabase
+    .from("household_stock_settings")
+    .upsert(
+      {
+        household_id: householdId,
+        ticker,
+        name: stock.name,
+        market: stock.market,
+        currency: stock.currency,
+        asset_type: stock.assetType ?? "equity",
+      },
+      { onConflict: "household_id,ticker" },
+    );
+
+  if (settingsError) {
+    console.error("household_stock_settings upsert error:", settingsError);
+    throw new APIError(
+      "STOCK_SETTINGS_ERROR",
+      "종목 설정 저장에 실패했습니다.",
+      500,
+    );
+  }
+
+  // 2. 매도 시 보유 수량 검증
+  if (type === "sell") {
+    const currentQuantity = await getHoldingQuantity(
+      supabase,
+      householdId,
+      ownerId,
+      ticker,
+    );
+
+    if (currentQuantity < quantity) {
+      throw new APIError(
+        "INSUFFICIENT_QUANTITY",
+        `보유 수량(${currentQuantity})이 매도 수량(${quantity})보다 적습니다.`,
+        400,
+      );
+    }
+  }
+
+  // 3. 거래 기록 INSERT
+  const { data, error } = await supabase
+    .from("transactions")
+    .insert({
+      household_id: householdId,
+      owner_id: ownerId,
+      ticker,
+      type,
+      quantity,
+      price,
+      transacted_at: transactedAt,
+      memo: memo || null,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    console.error("Transaction insert error:", error);
+    throw new APIError("TRANSACTION_ERROR", "거래 저장에 실패했습니다.", 500);
+  }
+
+  return data;
+}
+
+/**
+ * 특정 종목의 현재 보유 수량 조회
+ */
+async function getHoldingQuantity(
+  supabase: SupabaseClient<Database>,
+  householdId: string,
+  ownerId: string,
+  ticker: string,
+): Promise<number> {
+  const { data, error } = await supabase
+    .from("holdings")
+    .select("quantity")
+    .eq("household_id", householdId)
+    .eq("owner_id", ownerId)
+    .eq("ticker", ticker)
+    .single();
+
+  if (error) {
+    // PGRST116: 결과 없음 (보유하지 않은 종목)
+    if (error.code === "PGRST116") {
+      return 0;
+    }
+    console.error("Holdings query error:", error);
+    throw new APIError("HOLDINGS_ERROR", "보유 현황 조회에 실패했습니다.", 500);
+  }
+
+  return Number(data?.quantity ?? 0);
+}

--- a/schemas/transaction.ts
+++ b/schemas/transaction.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+
+/**
+ * 거래 생성 요청 스키마
+ */
+export const createTransactionSchema = z.object({
+  ticker: z.string().min(1, "종목 코드는 필수입니다."),
+  type: z.enum(["buy", "sell"], {
+    message: "거래 유형은 buy 또는 sell이어야 합니다.",
+  }),
+  quantity: z
+    .number()
+    .positive("수량은 0보다 커야 합니다.")
+    .max(999999999, "수량이 너무 큽니다."),
+  price: z
+    .number()
+    .min(0, "가격은 0 이상이어야 합니다.")
+    .max(999999999999, "가격이 너무 큽니다."),
+  transactedAt: z
+    .string()
+    .datetime({ message: "유효한 날짜 형식이 아닙니다." }),
+  memo: z.string().max(500, "메모는 500자 이내여야 합니다.").optional(),
+
+  // 종목 정보 (첫 거래 시 household_stock_settings 생성용)
+  stock: z.object({
+    name: z.string().min(1, "종목명은 필수입니다."),
+    market: z.enum(["KR", "US", "OTHER"]),
+    currency: z.enum(["KRW", "USD"]),
+    assetType: z
+      .enum(["equity", "bond", "cash", "commodity", "crypto", "alternative"])
+      .optional()
+      .default("equity"),
+  }),
+});
+
+export type CreateTransactionInput = z.infer<typeof createTransactionSchema>;


### PR DESCRIPTION
## Summary
- `POST /api/transactions` 엔드포인트 추가
- Zod 스키마로 요청 검증 (`schemas/transaction.ts`)
- 첫 거래 시 `household_stock_settings` 자동 생성 (UPSERT)
- 매도 시 보유 수량 검증 (`holdings` View 조회)
- React Query mutation hook (`useCreateTransaction`)

## 데이터 흐름
```
거래 저장 → transactions INSERT
         → household_stock_settings UPSERT (첫 거래)
         → holdings View 자동 갱신
```

## API 스펙
```typescript
POST /api/transactions
{
  ticker: string,
  type: "buy" | "sell",
  quantity: number,
  price: number,
  transactedAt: string (ISO datetime),
  memo?: string,
  stock: {
    name: string,
    market: "KR" | "US" | "OTHER",
    currency: "KRW" | "USD",
    assetType?: "equity" | "bond" | ...
  }
}
```

## Test plan
- [x] `pnpm type-check` 통과
- [x] `pnpm check` (biome) 통과

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)