### PR TITLE
[Dashboard] 총 자산 / 총 수익률 카드 구현 (#82)

### DIFF
--- a/app/(main)/dashboard/page.tsx
+++ b/app/(main)/dashboard/page.tsx
@@ -1,22 +1,12 @@
 import { BarChart3, PlusCircle } from "lucide-react";
-import { QuickActionCard, SummaryCard } from "@/components/dashboard";
+import {
+  DashboardSummarySection,
+  QuickActionCard,
+} from "@/components/dashboard";
 import { ExchangeRateInfo } from "@/components/dashboard/ExchangeRateInfo";
 import { getExchangeRateSafe } from "@/lib/api/exchange";
 import { getUser } from "@/lib/supabase/auth";
 import { createClient } from "@/lib/supabase/server";
-
-// Mock 데이터 (추후 API 연동 시 제거)
-const mockDashboardData = {
-  byMember: [
-    { label: "홍길동", value: 75000000, percentage: 60, color: "#4F46E5" },
-    { label: "김영희", value: 50000000, percentage: 40, color: "#03B26C" },
-  ],
-  byAssetClass: [
-    { label: "주식", value: 80000000, percentage: 64, color: "#4F46E5" },
-    { label: "채권", value: 25000000, percentage: 20, color: "#03B26C" },
-    { label: "현금", value: 20430000, percentage: 16, color: "#8B95A1" },
-  ],
-};
 
 export default async function DashboardPage() {
   const user = await getUser();
@@ -31,14 +21,8 @@ export default async function DashboardPage() {
         <p className="text-sm text-gray-500">안녕하세요, {user?.email}님</p>
       </div>
 
-      {/* 요약 카드 그리드 */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <SummaryCard title="구성원별 자산" items={mockDashboardData.byMember} />
-        <SummaryCard
-          title="자산군별 비중"
-          items={mockDashboardData.byAssetClass}
-        />
-      </div>
+      {/* 총 자산 / 수익률 / 요약 카드 */}
+      <DashboardSummarySection />
 
       {/* 빠른 액션 */}
       <div className="space-y-3">

--- a/app/api/dashboard/summary/route.ts
+++ b/app/api/dashboard/summary/route.ts
@@ -1,0 +1,224 @@
+import { NextResponse } from "next/server";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import { getExchangeRateSafe } from "@/lib/api/exchange";
+import { getHoldings } from "@/lib/api/holdings";
+import { getUserHouseholdId } from "@/lib/api/invitation";
+import { getStockPrices } from "@/lib/api/stock-price";
+import { createClient } from "@/lib/supabase/server";
+import type {
+  AssetClassSummary,
+  DashboardSummary,
+  MemberSummary,
+} from "@/types";
+
+interface HoldingWithValue {
+  ticker: string;
+  name: string;
+  quantity: number;
+  avgPrice: number;
+  totalInvested: number;
+  market: "KR" | "US" | "OTHER";
+  currency: "KRW" | "USD";
+  assetType: string;
+  ownerId: string;
+  ownerName: string;
+  currentPrice: number | null;
+  currentValue: number;
+  investedAmountKRW: number;
+}
+
+/**
+ * GET /api/dashboard/summary
+ * 대시보드 요약 데이터 조회
+ */
+export async function GET() {
+  try {
+    const supabase = await createClient();
+
+    // 인증 확인
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    // 사용자의 가구 조회
+    const householdId = await getUserHouseholdId(supabase, user.id);
+
+    if (!householdId) {
+      throw new APIError(
+        "HOUSEHOLD_NOT_FOUND",
+        "가구 정보를 찾을 수 없습니다.",
+        404,
+      );
+    }
+
+    // 환율 조회 (USD → KRW)
+    const exchangeRateResult = await getExchangeRateSafe(
+      supabase,
+      "USD",
+      "KRW",
+    );
+    const exchangeRate = exchangeRateResult?.rate ?? 1300; // 기본값 1300
+
+    // 보유 현황 조회 (페이지네이션 없이 전체)
+    const holdingsResult = await getHoldings(supabase, householdId, {
+      pagination: { page: 1, pageSize: 1000 },
+    });
+
+    const holdings = holdingsResult.data;
+
+    // 빈 holdings 처리
+    if (holdings.length === 0) {
+      const emptySummary: DashboardSummary = {
+        totalValue: 0,
+        totalInvested: 0,
+        totalReturn: 0,
+        returnRate: 0,
+        byMember: [],
+        byAssetClass: [],
+      };
+      return NextResponse.json({
+        ...emptySummary,
+        missingPriceCount: 0,
+        exchangeRate,
+      });
+    }
+
+    // 주가 조회
+    const stockQueries = holdings
+      .filter((h) => h.market === "KR" || h.market === "US")
+      .map((h) => ({
+        market: h.market as "KR" | "US",
+        code: h.ticker,
+      }));
+
+    const stockPrices = await getStockPrices(supabase, stockQueries);
+
+    // 각 종목별 현재가치 계산
+    let missingPriceCount = 0;
+    const holdingsWithValue: HoldingWithValue[] = holdings.map((h) => {
+      const priceKey = `${h.market}:${h.ticker}`;
+      const priceData = stockPrices[priceKey];
+      const currentPrice = priceData?.price ?? null;
+
+      if (currentPrice === null) {
+        missingPriceCount++;
+      }
+
+      // 현재가가 없으면 평균 매수가를 대신 사용
+      const effectivePrice = currentPrice ?? h.avgPrice;
+      const rawCurrentValue = h.quantity * effectivePrice;
+      const rawInvestedAmount = h.totalInvested;
+
+      // USD → KRW 환산
+      const isUSD = h.currency === "USD";
+      const currentValue = isUSD
+        ? rawCurrentValue * exchangeRate
+        : rawCurrentValue;
+      const investedAmountKRW = isUSD
+        ? rawInvestedAmount * exchangeRate
+        : rawInvestedAmount;
+
+      return {
+        ticker: h.ticker,
+        name: h.name,
+        quantity: h.quantity,
+        avgPrice: h.avgPrice,
+        totalInvested: h.totalInvested,
+        market: h.market,
+        currency: h.currency,
+        assetType: h.assetType,
+        ownerId: h.owner.id,
+        ownerName: h.owner.name,
+        currentPrice,
+        currentValue,
+        investedAmountKRW,
+      };
+    });
+
+    // 총계 계산
+    const totalValue = holdingsWithValue.reduce(
+      (sum, h) => sum + h.currentValue,
+      0,
+    );
+    const totalInvested = holdingsWithValue.reduce(
+      (sum, h) => sum + h.investedAmountKRW,
+      0,
+    );
+    const totalReturn = totalValue - totalInvested;
+    const returnRate =
+      totalInvested > 0 ? (totalReturn / totalInvested) * 100 : 0;
+
+    // 멤버별 집계
+    const memberMap = new Map<string, { name: string; value: number }>();
+    for (const h of holdingsWithValue) {
+      const existing = memberMap.get(h.ownerId);
+      if (existing) {
+        existing.value += h.currentValue;
+      } else {
+        memberMap.set(h.ownerId, { name: h.ownerName, value: h.currentValue });
+      }
+    }
+
+    const byMember: MemberSummary[] = Array.from(memberMap.entries()).map(
+      ([memberId, { name, value }]) => ({
+        memberId,
+        memberName: name,
+        totalValue: value,
+        percentage: totalValue > 0 ? (value / totalValue) * 100 : 0,
+      }),
+    );
+
+    // 자산군별 집계
+    const assetClassMap = new Map<string, number>();
+    for (const h of holdingsWithValue) {
+      const existing = assetClassMap.get(h.assetType) ?? 0;
+      assetClassMap.set(h.assetType, existing + h.currentValue);
+    }
+
+    const byAssetClass: AssetClassSummary[] = Array.from(
+      assetClassMap.entries(),
+    ).map(([assetClass, value]) => ({
+      assetClass: assetClass as AssetClassSummary["assetClass"],
+      totalValue: value,
+      percentage: totalValue > 0 ? (value / totalValue) * 100 : 0,
+    }));
+
+    const summary: DashboardSummary & {
+      missingPriceCount: number;
+      exchangeRate: number;
+    } = {
+      totalValue,
+      totalInvested,
+      totalReturn,
+      returnRate,
+      byMember,
+      byAssetClass,
+      missingPriceCount,
+      exchangeRate,
+    };
+
+    return NextResponse.json(summary);
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    console.error("Dashboard summary error:", error);
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "서버 오류가 발생했습니다.",
+        },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/components/dashboard/DashboardSummarySection.tsx
+++ b/components/dashboard/DashboardSummarySection.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useDashboardSummary } from "@/hooks/use-dashboard";
+import { SummaryCard } from "./SummaryCard";
+import { TotalAssetCard } from "./TotalAssetCard";
+import { TotalReturnCard } from "./TotalReturnCard";
+
+// 자산 유형 라벨 매핑
+const ASSET_TYPE_LABELS: Record<string, string> = {
+  equity: "주식",
+  bond: "채권",
+  cash: "현금",
+  alternative: "대체투자",
+  real_estate: "부동산",
+  commodity: "원자재",
+  crypto: "암호화폐",
+};
+
+// 자산 유형 색상 매핑
+const ASSET_TYPE_COLORS: Record<string, string> = {
+  equity: "#4F46E5",
+  bond: "#03B26C",
+  cash: "#8B95A1",
+  alternative: "#FF9F00",
+  real_estate: "#F04452",
+  commodity: "#8B5CF6",
+  crypto: "#EC4899",
+};
+
+// 멤버 색상 (순서대로 할당)
+const MEMBER_COLORS = ["#4F46E5", "#03B26C", "#FF9F00", "#F04452", "#8B95A1"];
+
+export function DashboardSummarySection() {
+  const { data, isLoading, error } = useDashboardSummary();
+
+  if (error) {
+    return (
+      <div className="bg-white rounded-2xl p-6 shadow-sm">
+        <p className="text-sm text-gray-500">
+          데이터를 불러오는데 실패했습니다.
+        </p>
+      </div>
+    );
+  }
+
+  // 멤버별 요약 데이터 변환
+  const byMemberItems =
+    data?.byMember.map((member, index) => ({
+      label: member.memberName,
+      value: member.totalValue,
+      percentage: member.percentage,
+      color: MEMBER_COLORS[index % MEMBER_COLORS.length],
+    })) ?? [];
+
+  // 자산군별 요약 데이터 변환
+  const byAssetClassItems =
+    data?.byAssetClass.map((assetClass) => ({
+      label: ASSET_TYPE_LABELS[assetClass.assetClass] ?? assetClass.assetClass,
+      value: assetClass.totalValue,
+      percentage: assetClass.percentage,
+      color: ASSET_TYPE_COLORS[assetClass.assetClass] ?? "#8B95A1",
+    })) ?? [];
+
+  const isEmpty = !isLoading && data && data.totalInvested === 0;
+
+  if (isEmpty) {
+    return (
+      <>
+        {/* 총 자산 / 수익률 카드 */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <TotalAssetCard totalValue={0} totalInvested={0} isLoading={false} />
+          <TotalReturnCard totalReturn={0} returnRate={0} isLoading={false} />
+        </div>
+        {/* 빈 상태 메시지 */}
+        <div className="bg-white rounded-2xl p-6 shadow-sm text-center">
+          <p className="text-gray-500">
+            아직 보유 종목이 없습니다. 거래를 등록해주세요.
+          </p>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      {/* 총 자산 / 수익률 카드 */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <TotalAssetCard
+          totalValue={data?.totalValue ?? 0}
+          totalInvested={data?.totalInvested ?? 0}
+          isLoading={isLoading}
+        />
+        <TotalReturnCard
+          totalReturn={data?.totalReturn ?? 0}
+          returnRate={data?.returnRate ?? 0}
+          missingPriceCount={data?.missingPriceCount}
+          isLoading={isLoading}
+        />
+      </div>
+
+      {/* 구성원별 / 자산군별 요약 카드 */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {isLoading ? (
+          <>
+            <div className="bg-white rounded-2xl p-5 shadow-sm">
+              <div className="animate-pulse space-y-3">
+                <div className="h-4 w-24 bg-gray-200 rounded" />
+                <div className="h-6 w-full bg-gray-200 rounded" />
+                <div className="h-6 w-full bg-gray-200 rounded" />
+              </div>
+            </div>
+            <div className="bg-white rounded-2xl p-5 shadow-sm">
+              <div className="animate-pulse space-y-3">
+                <div className="h-4 w-24 bg-gray-200 rounded" />
+                <div className="h-6 w-full bg-gray-200 rounded" />
+                <div className="h-6 w-full bg-gray-200 rounded" />
+              </div>
+            </div>
+          </>
+        ) : (
+          <>
+            {byMemberItems.length > 0 && (
+              <SummaryCard title="구성원별 자산" items={byMemberItems} />
+            )}
+            {byAssetClassItems.length > 0 && (
+              <SummaryCard title="자산군별 비중" items={byAssetClassItems} />
+            )}
+          </>
+        )}
+      </div>
+    </>
+  );
+}

--- a/components/dashboard/TotalAssetCard.tsx
+++ b/components/dashboard/TotalAssetCard.tsx
@@ -1,0 +1,37 @@
+import { formatCurrency } from "@/lib/utils/format";
+
+interface TotalAssetCardProps {
+  totalValue: number;
+  totalInvested: number;
+  isLoading?: boolean;
+}
+
+export function TotalAssetCard({
+  totalValue,
+  totalInvested,
+  isLoading,
+}: TotalAssetCardProps) {
+  if (isLoading) {
+    return (
+      <div className="bg-white rounded-2xl p-6 shadow-sm">
+        <div className="animate-pulse space-y-3">
+          <div className="h-4 w-16 bg-gray-200 rounded" />
+          <div className="h-9 w-40 bg-gray-200 rounded" />
+          <div className="h-4 w-32 bg-gray-200 rounded" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-2xl p-6 shadow-sm">
+      <span className="text-sm text-gray-500">총 자산</span>
+      <p className="text-3xl font-bold text-gray-900 mt-1">
+        {formatCurrency(totalValue, "KRW")}
+      </p>
+      <p className="text-sm text-gray-500 mt-2">
+        투자원금 {formatCurrency(totalInvested, "KRW")}
+      </p>
+    </div>
+  );
+}

--- a/components/dashboard/TotalReturnCard.tsx
+++ b/components/dashboard/TotalReturnCard.tsx
@@ -1,0 +1,60 @@
+import { AlertTriangle } from "lucide-react";
+import { cn } from "@/lib/utils/cn";
+import { formatCurrency, formatPercent } from "@/lib/utils/format";
+
+interface TotalReturnCardProps {
+  totalReturn: number;
+  returnRate: number;
+  missingPriceCount?: number;
+  isLoading?: boolean;
+}
+
+export function TotalReturnCard({
+  totalReturn,
+  returnRate,
+  missingPriceCount = 0,
+  isLoading,
+}: TotalReturnCardProps) {
+  if (isLoading) {
+    return (
+      <div className="bg-white rounded-2xl p-6 shadow-sm">
+        <div className="animate-pulse space-y-3">
+          <div className="h-4 w-16 bg-gray-200 rounded" />
+          <div className="h-9 w-24 bg-gray-200 rounded" />
+          <div className="h-4 w-32 bg-gray-200 rounded" />
+        </div>
+      </div>
+    );
+  }
+
+  const isPositive = returnRate >= 0;
+
+  return (
+    <div className="bg-white rounded-2xl p-6 shadow-sm">
+      <span className="text-sm text-gray-500">총 수익률</span>
+      <p
+        className={cn(
+          "text-3xl font-bold mt-1",
+          isPositive ? "text-positive" : "text-negative",
+        )}
+      >
+        {formatPercent(returnRate)}
+      </p>
+      <p
+        className={cn(
+          "text-sm mt-2",
+          isPositive ? "text-positive" : "text-negative",
+        )}
+      >
+        {isPositive ? "+" : ""}
+        {formatCurrency(totalReturn, "KRW")}
+      </p>
+      {missingPriceCount > 0 && (
+        <div className="flex items-center gap-1 mt-3 text-xs text-warning">
+          <AlertTriangle className="size-3" />
+          <span>{missingPriceCount}종목 현재가 없음</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/dashboard/index.ts
+++ b/components/dashboard/index.ts
@@ -1,2 +1,5 @@
+export { DashboardSummarySection } from "./DashboardSummarySection";
 export { QuickActionCard } from "./QuickActionCard";
 export { SummaryCard } from "./SummaryCard";
+export { TotalAssetCard } from "./TotalAssetCard";
+export { TotalReturnCard } from "./TotalReturnCard";

--- a/hooks/use-dashboard.ts
+++ b/hooks/use-dashboard.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { queries } from "@/lib/queries/keys";
+import type { DashboardSummary } from "@/types";
+
+interface DashboardSummaryResponse extends DashboardSummary {
+  missingPriceCount: number;
+  exchangeRate: number;
+}
+
+interface DashboardError {
+  error: {
+    code: string;
+    message: string;
+  };
+}
+
+async function fetchDashboardSummary(): Promise<DashboardSummaryResponse> {
+  const response = await fetch("/api/dashboard/summary");
+  const json = await response.json();
+
+  if (!response.ok) {
+    const error = json as DashboardError;
+    throw new Error(error.error.message);
+  }
+
+  return json as DashboardSummaryResponse;
+}
+
+export function useDashboardSummary() {
+  return useQuery({
+    queryKey: queries.dashboard.summary.queryKey,
+    queryFn: fetchDashboardSummary,
+    staleTime: 5 * 60 * 1000, // 5분
+  });
+}


### PR DESCRIPTION
## Summary
- 대시보드에 총 자산과 총 수익률을 표시하는 카드 구현
- holdings 데이터와 KIS API 주가 조회를 활용하여 실시간 평가금액 계산
- Mock 데이터 제거 및 실제 API 연동

## Changes
- `GET /api/dashboard/summary` API 추가
- `TotalAssetCard` 컴포넌트 (총 자산, 투자원금 표시)
- `TotalReturnCard` 컴포넌트 (수익률, 평가손익, 현재가 미입력 경고)
- `DashboardSummarySection` 클라이언트 컴포넌트 (React Query 연동)
- `useDashboardSummary` 훅 추가

## Checklist (from issue)
- [x] 총 자산 카드 (원화 기준 총 평가금액)
- [x] 총 수익률 카드 (전체 포트폴리오 수익률)
- [x] 총 투자원금 표시
- [x] 총 평가손익 표시 (금액)
- [x] 환율 적용 (USD 자산 → KRW 환산)
- [x] 현재가 미입력 종목 경고 표시

## Test plan
- [x] 로그인 후 대시보드 페이지 접근
- [x] 총 자산/수익률 카드가 정상적으로 렌더링되는지 확인
- [x] 거래 등록 후 값이 업데이트되는지 확인
- [x] USD 종목이 환율 적용되어 표시되는지 확인
- [x] 빈 상태(보유 종목 없음) 메시지 확인

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)