### PR TITLE
fix: invitations 테이블 created_by 외래키 인덱스 추가 (#85)

### DIFF
--- a/.claude/docs/DATABASE.md
+++ b/.claude/docs/DATABASE.md
@@ -202,6 +202,7 @@ create table public.invitations (
 create index invitations_email_idx on public.invitations(email);
 create index invitations_status_idx on public.invitations(status);
 create index invitations_household_id_idx on public.invitations(household_id);
+create index invitations_created_by_idx on public.invitations(created_by);
 ```
 
 | 컬럼 | 타입 | 설명 |

--- a/supabase/migrations/20260108065950_add_invitations_created_by_index.sql
+++ b/supabase/migrations/20260108065950_add_invitations_created_by_index.sql
@@ -1,0 +1,6 @@
+-- invitations 테이블 created_by 외래키 인덱스 추가
+-- 관련 이슈: #85
+-- Supabase Performance Advisor 경고 해결
+
+create index if not exists invitations_created_by_idx
+on public.invitations (created_by);


### PR DESCRIPTION
## Summary
- invitations 테이블의 `created_by` 외래키 컬럼에 인덱스 추가
- Supabase Performance Advisor 경고 해결
- DATABASE.md 문서 업데이트

## Test plan
- [x] `pnpm supabase db reset` 실행하여 마이그레이션 적용 확인

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)