### PR TITLE
feat: 자산 메인 페이지 생성 (/assets) (#93)

### DIFF
--- a/app/(main)/assets/page.tsx
+++ b/app/(main)/assets/page.tsx
@@ -1,0 +1,114 @@
+import { AssetTypeCard } from "@/components/assets";
+import { getExchangeRateSafe } from "@/lib/api/exchange";
+import { getHoldings } from "@/lib/api/holdings";
+import { getUserHouseholdId } from "@/lib/api/invitation";
+import { getStockPrices } from "@/lib/api/stock-price";
+import { requireUser } from "@/lib/supabase/auth";
+import { createClient } from "@/lib/supabase/server";
+import { formatCurrency } from "@/lib/utils/format";
+
+export default async function AssetsPage() {
+  const user = await requireUser();
+  const supabase = await createClient();
+
+  // 가구 ID 조회
+  const householdId = await getUserHouseholdId(supabase, user.id);
+
+  // 기본값
+  let holdingCount = 0;
+  let totalValue = 0;
+  let totalInvested = 0;
+  let returnRate = 0;
+
+  if (householdId) {
+    // 보유 현황 조회
+    const holdingsResult = await getHoldings(supabase, householdId, {
+      pagination: { page: 1, pageSize: 1000 },
+    });
+
+    const holdings = holdingsResult.data;
+    holdingCount = holdings.length;
+
+    if (holdings.length > 0) {
+      // 환율 조회
+      const exchangeRateResult = await getExchangeRateSafe(
+        supabase,
+        "USD",
+        "KRW",
+      );
+      const exchangeRate = exchangeRateResult?.rate ?? 1300;
+
+      // 주가 조회
+      const stockQueries = holdings
+        .filter((h) => h.market === "KR" || h.market === "US")
+        .map((h) => ({
+          market: h.market as "KR" | "US",
+          code: h.ticker,
+        }));
+
+      const stockPrices = await getStockPrices(supabase, stockQueries);
+
+      // 각 종목별 현재가치 계산
+      for (const h of holdings) {
+        const priceKey = `${h.market}:${h.ticker}`;
+        const priceData = stockPrices[priceKey];
+        const currentPrice = priceData?.price ?? h.avgPrice;
+
+        const rawCurrentValue = h.quantity * currentPrice;
+        const rawInvestedAmount = h.totalInvested;
+
+        // USD → KRW 환산
+        const isUSD = h.currency === "USD";
+        totalValue += isUSD ? rawCurrentValue * exchangeRate : rawCurrentValue;
+        totalInvested += isUSD
+          ? rawInvestedAmount * exchangeRate
+          : rawInvestedAmount;
+      }
+
+      // 수익률 계산
+      if (totalInvested > 0) {
+        returnRate = ((totalValue - totalInvested) / totalInvested) * 100;
+      }
+    }
+  }
+
+  return (
+    <>
+      {/* 페이지 헤더 */}
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">내 자산</h1>
+      </div>
+
+      {/* 총 자산 요약 */}
+      <div className="bg-white rounded-2xl p-5 shadow-sm">
+        <span className="text-sm text-gray-500">총 자산</span>
+        <p className="text-3xl font-bold text-gray-900 mt-1">
+          {formatCurrency(totalValue)}
+        </p>
+      </div>
+
+      {/* 자산 유형별 카드 */}
+      <div>
+        <h2 className="text-lg font-semibold text-gray-900 mb-3">자산 유형</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          {/* 주식/ETF - 활성 */}
+          <AssetTypeCard
+            type="stock"
+            holdingCount={holdingCount}
+            totalValue={totalValue}
+            returnRate={returnRate}
+          />
+
+          {/* 현금/예적금 - 준비 중 */}
+          <AssetTypeCard type="cash" disabled />
+
+          {/* 부동산 - 준비 중 */}
+          <AssetTypeCard type="real-estate" disabled />
+
+          {/* 기타 - 준비 중 */}
+          <AssetTypeCard type="other" disabled />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/components/assets/common/AssetTypeCard.tsx
+++ b/components/assets/common/AssetTypeCard.tsx
@@ -1,0 +1,146 @@
+import {
+  ChevronRight,
+  Home,
+  type LucideIcon,
+  Package,
+  TrendingUp,
+  Wallet,
+} from "lucide-react";
+import Link from "next/link";
+import { cn } from "@/lib/utils/cn";
+import { formatCurrency, formatPercent } from "@/lib/utils/format";
+
+export type AssetType = "stock" | "cash" | "real-estate" | "other";
+
+interface AssetTypeConfig {
+  icon: LucideIcon;
+  label: string;
+  color: string;
+  bgColor: string;
+}
+
+const ASSET_TYPE_CONFIG: Record<AssetType, AssetTypeConfig> = {
+  stock: {
+    icon: TrendingUp,
+    label: "주식/ETF",
+    color: "text-indigo-600",
+    bgColor: "bg-indigo-50",
+  },
+  cash: {
+    icon: Wallet,
+    label: "현금/예적금",
+    color: "text-emerald-600",
+    bgColor: "bg-emerald-50",
+  },
+  "real-estate": {
+    icon: Home,
+    label: "부동산",
+    color: "text-rose-600",
+    bgColor: "bg-rose-50",
+  },
+  other: {
+    icon: Package,
+    label: "기타",
+    color: "text-amber-600",
+    bgColor: "bg-amber-50",
+  },
+};
+
+interface AssetTypeCardProps {
+  type: AssetType;
+  holdingCount?: number;
+  totalValue?: number;
+  returnRate?: number;
+  disabled?: boolean;
+  isLoading?: boolean;
+}
+
+export function AssetTypeCard({
+  type,
+  holdingCount = 0,
+  totalValue = 0,
+  returnRate = 0,
+  disabled = false,
+  isLoading = false,
+}: AssetTypeCardProps) {
+  const config = ASSET_TYPE_CONFIG[type];
+  const Icon = config.icon;
+
+  // 로딩 상태
+  if (isLoading) {
+    return (
+      <div className="bg-white rounded-2xl p-5 shadow-sm">
+        <div className="animate-pulse space-y-3">
+          <div className="flex items-center gap-2">
+            <div className="w-10 h-10 bg-gray-200 rounded-xl" />
+            <div className="h-5 w-16 bg-gray-200 rounded" />
+          </div>
+          <div className="h-6 w-24 bg-gray-200 rounded" />
+          <div className="h-4 w-20 bg-gray-200 rounded" />
+        </div>
+      </div>
+    );
+  }
+
+  // 비활성 상태 (준비 중)
+  if (disabled) {
+    return (
+      <div className="bg-white rounded-2xl p-5 shadow-sm opacity-60">
+        <div className="flex items-center gap-2 mb-3">
+          <div className={cn("p-2 rounded-xl", config.bgColor)}>
+            <Icon className={cn("w-5 h-5", config.color)} />
+          </div>
+          <span className="font-medium text-gray-900">{config.label}</span>
+        </div>
+        <p className="text-sm text-gray-500">준비 중</p>
+      </div>
+    );
+  }
+
+  // 활성 상태 (주식 카드)
+  const isPositive = returnRate >= 0;
+
+  return (
+    <div className="bg-white rounded-2xl p-5 shadow-sm">
+      {/* 헤더: 아이콘 + 라벨 */}
+      <div className="flex items-center gap-2 mb-3">
+        <div className={cn("p-2 rounded-xl", config.bgColor)}>
+          <Icon className={cn("w-5 h-5", config.color)} />
+        </div>
+        <span className="font-medium text-gray-900">{config.label}</span>
+      </div>
+
+      {/* 총 평가금액 */}
+      <p className="text-xl font-bold text-gray-900 mb-1">
+        {formatCurrency(totalValue)}
+      </p>
+
+      {/* 보유 종목 수 + 수익률 */}
+      <div className="flex items-center gap-2 text-sm mb-4 whitespace-nowrap">
+        <span className="text-gray-500">{holdingCount}종목</span>
+        <span className="text-gray-300">·</span>
+        <span className={isPositive ? "text-rose-500" : "text-blue-500"}>
+          {formatPercent(returnRate)}
+        </span>
+      </div>
+
+      {/* 바로가기 버튼 */}
+      <div className="flex gap-2">
+        <Link
+          href="/assets/stock/holdings"
+          className="flex-1 flex items-center justify-center gap-1 py-2 px-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-xl hover:bg-gray-200 transition-colors whitespace-nowrap"
+        >
+          보유
+          <ChevronRight className="w-4 h-4 shrink-0" />
+        </Link>
+        <Link
+          href="/assets/stock/transactions"
+          className="flex-1 flex items-center justify-center gap-1 py-2 px-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-xl hover:bg-gray-200 transition-colors whitespace-nowrap"
+        >
+          거래
+          <ChevronRight className="w-4 h-4 shrink-0" />
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/components/assets/common/index.ts
+++ b/components/assets/common/index.ts
@@ -1,0 +1,1 @@
+export { type AssetType, AssetTypeCard } from "./AssetTypeCard";

--- a/components/assets/index.ts
+++ b/components/assets/index.ts
@@ -1,0 +1,1 @@
+export * from "./common";


### PR DESCRIPTION
## Summary
- 자산 유형 선택 허브 역할을 하는 `/assets` 페이지 생성
- `AssetTypeCard` 컴포넌트로 자산 유형별 카드 표시 (활성/비활성/로딩 상태 지원)
- holdings API 연동하여 주식 보유 종목 수, 총 평가금액, 수익률 표시
- 반응형 레이아웃: 모바일 1열, 태블릿 2열, PC 4열

## Test plan
- [x] `/assets` 페이지 접근 확인
- [x] 주식 카드에 보유 종목 수, 평가금액, 수익률 표시 확인
- [x] 준비 중 카드(현금, 부동산, 기타) 비활성화 상태 확인
- [x] 모바일/태블릿/PC 반응형 레이아웃 확인
- [x] "보유", "거래" 버튼 클릭 시 해당 페이지 이동 확인

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)