### PR TITLE
fix: search_stocks 함수 search_path 보안 수정 (#84)

### DIFF
--- a/supabase/migrations/20260107120827_fix_search_stocks_search_path.sql
+++ b/supabase/migrations/20260107120827_fix_search_stocks_search_path.sql
@@ -1,0 +1,29 @@
+-- search_stocks 함수에 search_path 보안 설정 추가
+-- Supabase Security Advisor: Function has a role mutable search_path
+-- 참고: https://supabase.com/docs/guides/database/database-linter?lint=0011_function_search_path_mutable
+
+create or replace function public.search_stocks(
+  search_query text,
+  market_filter market_type default null,
+  result_limit int default 50
+)
+returns setof public.stock_master
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select *
+  from public.stock_master
+  where
+    is_active = true
+    and is_suspended = false
+    and (market_filter is null or market = market_filter)
+    and (
+      code ilike trim(search_query) || '%'
+      or name ilike '%' || trim(search_query) || '%'
+      or name_en ilike '%' || trim(search_query) || '%'
+      or choseong like trim(search_query) || '%'
+    )
+  limit result_limit;
+$$;


### PR DESCRIPTION
## Summary
- `search_stocks` 함수에 `set search_path = ''` 보안 설정 추가
- Supabase Security Advisor 경고 해결 (Function has a role mutable search_path)
- 기존 프로젝트의 다른 함수들과 동일한 패턴 적용

## Test plan
- [x] 로컬 Supabase에서 마이그레이션 실행 확인
- [x] `proconfig`에 `search_path` 설정 확인
- [x] 함수 정상 동작 확인

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)