### PR TITLE
refactor: 네비게이션 메뉴 구조 업데이트 (#96)

### DIFF
--- a/components/layout/BottomNav.tsx
+++ b/components/layout/BottomNav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { BarChart3, FileText, Home, Settings, TrendingUp } from "lucide-react";
+import { BarChart3, Briefcase, Home, Settings, Users } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils/cn";
@@ -8,9 +8,9 @@ import { cn } from "@/lib/utils/cn";
 const navItems = [
   { href: "/home", label: "홈", icon: Home },
   { href: "/dashboard", label: "분석", icon: BarChart3 },
-  { href: "/assets/stock/holdings", label: "보유", icon: TrendingUp },
-  { href: "/assets/stock/transactions", label: "거래", icon: FileText },
-  { href: "/assets/stock/settings", label: "설정", icon: Settings },
+  { href: "/assets", label: "자산", icon: Briefcase },
+  { href: "/household", label: "가구", icon: Users },
+  { href: "/settings", label: "설정", icon: Settings },
 ];
 
 export function BottomNav() {

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { BarChart3, FileText, Home, Settings, TrendingUp } from "lucide-react";
+import { BarChart3, Briefcase, Home, Settings, Users } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils/cn";
@@ -8,9 +8,9 @@ import { cn } from "@/lib/utils/cn";
 const navItems = [
   { href: "/home", label: "홈", icon: Home },
   { href: "/dashboard", label: "분석", icon: BarChart3 },
-  { href: "/assets/stock/holdings", label: "보유 현황", icon: TrendingUp },
-  { href: "/assets/stock/transactions", label: "거래 내역", icon: FileText },
-  { href: "/assets/stock/settings", label: "설정", icon: Settings },
+  { href: "/assets", label: "자산", icon: Briefcase },
+  { href: "/household", label: "가구", icon: Users },
+  { href: "/settings", label: "설정", icon: Settings },
 ];
 
 export function Sidebar() {


### PR DESCRIPTION
## Summary
- Sidebar와 BottomNav의 네비게이션 구조를 새 URL 구조에 맞게 업데이트
- 기존 `[홈] [분석] [보유] [거래] [설정]` → `[홈] [분석] [자산] [가구] [설정]`
- 아이콘 변경: `TrendingUp`, `FileText` → `Briefcase`, `Users`

## Test plan
- [ ] PC에서 Sidebar 메뉴 클릭 시 올바른 경로로 이동하는지 확인
- [ ] 모바일에서 BottomNav 메뉴 클릭 시 올바른 경로로 이동하는지 확인
- [ ] `/assets/*` 경로에서 "자산" 메뉴가 활성화되는지 확인
- [ ] `/household/*` 경로에서 "가구" 메뉴가 활성화되는지 확인
- [ ] `/settings/*` 경로에서 "설정" 메뉴가 활성화되는지 확인

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)