### PR TITLE
feat: 메인 홈 페이지 및 랜딩페이지 구현 (#79)

### DIFF
--- a/app/(main)/home/page.tsx
+++ b/app/(main)/home/page.tsx
@@ -1,0 +1,59 @@
+import {
+  QuickActions,
+  RecentTransactions,
+  TopHoldings,
+  TotalAssetCard,
+} from "@/components/home";
+import { getHoldings } from "@/lib/api/holdings";
+import { getUserHouseholdId } from "@/lib/api/invitation";
+import { requireUser } from "@/lib/supabase/auth";
+import { createClient } from "@/lib/supabase/server";
+
+export default async function HomePage() {
+  const user = await requireUser();
+  const supabase = await createClient();
+
+  // 가구 ID 조회
+  const householdId = await getUserHouseholdId(supabase, user.id);
+
+  // 총 투자금액 계산 (holdings 전체 조회)
+  let totalInvested = 0;
+  if (householdId) {
+    const holdings = await getHoldings(supabase, householdId, {
+      pagination: { page: 1, pageSize: 1000 },
+    });
+    totalInvested = holdings.data.reduce((sum, h) => sum + h.totalInvested, 0);
+  }
+
+  // 사용자 이름 조회
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("name")
+    .eq("id", user.id)
+    .single();
+
+  const userName = profile?.name ?? user.email?.split("@")[0] ?? "사용자";
+
+  return (
+    <>
+      {/* 인사말 */}
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">
+          안녕하세요, {userName}님
+        </h1>
+      </div>
+
+      {/* 총 자산 카드 */}
+      <TotalAssetCard totalInvested={totalInvested} />
+
+      {/* 빠른 액션 */}
+      <QuickActions />
+
+      {/* 최근 거래 & TOP 5 종목 */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <RecentTransactions />
+        <TopHoldings />
+      </div>
+    </>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,65 +1,89 @@
-import Image from "next/image";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
 
-export default function Home() {
+export default function LandingPage() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex min-h-screen w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
-          priority
-        />
-        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
+    <div className="min-h-screen bg-white">
+      {/* 헤더 */}
+      <header className="sticky top-0 z-40 h-14 bg-white/80 backdrop-blur-sm border-b border-gray-100">
+        <div className="h-full max-w-5xl mx-auto px-4 flex items-center justify-between">
+          <span className="text-xl font-bold text-primary">oat</span>
+          <div className="flex items-center gap-2">
+            <Button variant="ghost" asChild>
+              <Link href="/login">로그인</Link>
+            </Button>
+            <Button asChild>
+              <Link href="/signup">시작하기</Link>
+            </Button>
+          </div>
+        </div>
+      </header>
+
+      {/* 히어로 섹션 */}
+      <section className="py-20 px-4">
+        <div className="max-w-3xl mx-auto text-center space-y-6">
+          <h1 className="text-4xl md:text-5xl font-bold text-gray-900 leading-tight">
+            가족 자산,
+            <br />
+            한눈에 보세요
           </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{" "}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Templates
-            </a>{" "}
-            or the{" "}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Learning
-            </a>{" "}
-            center.
+          <p className="text-lg md:text-xl text-gray-600 max-w-xl mx-auto">
+            각자 다른 증권사, 다른 종목,
+            <br />
+            이제 하나로 모아 관리하세요.
           </p>
+          <div className="pt-4">
+            <Button size="lg" className="text-base px-8" asChild>
+              <Link href="/signup">무료로 시작하기</Link>
+            </Button>
+          </div>
         </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
-          <a
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[158px]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
+      </section>
+
+      {/* 기능 소개 */}
+      <section className="py-16 px-4 bg-gray-50">
+        <div className="max-w-4xl mx-auto">
+          <h2 className="text-2xl font-bold text-gray-900 text-center mb-12">
+            oat와 함께하면
+          </h2>
+          <div className="grid md:grid-cols-3 gap-8">
+            <FeatureCard
+              title="가족 자산 통합"
+              description="가족 구성원의 투자 자산을 한 대시보드에서 한눈에 확인하세요."
             />
-            Deploy Now
-          </a>
-          <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Documentation
-          </a>
+            <FeatureCard
+              title="환율 자동 반영"
+              description="해외 주식도 원화로 자동 환산하여 총 자산을 파악할 수 있어요."
+            />
+            <FeatureCard
+              title="포트폴리오 분석"
+              description="자산군별, 위험도별 비중을 차트로 확인하고 리밸런싱하세요."
+            />
+          </div>
         </div>
-      </main>
+      </section>
+
+      {/* 푸터 */}
+      <footer className="py-8 px-4 border-t border-gray-100">
+        <div className="max-w-5xl mx-auto text-center text-sm text-gray-500">
+          <p>oat - 가족 자산 통합 관리</p>
+        </div>
+      </footer>
+    </div>
+  );
+}
+
+function FeatureCard({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="bg-white rounded-2xl p-6 shadow-sm">
+      <h3 className="font-semibold text-gray-900 mb-2">{title}</h3>
+      <p className="text-sm text-gray-600 leading-relaxed">{description}</p>
     </div>
   );
 }

--- a/components/home/QuickActions.tsx
+++ b/components/home/QuickActions.tsx
@@ -1,0 +1,59 @@
+import { BarChart3, MinusCircle, PlusCircle } from "lucide-react";
+import Link from "next/link";
+import { cn } from "@/lib/utils/cn";
+
+const actions = [
+  {
+    href: "/transactions/new?type=buy",
+    label: "매수",
+    icon: PlusCircle,
+    color: "text-green-600",
+    bgColor: "bg-green-50",
+  },
+  {
+    href: "/transactions/new?type=sell",
+    label: "매도",
+    icon: MinusCircle,
+    color: "text-red-600",
+    bgColor: "bg-red-50",
+  },
+  {
+    href: "/dashboard",
+    label: "분석",
+    icon: BarChart3,
+    color: "text-primary",
+    bgColor: "bg-primary/10",
+  },
+];
+
+export function QuickActions() {
+  return (
+    <div className="bg-white rounded-2xl p-5 shadow-sm">
+      <h3 className="text-sm font-medium text-gray-500 mb-4">빠른 액션</h3>
+      <div className="grid grid-cols-3 gap-3">
+        {actions.map((action) => {
+          const Icon = action.icon;
+          return (
+            <Link
+              key={action.href}
+              href={action.href}
+              className="flex flex-col items-center gap-2 p-3 rounded-xl hover:bg-gray-50 transition-colors"
+            >
+              <div
+                className={cn(
+                  "flex items-center justify-center size-12 rounded-full",
+                  action.bgColor,
+                )}
+              >
+                <Icon className={cn("size-6", action.color)} />
+              </div>
+              <span className="text-sm font-medium text-gray-700">
+                {action.label}
+              </span>
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/home/RecentTransactions.tsx
+++ b/components/home/RecentTransactions.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { ArrowRight } from "lucide-react";
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { useTransactions } from "@/hooks/use-transaction";
+import { formatDateShort } from "@/lib/utils/format";
+
+export function RecentTransactions() {
+  const { data, isLoading } = useTransactions({
+    page: 1,
+    pageSize: 5,
+  });
+
+  const transactions = data?.data ?? [];
+
+  return (
+    <div className="bg-white rounded-2xl p-5 shadow-sm">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-sm font-medium text-gray-500">최근 거래</h3>
+        <Link
+          href="/transactions"
+          className="flex items-center gap-1 text-sm text-primary hover:underline"
+        >
+          전체 보기
+          <ArrowRight className="size-4" />
+        </Link>
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="h-12 bg-gray-100 rounded-lg animate-pulse"
+            />
+          ))}
+        </div>
+      ) : transactions.length === 0 ? (
+        <div className="py-8 text-center text-sm text-gray-500">
+          아직 거래 내역이 없어요
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {transactions.map((tx) => (
+            <div key={tx.id} className="flex items-center justify-between py-2">
+              <div className="flex items-center gap-3">
+                <Badge
+                  variant={tx.type === "buy" ? "default" : "secondary"}
+                  className="w-10 justify-center"
+                >
+                  {tx.type === "buy" ? "매수" : "매도"}
+                </Badge>
+                <div>
+                  <p className="font-medium text-gray-900">{tx.stockName}</p>
+                  <p className="text-xs text-gray-500">
+                    {tx.quantity.toLocaleString()}주
+                  </p>
+                </div>
+              </div>
+              <span className="text-sm text-gray-500">
+                {formatDateShort(tx.transactedAt)}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/home/TopHoldings.tsx
+++ b/components/home/TopHoldings.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { ArrowRight } from "lucide-react";
+import Link from "next/link";
+import type { HoldingWithDetails } from "@/lib/api/holdings";
+import { queries } from "@/lib/queries/keys";
+import { formatCurrency } from "@/lib/utils/format";
+import type { PaginatedResult } from "@/lib/utils/query";
+
+async function fetchTopHoldings(): Promise<
+  PaginatedResult<HoldingWithDetails>
+> {
+  const response = await fetch("/api/holdings?pageSize=5");
+  if (!response.ok) {
+    throw new Error("보유 현황 조회에 실패했습니다.");
+  }
+  return response.json();
+}
+
+export function TopHoldings() {
+  const { data, isLoading } = useQuery({
+    queryKey: queries.holdings.list.queryKey,
+    queryFn: fetchTopHoldings,
+  });
+
+  const holdings = data?.data ?? [];
+
+  return (
+    <div className="bg-white rounded-2xl p-5 shadow-sm">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-sm font-medium text-gray-500">보유 종목 TOP 5</h3>
+        <Link
+          href="/holdings"
+          className="flex items-center gap-1 text-sm text-primary hover:underline"
+        >
+          전체 보기
+          <ArrowRight className="size-4" />
+        </Link>
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="h-12 bg-gray-100 rounded-lg animate-pulse"
+            />
+          ))}
+        </div>
+      ) : holdings.length === 0 ? (
+        <div className="py-8 text-center text-sm text-gray-500">
+          아직 보유 종목이 없어요
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {holdings.map((holding, index) => (
+            <div
+              key={`${holding.ticker}-${holding.owner.id}`}
+              className="flex items-center justify-between py-2"
+            >
+              <div className="flex items-center gap-3">
+                <span className="flex items-center justify-center size-6 rounded-full bg-gray-100 text-xs font-medium text-gray-600">
+                  {index + 1}
+                </span>
+                <div>
+                  <p className="font-medium text-gray-900">{holding.name}</p>
+                  <p className="text-xs text-gray-500">{holding.owner.name}</p>
+                </div>
+              </div>
+              <span className="text-sm font-medium text-gray-900 tabular-nums">
+                {formatCurrency(holding.totalInvested, holding.currency)}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/home/TotalAssetCard.tsx
+++ b/components/home/TotalAssetCard.tsx
@@ -1,0 +1,20 @@
+import { formatCurrency } from "@/lib/utils/format";
+
+interface TotalAssetCardProps {
+  totalInvested: number;
+  currency?: "KRW" | "USD";
+}
+
+export function TotalAssetCard({
+  totalInvested,
+  currency = "KRW",
+}: TotalAssetCardProps) {
+  return (
+    <div className="bg-white rounded-2xl p-6 shadow-sm">
+      <span className="text-sm text-gray-500">우리집 총 투자금액</span>
+      <p className="text-3xl font-bold text-gray-900 mt-1">
+        {formatCurrency(totalInvested, currency)}
+      </p>
+    </div>
+  );
+}

--- a/components/home/index.ts
+++ b/components/home/index.ts
@@ -1,0 +1,4 @@
+export { QuickActions } from "./QuickActions";
+export { RecentTransactions } from "./RecentTransactions";
+export { TopHoldings } from "./TopHoldings";
+export { TotalAssetCard } from "./TotalAssetCard";

--- a/components/layout/BottomNav.tsx
+++ b/components/layout/BottomNav.tsx
@@ -1,14 +1,15 @@
 "use client";
 
-import { FileText, Home, Settings, TrendingUp } from "lucide-react";
+import { BarChart3, FileText, Home, Settings, TrendingUp } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils/cn";
 
 const navItems = [
-  { href: "/dashboard", label: "홈", icon: Home },
-  { href: "/holdings", label: "보유 현황", icon: TrendingUp },
-  { href: "/transactions", label: "거래 내역", icon: FileText },
+  { href: "/home", label: "홈", icon: Home },
+  { href: "/dashboard", label: "분석", icon: BarChart3 },
+  { href: "/holdings", label: "보유", icon: TrendingUp },
+  { href: "/transactions", label: "거래", icon: FileText },
   { href: "/settings/stocks", label: "설정", icon: Settings },
 ];
 
@@ -16,6 +17,9 @@ export function BottomNav() {
   const pathname = usePathname();
 
   const isActive = (href: string) => {
+    if (href === "/home") {
+      return pathname === "/home";
+    }
     if (href === "/dashboard") {
       return pathname === "/dashboard";
     }
@@ -24,7 +28,7 @@ export function BottomNav() {
 
   return (
     <nav className="fixed bottom-0 left-0 right-0 z-40 h-16 bg-white border-t border-gray-200 lg:hidden">
-      <div className="h-full grid grid-cols-4">
+      <div className="h-full grid grid-cols-5">
         {navItems.map((item) => {
           const Icon = item.icon;
           const active = isActive(item.href);

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -8,7 +8,7 @@ export function Header() {
     <header className="sticky top-0 z-40 h-14 bg-white border-b border-gray-200">
       <div className="h-full px-4 flex items-center justify-between">
         {/* 로고 */}
-        <Link href="/dashboard" className="flex items-center gap-2">
+        <Link href="/home" className="flex items-center gap-2">
           <span className="text-xl font-bold text-primary">oat</span>
         </Link>
 

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { FileText, Home, Settings, TrendingUp } from "lucide-react";
+import { BarChart3, FileText, Home, Settings, TrendingUp } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils/cn";
 
 const navItems = [
-  { href: "/dashboard", label: "홈", icon: Home },
+  { href: "/home", label: "홈", icon: Home },
+  { href: "/dashboard", label: "분석", icon: BarChart3 },
   { href: "/holdings", label: "보유 현황", icon: TrendingUp },
   { href: "/transactions", label: "거래 내역", icon: FileText },
   { href: "/settings/stocks", label: "설정", icon: Settings },
@@ -16,6 +17,9 @@ export function Sidebar() {
   const pathname = usePathname();
 
   const isActive = (href: string) => {
+    if (href === "/home") {
+      return pathname === "/home";
+    }
     if (href === "/dashboard") {
       return pathname === "/dashboard";
     }

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -4,9 +4,9 @@ import type { Database } from "@/types";
 
 const AUTH_ROUTES = ["/login", "/signup", "/reset-password", "/auth/callback"];
 const PUBLIC_ROUTES = ["/"];
+const LANDING_ROUTE = "/";
 
-// TODO: 인증 후 첫 진입 라우트 - 추후 결정 필요 (대시보드 또는 다른 페이지)
-const DEFAULT_AUTH_REDIRECT = "/dashboard";
+const DEFAULT_AUTH_REDIRECT = "/home";
 const DEFAULT_UNAUTH_REDIRECT = "/login";
 
 export async function updateSession(request: NextRequest) {
@@ -52,8 +52,15 @@ export async function updateSession(request: NextRequest) {
     return supabaseResponse;
   }
 
-  // 인증된 사용자가 auth 라우트 접근 시 첫 진입 라우트로 리다이렉트
+  // 인증된 사용자가 auth 라우트 접근 시 홈으로 리다이렉트
   if (user && isAuthRoute) {
+    const redirectUrl = request.nextUrl.clone();
+    redirectUrl.pathname = DEFAULT_AUTH_REDIRECT;
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  // 인증된 사용자가 랜딩페이지 접근 시 홈으로 리다이렉트
+  if (user && pathname === LANDING_ROUTE) {
     const redirectUrl = request.nextUrl.clone();
     redirectUrl.pathname = DEFAULT_AUTH_REDIRECT;
     return NextResponse.redirect(redirectUrl);


### PR DESCRIPTION
## Summary
- 공개 랜딩페이지 (`/`) 구현 - 서비스 소개 및 회원가입 유도
- 로그인 후 홈 페이지 (`/home`) 구현 - 빠른 액션 중심
- 네비게이션 구조 변경: 홈 `/home` → 분석 `/dashboard`
- 미들웨어 수정: 인증된 사용자 `/` 접근 시 `/home`으로 리다이렉트

## 주요 변경 사항

### 새로 추가된 페이지
- `/` - 공개 랜딩페이지 (비로그인 사용자용)
- `/home` - 메인 홈 페이지 (로그인 사용자용)

### 홈 페이지 구성
- **TotalAssetCard**: 우리집 총 투자금액 표시
- **QuickActions**: 빠른 액션 버튼 (매수/매도/분석)
- **RecentTransactions**: 최근 거래 5건
- **TopHoldings**: 보유 종목 TOP 5

### 네비게이션 변경
- 기존: 홈(`/dashboard`) → 보유 현황 → 거래 내역 → 설정
- 변경: 홈(`/home`) → 분석(`/dashboard`) → 보유 현황 → 거래 내역 → 설정

## Test plan
- [ ] 비로그인 상태에서 `/` 접근 시 랜딩페이지 표시 확인
- [ ] 로그인 상태에서 `/` 접근 시 `/home`으로 리다이렉트 확인
- [ ] `/home` 페이지에서 총 투자금액, 빠른 액션, 최근 거래, TOP 5 종목 표시 확인
- [ ] 네비게이션 메뉴에서 홈/분석 링크 정상 동작 확인

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)