### PR TITLE
feat: system_config 전용 Supabase 클라이언트 분리

### DIFF
--- a/.claude/docs/ENV.md
+++ b/.claude/docs/ENV.md
@@ -35,6 +35,17 @@
 | `NEXT_PUBLIC_APP_URL` | 앱 URL | `http://localhost:3000` |
 | `LOG_LEVEL` | 로그 레벨 | `info` |
 
+### system_config 전용 (선택)
+
+로컬 개발 시 운영 DB의 KIS 토큰에 접근해야 하는 경우 설정합니다.
+
+| 변수명 | 설명 | 예시 |
+|--------|------|------|
+| `SYSTEM_CONFIG_SUPABASE_URL` | 운영 Supabase URL | `https://xxx.supabase.co` |
+| `SYSTEM_CONFIG_SECRET_KEY` | 운영 Secret Key | `sb_secret_xxx` |
+
+> 미설정 시 `NEXT_PUBLIC_SUPABASE_URL`과 `SUPABASE_SECRET_KEY`를 사용합니다.
+
 ### GitHub Actions Secrets
 
 GitHub Actions에서 종목/환율 동기화에 사용. GitHub Repository > Settings > Secrets에 설정.
@@ -134,6 +145,10 @@ declare namespace NodeJS {
     NEXT_PUBLIC_SUPABASE_URL: string;
     NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: string;
     SUPABASE_SECRET_KEY: string;
+
+    // system_config 전용 (선택)
+    SYSTEM_CONFIG_SUPABASE_URL?: string;
+    SYSTEM_CONFIG_SECRET_KEY?: string;
 
     // App
     NEXT_PUBLIC_APP_URL?: string;

--- a/lib/kis/client.ts
+++ b/lib/kis/client.ts
@@ -7,7 +7,7 @@
  */
 
 import { APIError } from "@/lib/api/error";
-import { createClient } from "@/lib/supabase/server";
+import { getSystemConfigClient } from "@/lib/supabase/system-config-client";
 import type {
   KISAPIResponse,
   KISDomesticMultiPriceOutput,
@@ -55,7 +55,7 @@ async function getTokenFromDB(): Promise<{
   accessToken: string;
   expiresAt: Date;
 } | null> {
-  const supabase = await createClient();
+  const supabase = getSystemConfigClient();
 
   const { data, error } = await supabase
     .from("system_config")
@@ -85,7 +85,7 @@ async function saveTokenToDB(
   accessToken: string,
   expiresAt: Date,
 ): Promise<void> {
-  const supabase = await createClient();
+  const supabase = getSystemConfigClient();
 
   const { error } = await supabase.from("system_config").upsert(
     {
@@ -357,6 +357,6 @@ export function getExchangeCode(exchange: string): OverseasExchangeCode {
  * 토큰 캐시 초기화 (테스트용)
  */
 export async function clearTokenCache(): Promise<void> {
-  const supabase = await createClient();
+  const supabase = getSystemConfigClient();
   await supabase.from("system_config").delete().eq("key", KIS_TOKEN_KEY);
 }

--- a/lib/supabase/system-config-client.ts
+++ b/lib/supabase/system-config-client.ts
@@ -1,0 +1,48 @@
+/**
+ * system_config 테이블 전용 Supabase 클라이언트
+ *
+ * - 로컬 개발 시에도 운영 DB에 접근 가능
+ * - Secret Key 사용 (RLS 우회)
+ * - 서버 전용 (브라우저에서 사용 금지)
+ */
+
+import { createClient as createSupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/types";
+
+let instance: ReturnType<typeof createSupabaseClient<Database>> | null = null;
+
+/**
+ * system_config 전용 Supabase 클라이언트 반환
+ *
+ * 환경변수 우선순위:
+ * 1. SYSTEM_CONFIG_SUPABASE_URL / SYSTEM_CONFIG_SECRET_KEY (운영 DB 직접 접근)
+ * 2. NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SECRET_KEY (기본 클라이언트)
+ */
+export function getSystemConfigClient() {
+  if (instance) return instance;
+
+  const url =
+    process.env.SYSTEM_CONFIG_SUPABASE_URL ||
+    process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key =
+    process.env.SYSTEM_CONFIG_SECRET_KEY || process.env.SUPABASE_SECRET_KEY;
+
+  if (!url || !key) {
+    throw new Error(
+      "system_config 클라이언트: SYSTEM_CONFIG_SUPABASE_URL/SECRET_KEY 또는 기본 환경변수 필요",
+    );
+  }
+
+  instance = createSupabaseClient<Database>(url, key, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  return instance;
+}
+
+/**
+ * 테스트용: 싱글톤 인스턴스 초기화
+ */
+export function resetSystemConfigClient() {
+  instance = null;
+}


### PR DESCRIPTION
## Summary

- 로컬 개발 시 운영 DB의 KIS 토큰에 접근할 수 있도록 `system_config` 테이블 전용 Supabase 클라이언트 분리
- `SYSTEM_CONFIG_SUPABASE_URL`, `SYSTEM_CONFIG_SECRET_KEY` 환경변수 지원
- 미설정 시 기존 환경변수로 fallback

## Test plan

- [x] 환경변수 미설정 시 기본 동작 확인 (`pnpm dev`)
- [x] `SYSTEM_CONFIG_*` 환경변수 설정 후 운영 DB 접근 확인
- [x] 타입 체크 통과 (`pnpm type-check`)
- [x] 빌드 성공 (`pnpm build`)

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)