### PR TITLE
feat: invitations 테이블 스키마를 이메일 기반으로 변경

### DIFF
--- a/supabase/migrations/20260108003818_alter_invitations_email_based.sql
+++ b/supabase/migrations/20260108003818_alter_invitations_email_based.sql
@@ -1,0 +1,42 @@
+-- invitations 테이블 스키마 변경: 코드 기반 → 이메일 기반
+-- 관련 이슈: #119
+
+-- 1. invitation_status enum 생성
+create type invitation_status as enum ('pending', 'accepted', 'expired', 'cancelled');
+
+-- 2. 기존 데이터 삭제 (로컬 개발 환경)
+truncate table public.invitations;
+
+-- 3. 기존 컬럼 삭제
+alter table public.invitations
+  drop column code,
+  drop column used_by,
+  drop column used_at;
+
+-- 4. 새 컬럼 추가
+alter table public.invitations
+  add column email text not null,
+  add column status invitation_status default 'pending';
+
+-- 5. 유니크 제약 추가 (같은 가구에 같은 이메일로 중복 초대 방지)
+alter table public.invitations
+  add constraint invitations_household_email_unique unique (household_id, email);
+
+-- 6. 기존 인덱스 제거
+drop index if exists invitations_code_idx;
+
+-- 7. 새 인덱스 추가
+create index invitations_email_idx on public.invitations(email);
+create index invitations_status_idx on public.invitations(status);
+
+-- 8. RLS 정책 업데이트
+-- 기존 정책 삭제
+drop policy if exists "Anyone can view invitations" on public.invitations;
+
+-- 새 정책: 가구 멤버이거나 본인 이메일로 초대된 경우 조회 가능
+create policy "Users can view invitations by email or household"
+  on public.invitations for select
+  using (
+    is_household_member(household_id)
+    or email = (select email from auth.users where id = auth.uid())
+  );

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -190,34 +190,31 @@ export type Database = {
       };
       invitations: {
         Row: {
-          code: string;
           created_at: string;
           created_by: string;
+          email: string;
           expires_at: string;
           household_id: string;
           id: string;
-          used_at: string | null;
-          used_by: string | null;
+          status: Database["public"]["Enums"]["invitation_status"] | null;
         };
         Insert: {
-          code: string;
           created_at?: string;
           created_by: string;
+          email: string;
           expires_at: string;
           household_id: string;
           id?: string;
-          used_at?: string | null;
-          used_by?: string | null;
+          status?: Database["public"]["Enums"]["invitation_status"] | null;
         };
         Update: {
-          code?: string;
           created_at?: string;
           created_by?: string;
+          email?: string;
           expires_at?: string;
           household_id?: string;
           id?: string;
-          used_at?: string | null;
-          used_by?: string | null;
+          status?: Database["public"]["Enums"]["invitation_status"] | null;
         };
         Relationships: [
           {
@@ -232,13 +229,6 @@ export type Database = {
             columns: ["household_id"];
             isOneToOne: false;
             referencedRelation: "households";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "invitations_used_by_fkey";
-            columns: ["used_by"];
-            isOneToOne: false;
-            referencedRelation: "profiles";
             referencedColumns: ["id"];
           },
         ];
@@ -581,6 +571,7 @@ export type Database = {
       currency_type: "KRW" | "USD";
       exchange_type: "KOSPI" | "KOSDAQ" | "NYSE" | "NASDAQ" | "AMEX";
       household_role: "owner" | "member";
+      invitation_status: "pending" | "accepted" | "expired" | "cancelled";
       market_type: "KR" | "US" | "OTHER";
       risk_level: "safe" | "moderate" | "aggressive";
       stock_type_category:
@@ -747,6 +738,7 @@ export const Constants = {
       currency_type: ["KRW", "USD"],
       exchange_type: ["KOSPI", "KOSDAQ", "NYSE", "NASDAQ", "AMEX"],
       household_role: ["owner", "member"],
+      invitation_status: ["pending", "accepted", "expired", "cancelled"],
       market_type: ["KR", "US", "OTHER"],
       risk_level: ["safe", "moderate", "aggressive"],
       stock_type_category: [


### PR DESCRIPTION
## Summary
- invitations 테이블을 코드 기반에서 이메일 기반으로 변경
- `invitation_status` enum 추가 (`pending`, `accepted`, `expired`, `cancelled`)
- `code`, `used_by`, `used_at` 컬럼 삭제 → `email`, `status` 컬럼 추가
- RLS 정책 업데이트: 가구 멤버 또는 본인 이메일로 초대된 경우 조회 가능

## Changes
| 항목 | 현재 | 변경 후 |
|------|------|---------|
| 초대 방식 | 6자리 코드 (`code`) | 이메일 (`email`) |
| 상태 관리 | `used_by`, `used_at` | `status` enum |
| 유니크 제약 | `code` (전역) | `household_id` + `email` |

## Test plan
- [x] 마이그레이션 적용 확인 (`pnpm supabase db reset`)
- [x] Supabase 타입 재생성 확인

## Related
- Closes #119
- Epic: #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)