### PR TITLE
feat: 주식 보유/거래 페이지에 탭 네비게이션 추가 (#94)

### DIFF
--- a/app/(main)/assets/stock/holdings/page.tsx
+++ b/app/(main)/assets/stock/holdings/page.tsx
@@ -1,3 +1,4 @@
+import { StockTabNav } from "@/components/assets/stock";
 import { HoldingsList } from "@/components/holdings/HoldingsList";
 import { getHoldings } from "@/lib/api/holdings";
 import { getHouseholdWithMembers } from "@/lib/api/household";
@@ -32,13 +33,13 @@ export default async function HoldingsPage() {
 
   return (
     <>
-      {/* 페이지 헤더 */}
-      <div>
-        <h1 className="text-2xl font-bold text-gray-900">보유 현황</h1>
-        <p className="text-sm text-gray-500">
-          총 {initialData.total}개 종목 보유 중
-        </p>
-      </div>
+      {/* 탭 네비게이션 */}
+      <StockTabNav activeTab="holdings" />
+
+      {/* 보유 현황 요약 */}
+      <p className="text-sm text-gray-500">
+        총 {initialData.total}개 종목 보유 중
+      </p>
 
       {/* 보유 현황 목록 */}
       <HoldingsList initialData={initialData} members={members} />

--- a/app/(main)/assets/stock/transactions/page.tsx
+++ b/app/(main)/assets/stock/transactions/page.tsx
@@ -1,7 +1,5 @@
-import { Plus } from "lucide-react";
-import Link from "next/link";
+import { StockTabNav } from "@/components/assets/stock";
 import { TransactionList } from "@/components/transactions/TransactionList";
-import { Button } from "@/components/ui/button";
 import { getHouseholdWithMembers } from "@/lib/api/household";
 import { getUserHouseholdId } from "@/lib/api/invitation";
 import { requireUser } from "@/lib/supabase/auth";
@@ -29,16 +27,8 @@ export default async function TransactionsPage() {
 
   return (
     <>
-      {/* 페이지 헤더 */}
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold text-gray-900">거래 내역</h1>
-        <Button asChild>
-          <Link href="/assets/stock/transactions/new">
-            <Plus className="size-4 mr-2" />
-            거래 등록
-          </Link>
-        </Button>
-      </div>
+      {/* 탭 네비게이션 */}
+      <StockTabNav activeTab="transactions" />
 
       {/* 거래 내역 목록 */}
       <TransactionList members={members} currentUserId={user.id} />

--- a/components/assets/index.ts
+++ b/components/assets/index.ts
@@ -1,1 +1,2 @@
 export * from "./common";
+export * from "./stock";

--- a/components/assets/stock/StockTabNav.tsx
+++ b/components/assets/stock/StockTabNav.tsx
@@ -1,0 +1,58 @@
+import { ArrowLeft, Plus } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils/cn";
+
+interface StockTabNavProps {
+  activeTab: "holdings" | "transactions";
+}
+
+const TABS = [
+  { key: "holdings", label: "보유 현황", href: "/assets/stock/holdings" },
+  {
+    key: "transactions",
+    label: "거래 내역",
+    href: "/assets/stock/transactions",
+  },
+] as const;
+
+export function StockTabNav({ activeTab }: StockTabNavProps) {
+  return (
+    <div className="space-y-4">
+      {/* 상단: 뒤로가기 + 거래 추가 버튼 */}
+      <div className="flex items-center justify-between">
+        <Link
+          href="/assets"
+          className="flex items-center gap-1 text-gray-600 hover:text-gray-900 transition-colors"
+        >
+          <ArrowLeft className="w-5 h-5" />
+          <span className="text-sm font-medium">자산</span>
+        </Link>
+        <Button asChild size="sm">
+          <Link href="/assets/stock/transactions/new">
+            <Plus className="w-4 h-4 mr-1" />
+            거래 추가
+          </Link>
+        </Button>
+      </div>
+
+      {/* 탭 네비게이션 */}
+      <div className="flex gap-1 p-1 bg-gray-100 rounded-xl">
+        {TABS.map((tab) => (
+          <Link
+            key={tab.key}
+            href={tab.href}
+            className={cn(
+              "flex-1 py-2 text-center text-sm font-medium rounded-lg transition-all",
+              activeTab === tab.key
+                ? "bg-white text-gray-900 shadow-sm"
+                : "text-gray-500 hover:text-gray-700",
+            )}
+          >
+            {tab.label}
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/assets/stock/index.ts
+++ b/components/assets/stock/index.ts
@@ -1,0 +1,1 @@
+export * from "./StockTabNav";


### PR DESCRIPTION
## Summary
- 주식 보유 현황(`/assets/stock/holdings`)과 거래 내역(`/assets/stock/transactions`) 페이지에 공통 탭 네비게이션 컴포넌트 적용
- 뒤로가기 링크("← 자산" → `/assets`) 추가
- 탭 UI([보유 현황] [거래 내역]) 추가로 두 페이지 간 빠른 전환 지원
- 거래 추가 버튼을 탭 네비게이션으로 통합

Closes #94

## Test plan
- [x] `/assets/stock/holdings` 페이지 접속 후 "← 자산" 클릭 시 `/assets`로 이동 확인
- [x] "거래 내역" 탭 클릭 시 `/assets/stock/transactions`로 이동 확인
- [x] "+ 거래 추가" 버튼 클릭 시 `/assets/stock/transactions/new`로 이동 확인
- [x] `/assets/stock/transactions` 페이지에서 "보유 현황" 탭 클릭 시 `/assets/stock/holdings`로 이동 확인
- [x] 각 페이지에서 현재 탭의 활성 상태 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)