### PR TITLE
feat: 보유 현황 페이지 구현

### DIFF
--- a/app/(main)/holdings/page.tsx
+++ b/app/(main)/holdings/page.tsx
@@ -1,0 +1,65 @@
+import { ArrowLeft } from "lucide-react";
+import Link from "next/link";
+import { HoldingsList } from "@/components/holdings/HoldingsList";
+import { Button } from "@/components/ui/button";
+import { getHoldings } from "@/lib/api/holdings";
+import { getHouseholdWithMembers } from "@/lib/api/household";
+import { getUserHouseholdId } from "@/lib/api/invitation";
+import { requireUser } from "@/lib/supabase/auth";
+import { createClient } from "@/lib/supabase/server";
+
+export default async function HoldingsPage() {
+  const user = await requireUser();
+  const supabase = await createClient();
+
+  // 가구 정보 조회
+  const householdId = await getUserHouseholdId(supabase, user.id);
+
+  if (!householdId) {
+    return (
+      <div className="min-h-screen bg-gray-50 p-4">
+        <div className="max-w-4xl mx-auto">
+          <p className="text-center text-gray-500 py-12">
+            가구 정보를 찾을 수 없습니다.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // 가구 구성원 목록 조회
+  const household = await getHouseholdWithMembers(supabase, user.id);
+  const members =
+    household?.members.map((m) => ({ id: m.userId, name: m.name })) ?? [];
+
+  // 초기 보유 현황 조회
+  const initialData = await getHoldings(supabase, householdId, {
+    pagination: { page: 1, pageSize: 20 },
+  });
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-4">
+      <div className="max-w-4xl mx-auto space-y-6">
+        {/* 헤더 */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-4">
+            <Button variant="ghost" size="icon" asChild>
+              <Link href="/dashboard">
+                <ArrowLeft className="size-5" />
+              </Link>
+            </Button>
+            <div>
+              <h1 className="text-2xl font-bold text-gray-900">보유 현황</h1>
+              <p className="text-sm text-gray-500">
+                총 {initialData.total}개 종목 보유 중
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* 보유 현황 목록 */}
+        <HoldingsList initialData={initialData} members={members} />
+      </div>
+    </div>
+  );
+}

--- a/app/api/holdings/route.ts
+++ b/app/api/holdings/route.ts
@@ -1,0 +1,76 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import { getHoldings, type HoldingsFilters } from "@/lib/api/holdings";
+import { getUserHouseholdId } from "@/lib/api/invitation";
+import { createClient } from "@/lib/supabase/server";
+import type { AssetType, MarketType } from "@/types";
+
+/**
+ * GET /api/holdings
+ * 보유 현황 목록 조회
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+
+    // 인증 확인
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    // 사용자의 가구 조회
+    const householdId = await getUserHouseholdId(supabase, user.id);
+
+    if (!householdId) {
+      throw new APIError(
+        "HOUSEHOLD_NOT_FOUND",
+        "가구 정보를 찾을 수 없습니다.",
+        404,
+      );
+    }
+
+    // Query params 파싱
+    const searchParams = request.nextUrl.searchParams;
+    const ownerId = searchParams.get("ownerId");
+    const assetType = searchParams.get("assetType") as AssetType | null;
+    const market = searchParams.get("market") as MarketType | null;
+    const page = Number(searchParams.get("page")) || 1;
+    const pageSize = Number(searchParams.get("pageSize")) || 20;
+
+    const filters: HoldingsFilters = {};
+    if (ownerId) filters.ownerId = ownerId;
+    if (assetType) filters.assetType = assetType;
+    if (market) filters.market = market;
+
+    // 보유 현황 조회
+    const result = await getHoldings(supabase, householdId, {
+      filters,
+      pagination: { page, pageSize },
+    });
+
+    return NextResponse.json(result);
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    console.error("Holdings list error:", error);
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "서버 오류가 발생했습니다.",
+        },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/components/holdings/HoldingsFilters.tsx
+++ b/components/holdings/HoldingsFilters.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { HoldingsFilters as Filters } from "@/lib/api/holdings";
+import type { AssetType, MarketType } from "@/types";
+
+interface Member {
+  id: string;
+  name: string;
+}
+
+interface HoldingsFiltersProps {
+  filters: Filters;
+  onFiltersChange: (filters: Filters) => void;
+  members: Member[];
+}
+
+export function HoldingsFilters({
+  filters,
+  onFiltersChange,
+  members,
+}: HoldingsFiltersProps) {
+  const handleOwnerChange = (value: string) => {
+    onFiltersChange({
+      ...filters,
+      ownerId: value === "all" ? undefined : value,
+    });
+  };
+
+  const handleAssetTypeChange = (value: string) => {
+    onFiltersChange({
+      ...filters,
+      assetType: value === "all" ? undefined : (value as AssetType),
+    });
+  };
+
+  const handleMarketChange = (value: string) => {
+    onFiltersChange({
+      ...filters,
+      market: value === "all" ? undefined : (value as MarketType),
+    });
+  };
+
+  return (
+    <div className="flex flex-wrap gap-3">
+      {members.length > 1 && (
+        <Select
+          value={filters.ownerId ?? "all"}
+          onValueChange={handleOwnerChange}
+        >
+          <SelectTrigger className="w-[120px]">
+            <SelectValue placeholder="소유자" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">전체</SelectItem>
+            {members.map((member) => (
+              <SelectItem key={member.id} value={member.id}>
+                {member.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )}
+
+      <Select
+        value={filters.assetType ?? "all"}
+        onValueChange={handleAssetTypeChange}
+      >
+        <SelectTrigger className="w-[120px]">
+          <SelectValue placeholder="자산유형" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">전체</SelectItem>
+          <SelectItem value="equity">주식</SelectItem>
+          <SelectItem value="bond">채권</SelectItem>
+          <SelectItem value="cash">현금</SelectItem>
+          <SelectItem value="commodity">원자재</SelectItem>
+          <SelectItem value="crypto">암호화폐</SelectItem>
+          <SelectItem value="alternative">대체투자</SelectItem>
+        </SelectContent>
+      </Select>
+
+      <Select
+        value={filters.market ?? "all"}
+        onValueChange={handleMarketChange}
+      >
+        <SelectTrigger className="w-[120px]">
+          <SelectValue placeholder="시장" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">전체</SelectItem>
+          <SelectItem value="KR">국내</SelectItem>
+          <SelectItem value="US">미국</SelectItem>
+          <SelectItem value="OTHER">기타</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/components/holdings/HoldingsList.tsx
+++ b/components/holdings/HoldingsList.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/ui/pagination";
+import type {
+  HoldingsFilters as Filters,
+  HoldingWithDetails,
+} from "@/lib/api/holdings";
+import type { PaginatedResult } from "@/lib/utils/query";
+import { HoldingsFilters } from "./HoldingsFilters";
+import { HoldingsTable } from "./HoldingsTable";
+
+interface Member {
+  id: string;
+  name: string;
+}
+
+interface HoldingsListProps {
+  initialData: PaginatedResult<HoldingWithDetails>;
+  members: Member[];
+}
+
+export function HoldingsList({ initialData, members }: HoldingsListProps) {
+  const [data, setData] = useState(initialData);
+  const [filters, setFilters] = useState<Filters>({});
+  const [page, setPage] = useState(1);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const fetchHoldings = async (newFilters: Filters, newPage: number) => {
+    setIsLoading(true);
+    try {
+      const params = new URLSearchParams();
+      if (newFilters.ownerId) params.set("ownerId", newFilters.ownerId);
+      if (newFilters.assetType) params.set("assetType", newFilters.assetType);
+      if (newFilters.market) params.set("market", newFilters.market);
+      params.set("page", String(newPage));
+
+      const response = await fetch(`/api/holdings?${params.toString()}`);
+      if (!response.ok) throw new Error("Failed to fetch");
+      const result = await response.json();
+      setData(result);
+    } catch (error) {
+      console.error("Failed to fetch holdings:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleFiltersChange = (newFilters: Filters) => {
+    setFilters(newFilters);
+    setPage(1);
+    fetchHoldings(newFilters, 1);
+  };
+
+  const handlePageChange = (newPage: number) => {
+    setPage(newPage);
+    fetchHoldings(filters, newPage);
+  };
+
+  return (
+    <div className="space-y-4">
+      <HoldingsFilters
+        filters={filters}
+        onFiltersChange={handleFiltersChange}
+        members={members}
+      />
+
+      <div className={isLoading ? "opacity-50 pointer-events-none" : ""}>
+        <HoldingsTable data={data.data} />
+      </div>
+
+      {data.totalPages > 1 && (
+        <Pagination>
+          <PaginationContent>
+            <PaginationItem>
+              <PaginationPrevious
+                onClick={() => handlePageChange(page - 1)}
+                className={
+                  page <= 1
+                    ? "pointer-events-none opacity-50"
+                    : "cursor-pointer"
+                }
+              />
+            </PaginationItem>
+            <PaginationItem>
+              <span className="px-4 text-sm text-gray-700">
+                {page} / {data.totalPages}
+              </span>
+            </PaginationItem>
+            <PaginationItem>
+              <PaginationNext
+                onClick={() => handlePageChange(page + 1)}
+                className={
+                  page >= data.totalPages
+                    ? "pointer-events-none opacity-50"
+                    : "cursor-pointer"
+                }
+              />
+            </PaginationItem>
+          </PaginationContent>
+        </Pagination>
+      )}
+    </div>
+  );
+}

--- a/components/holdings/HoldingsTable.tsx
+++ b/components/holdings/HoldingsTable.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import {
+  type ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  type SortingState,
+  useReactTable,
+} from "@tanstack/react-table";
+import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
+import type React from "react";
+import { useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { HoldingWithDetails } from "@/lib/api/holdings";
+import { cn } from "@/lib/utils/cn";
+import { formatCurrency } from "@/lib/utils/format";
+
+interface HoldingsTableProps {
+  data: HoldingWithDetails[];
+}
+
+// 정렬 버튼 헤더 컴포넌트
+function SortableHeader({
+  column,
+  children,
+}: {
+  column: {
+    getIsSorted: () => false | "asc" | "desc";
+    toggleSorting: (desc: boolean) => void;
+  };
+  children: React.ReactNode;
+}) {
+  const sorted = column.getIsSorted();
+  return (
+    <Button
+      variant="ghost"
+      onClick={() => column.toggleSorting(sorted === "asc")}
+      className="h-8 px-2 hover:bg-transparent"
+    >
+      {children}
+      {sorted === "asc" ? (
+        <ArrowUp className="ml-1 size-4" />
+      ) : sorted === "desc" ? (
+        <ArrowDown className="ml-1 size-4" />
+      ) : (
+        <ArrowUpDown className="ml-1 size-4 opacity-50" />
+      )}
+    </Button>
+  );
+}
+
+// 자산유형 한글 매핑
+const ASSET_TYPE_LABELS: Record<string, string> = {
+  equity: "주식",
+  bond: "채권",
+  cash: "현금",
+  commodity: "원자재",
+  crypto: "암호화폐",
+  alternative: "대체투자",
+};
+
+// 시장 한글 매핑
+const MARKET_LABELS: Record<string, string> = {
+  KR: "국내",
+  US: "미국",
+  OTHER: "기타",
+};
+
+const columns: ColumnDef<HoldingWithDetails>[] = [
+  {
+    accessorKey: "name",
+    header: ({ column }) => (
+      <SortableHeader column={column}>종목</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <div>
+        <div className="font-medium">{row.original.name}</div>
+        <div className="text-xs text-gray-500">{row.original.ticker}</div>
+      </div>
+    ),
+  },
+  {
+    id: "owner",
+    accessorKey: "owner",
+    header: "소유자",
+    meta: { className: "hidden lg:table-cell" },
+    cell: ({ row }) => row.original.owner.name,
+  },
+  {
+    accessorKey: "quantity",
+    header: ({ column }) => (
+      <SortableHeader column={column}>수량</SortableHeader>
+    ),
+    meta: { className: "hidden md:table-cell" },
+    cell: ({ row }) => (
+      <span className="tabular-nums">
+        {row.original.quantity.toLocaleString()}
+      </span>
+    ),
+  },
+  {
+    accessorKey: "avgPrice",
+    header: ({ column }) => (
+      <SortableHeader column={column}>평균 매수가</SortableHeader>
+    ),
+    meta: { className: "hidden md:table-cell" },
+    cell: ({ row }) => (
+      <span className="tabular-nums">
+        {formatCurrency(row.original.avgPrice, row.original.currency)}
+      </span>
+    ),
+  },
+  {
+    accessorKey: "totalInvested",
+    header: ({ column }) => (
+      <SortableHeader column={column}>투자 금액</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="tabular-nums font-medium">
+        {formatCurrency(row.original.totalInvested, row.original.currency)}
+      </span>
+    ),
+  },
+  {
+    id: "market",
+    accessorKey: "market",
+    header: "시장",
+    meta: { className: "hidden lg:table-cell" },
+    cell: ({ row }) => (
+      <Badge variant="outline">
+        {MARKET_LABELS[row.original.market] ?? row.original.market}
+      </Badge>
+    ),
+  },
+  {
+    id: "assetType",
+    accessorKey: "assetType",
+    header: "유형",
+    meta: { className: "hidden lg:table-cell" },
+    cell: ({ row }) => (
+      <span className="text-gray-600">
+        {ASSET_TYPE_LABELS[row.original.assetType] ?? row.original.assetType}
+      </span>
+    ),
+  },
+];
+
+export function HoldingsTable({ data }: HoldingsTableProps) {
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: "totalInvested", desc: true },
+  ]);
+
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    onSortingChange: setSorting,
+    state: {
+      sorting,
+    },
+  });
+
+  return (
+    <div className="rounded-xl border bg-white overflow-hidden">
+      <Table>
+        <TableHeader>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <TableRow key={headerGroup.id} className="bg-gray-50">
+              {headerGroup.headers.map((header) => {
+                const meta = header.column.columnDef.meta as
+                  | { className?: string }
+                  | undefined;
+                return (
+                  <TableHead
+                    key={header.id}
+                    className={cn("px-4 py-3", meta?.className)}
+                  >
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext(),
+                        )}
+                  </TableHead>
+                );
+              })}
+            </TableRow>
+          ))}
+        </TableHeader>
+        <TableBody>
+          {table.getRowModel().rows.length ? (
+            table.getRowModel().rows.map((row) => (
+              <TableRow key={row.id}>
+                {row.getVisibleCells().map((cell) => {
+                  const meta = cell.column.columnDef.meta as
+                    | { className?: string }
+                    | undefined;
+                  return (
+                    <TableCell
+                      key={cell.id}
+                      className={cn("px-4 py-3", meta?.className)}
+                    >
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext(),
+                      )}
+                    </TableCell>
+                  );
+                })}
+              </TableRow>
+            ))
+          ) : (
+            <TableRow>
+              <TableCell colSpan={columns.length} className="h-24 text-center">
+                보유 종목이 없습니다.
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/lib/api/holdings.ts
+++ b/lib/api/holdings.ts
@@ -1,0 +1,158 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  calculateRange,
+  createPaginatedResult,
+  type PaginatedResult,
+  type PaginationOptions,
+  type SortOptions,
+} from "@/lib/utils/query";
+import type {
+  AssetType,
+  CurrencyType,
+  Database,
+  MarketType,
+  RiskLevel,
+} from "@/types";
+import { APIError } from "./error";
+
+/**
+ * 보유 현황 조회 필터
+ */
+export interface HoldingsFilters {
+  ownerId?: string;
+  assetType?: AssetType;
+  market?: MarketType;
+}
+
+/**
+ * 보유 현황 정렬 필드
+ */
+export type HoldingsSortField =
+  | "name"
+  | "total_invested"
+  | "quantity"
+  | "avg_price";
+
+/**
+ * 보유 현황 with 관련 정보
+ */
+export interface HoldingWithDetails {
+  ticker: string;
+  name: string;
+  quantity: number;
+  avgPrice: number;
+  totalInvested: number;
+  market: MarketType;
+  currency: CurrencyType;
+  assetType: AssetType;
+  riskLevel: RiskLevel | null;
+  firstTransactionAt: string | null;
+  lastTransactionAt: string | null;
+  owner: {
+    id: string;
+    name: string;
+  };
+}
+
+/**
+ * 보유 현황 조회 옵션
+ */
+export interface GetHoldingsOptions {
+  filters?: HoldingsFilters;
+  sort?: SortOptions<HoldingsSortField>;
+  pagination?: PaginationOptions;
+}
+
+// 정렬 필드 -> DB 컬럼 매핑
+const HOLDINGS_SORT_COLUMNS: Record<HoldingsSortField, string> = {
+  name: "name",
+  total_invested: "total_invested",
+  quantity: "quantity",
+  avg_price: "avg_price",
+};
+
+/**
+ * 보유 현황 목록 조회
+ */
+export async function getHoldings(
+  supabase: SupabaseClient<Database>,
+  householdId: string,
+  options?: GetHoldingsOptions,
+): Promise<PaginatedResult<HoldingWithDetails>> {
+  const { filters, sort, pagination } = options ?? {};
+
+  // 기본 쿼리 빌드
+  let query = supabase
+    .from("holdings")
+    .select("*", { count: "exact" })
+    .eq("household_id", householdId);
+
+  // 필터 적용
+  if (filters?.ownerId) {
+    query = query.eq("owner_id", filters.ownerId);
+  }
+  if (filters?.assetType) {
+    query = query.eq("asset_type", filters.assetType);
+  }
+  if (filters?.market) {
+    query = query.eq("market", filters.market);
+  }
+
+  // 정렬 적용
+  const sortField = sort?.field ?? "total_invested";
+  const sortDirection = sort?.direction ?? "desc";
+  const sortColumn = HOLDINGS_SORT_COLUMNS[sortField];
+  query = query.order(sortColumn, {
+    ascending: sortDirection === "asc",
+    nullsFirst: false,
+  });
+
+  // 페이지네이션 적용
+  const { from, to } = calculateRange(pagination);
+  query = query.range(from, to);
+
+  const { data, error, count } = await query;
+
+  if (error) {
+    console.error("Holdings query error:", error);
+    throw new APIError("HOLDINGS_ERROR", "보유 현황 조회에 실패했습니다.", 500);
+  }
+
+  // 소유자 정보 조회 (별도 쿼리)
+  const ownerIds = [...new Set((data ?? []).map((h) => h.owner_id))].filter(
+    (id): id is string => id !== null,
+  );
+  const ownerMap = new Map<string, string>();
+
+  if (ownerIds.length > 0) {
+    const { data: profiles } = await supabase
+      .from("profiles")
+      .select("id, name")
+      .in("id", ownerIds);
+
+    for (const p of profiles ?? []) {
+      ownerMap.set(p.id, p.name);
+    }
+  }
+
+  // 데이터 변환
+  const holdings: HoldingWithDetails[] = (data ?? []).map((h) => ({
+    ticker: h.ticker ?? "",
+    name: h.name ?? h.ticker ?? "",
+    quantity: Number(h.quantity ?? 0),
+    avgPrice: Number(h.avg_price ?? 0),
+    totalInvested: Number(h.total_invested ?? 0),
+    market: h.market ?? "KR",
+    currency: h.currency ?? "KRW",
+    assetType: h.asset_type ?? "equity",
+    riskLevel: h.risk_level,
+    firstTransactionAt: h.first_transaction_at,
+    lastTransactionAt: h.last_transaction_at,
+    owner: {
+      id: h.owner_id ?? "",
+      name: ownerMap.get(h.owner_id ?? "") ?? "알 수 없음",
+    },
+  }));
+
+  return createPaginatedResult(holdings, count ?? 0, pagination);
+}


### PR DESCRIPTION
## Summary
- Holdings API 함수 및 Route 추가 (`lib/api/holdings.ts`, `app/api/holdings/route.ts`)
- HoldingsTable: TanStack Table 기반 테이블 (종목명, 수량, 평균매수가, 투자금액 정렬 지원)
- HoldingsFilters: 소유자, 자산유형(equity/bond/cash 등), 시장(KR/US/OTHER) 필터
- HoldingsList: 필터 + 테이블 + 페이지네이션 컨테이너
- `/holdings` 페이지 (서버 컴포넌트로 초기 데이터 로드)

## Test plan
- [x] `pnpm type-check` 통과
- [x] `pnpm check` (biome) 통과

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)