### PR TITLE
feat: accounts 테이블 생성 및 RLS 정책 추가

### DIFF
--- a/supabase/migrations/20260108060000_create_accounts.sql
+++ b/supabase/migrations/20260108060000_create_accounts.sql
@@ -1,0 +1,42 @@
+-- accounts 테이블 생성
+create table public.accounts (
+  id uuid primary key default gen_random_uuid(),
+  household_id uuid not null references public.households(id) on delete cascade,
+  owner_id uuid not null references public.profiles(id) on delete cascade,
+  name text not null,
+  broker text,
+  account_number text,
+  account_type text,
+  is_default boolean default false,
+  memo text,
+  created_at timestamptz default now() not null,
+  updated_at timestamptz default now() not null,
+  unique (household_id, owner_id, name)
+);
+
+-- 인덱스
+create index accounts_household_id_idx on public.accounts(household_id);
+create index accounts_owner_id_idx on public.accounts(owner_id);
+
+-- RLS 활성화
+alter table public.accounts enable row level security;
+
+-- RLS 정책: 가구 멤버만 조회 가능
+create policy "Users can view household accounts"
+  on public.accounts for select
+  using (is_household_member(household_id));
+
+-- RLS 정책: 가구 멤버만 생성 가능
+create policy "Users can insert household accounts"
+  on public.accounts for insert
+  with check (is_household_member(household_id));
+
+-- RLS 정책: 본인 계좌만 수정 가능
+create policy "Users can update own accounts"
+  on public.accounts for update
+  using (is_household_member(household_id) and owner_id = (select auth.uid()));
+
+-- RLS 정책: 본인 계좌만 삭제 가능
+create policy "Users can delete own accounts"
+  on public.accounts for delete
+  using (is_household_member(household_id) and owner_id = (select auth.uid()));

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -34,6 +34,63 @@ export type Database = {
   };
   public: {
     Tables: {
+      accounts: {
+        Row: {
+          account_number: string | null;
+          account_type: string | null;
+          broker: string | null;
+          created_at: string;
+          household_id: string;
+          id: string;
+          is_default: boolean | null;
+          memo: string | null;
+          name: string;
+          owner_id: string;
+          updated_at: string;
+        };
+        Insert: {
+          account_number?: string | null;
+          account_type?: string | null;
+          broker?: string | null;
+          created_at?: string;
+          household_id: string;
+          id?: string;
+          is_default?: boolean | null;
+          memo?: string | null;
+          name: string;
+          owner_id: string;
+          updated_at?: string;
+        };
+        Update: {
+          account_number?: string | null;
+          account_type?: string | null;
+          broker?: string | null;
+          created_at?: string;
+          household_id?: string;
+          id?: string;
+          is_default?: boolean | null;
+          memo?: string | null;
+          name?: string;
+          owner_id?: string;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "accounts_household_id_fkey";
+            columns: ["household_id"];
+            isOneToOne: false;
+            referencedRelation: "households";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "accounts_owner_id_fkey";
+            columns: ["owner_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
       exchange_rates: {
         Row: {
           from_currency: Database["public"]["Enums"]["currency_type"];


### PR DESCRIPTION
## Summary
- accounts 테이블 마이그레이션 추가 (계좌 정보 저장)
- RLS 정책: 가구 멤버 조회/생성, 본인 계좌만 수정/삭제
- Supabase 타입 재생성

## Test plan
- [x] `pnpm supabase db reset` 으로 마이그레이션 적용 확인
- [x] `pnpm supabase:types` 로 타입 생성 확인
- [ ] accounts 테이블 CRUD 동작 확인

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)