### PR TITLE
fix: next-task/resume-task 커맨드 개선

### DIFF
--- a/.claude/commands/next-task.md
+++ b/.claude/commands/next-task.md
@@ -11,11 +11,24 @@ allowed-tools: Bash(gh:*), Bash(git:*)
 
 ## 2단계: 이미 작업 중인 이슈 확인
 
-!`git worktree list`
-!`git branch -a | grep -E "^(\*| )*(feature|fix)/" | head -20`
+### 2-1. 원격 브랜치 확인
 
-위 결과에서 브랜치명 패턴 `feature/[번호]-*` 또는 `fix/[번호]-*`로 이미 작업 중인 이슈 번호를 추출합니다.
-이미 브랜치가 존재하는 이슈는 **작업 중**으로 간주하여 추천에서 제외합니다.
+```bash
+git fetch origin --prune
+git branch -r --list 'origin/feature/*' 'origin/fix/*'
+```
+
+### 2-2. 열린 PR 확인
+
+```bash
+gh pr list --state open --json number,headRefName
+```
+
+위 결과에서:
+1. 원격 브랜치명 패턴 `origin/feature/[번호]-*` 또는 `origin/fix/[번호]-*`에서 이슈 번호 추출
+2. 열린 PR의 `headRefName`에서 이슈 번호 추출
+
+**두 결과를 합쳐서** 이미 작업 중인 이슈 번호 목록을 만들고, 추천에서 제외합니다.
 
 ## 3단계: 이슈 분석 및 추천
 

--- a/.claude/commands/resume-task.md
+++ b/.claude/commands/resume-task.md
@@ -29,7 +29,40 @@ git branch --show-current
 - `feature/42-add-login` → `42`
 - `fix/123-bug-fix` → `123`
 
-## 3단계: 작업 시작
+## 3단계: PR 확인 및 생성
+
+### 3-1. 해당 브랜치의 PR 존재 확인
+
+```bash
+gh pr list --head [현재브랜치명] --state open --json number,url
+```
+
+### 3-2. PR 상태에 따른 분기
+
+| 상태 | 동작 |
+|------|------|
+| PR 있음 | PR 정보 표시 후 4단계로 진행 |
+| PR 없음 + 로컬 커밋 있음 | 원격에 push 후 Draft PR 생성, 4단계로 진행 |
+| PR 없음 + 로컬 커밋 없음 | PR 없이 4단계로 진행 |
+
+### 로컬 커밋 확인 방법
+
+```bash
+# main 브랜치 대비 새 커밋이 있는지 확인
+git log origin/main..HEAD --oneline
+```
+
+### Draft PR 생성 (커밋이 있을 때)
+
+```bash
+# 원격에 push
+git push -u origin [현재브랜치명]
+
+# Draft PR 생성
+gh pr create --draft --title "[WIP] #[이슈번호] 이슈제목" --body "Closes #[이슈번호]"
+```
+
+## 4단계: 작업 시작
 
 `.claude/shared/_start-work.md` 프로세스를 따릅니다:
 


### PR DESCRIPTION
## Summary
- next-task: 로컬 브랜치 대신 원격 브랜치 + 열린 PR 확인으로 변경하여 작업 중인 이슈 감지 정확도 향상
- resume-task: PR 존재 확인 및 커밋이 있을 경우 Draft PR 자동 생성 로직 추가

## Test plan
- [x] `/next-task` 실행 시 원격 브랜치와 열린 PR 기반으로 작업 중 이슈 제외 확인
- [x] `/resume-task` 실행 시 PR 없고 커밋 있으면 Draft PR 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)