### PR TITLE
feat: 앱 설정 허브 페이지 구현 (#127)

### DIFF
--- a/app/(main)/settings/page.tsx
+++ b/app/(main)/settings/page.tsx
@@ -1,0 +1,22 @@
+import { SettingsMenu } from "@/components/settings";
+
+const APP_VERSION = "0.1.0";
+
+export default function SettingsPage() {
+  return (
+    <div className="max-w-lg mx-auto space-y-6">
+      {/* 페이지 헤더 */}
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">설정</h1>
+      </div>
+
+      {/* 설정 메뉴 */}
+      <SettingsMenu />
+
+      {/* 버전 정보 */}
+      <div className="text-center text-sm text-gray-400">
+        버전 {APP_VERSION}
+      </div>
+    </div>
+  );
+}

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -1,21 +1,13 @@
-"use client";
-
 import Link from "next/link";
-import { LogoutButton } from "@/components/auth/LogoutButton";
 
 export function Header() {
   return (
     <header className="sticky top-0 z-40 h-14 bg-white border-b border-gray-200">
-      <div className="h-full px-4 flex items-center justify-between">
+      <div className="h-full px-4 flex items-center">
         {/* 로고 */}
         <Link href="/home" className="flex items-center gap-2">
           <span className="text-xl font-bold text-primary">oat</span>
         </Link>
-
-        {/* 우측 액션 */}
-        <div className="flex items-center gap-2">
-          <LogoutButton />
-        </div>
       </div>
     </header>
   );

--- a/components/settings/SettingsMenu.tsx
+++ b/components/settings/SettingsMenu.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { Bell, LogOut, Monitor, Shield, User } from "lucide-react";
+import { useTransition } from "react";
+import { signOutAction } from "@/app/(auth)/logout/actions";
+import { SettingsMenuItem } from "./SettingsMenuItem";
+
+export function SettingsMenu() {
+  const [isPending, startTransition] = useTransition();
+
+  const handleLogout = () => {
+    startTransition(async () => {
+      await signOutAction();
+    });
+  };
+
+  return (
+    <div className="space-y-4">
+      <SettingsMenuItem
+        icon={User}
+        label="프로필"
+        description="이름, 이메일 관리"
+        href="/settings/profile"
+        disabled
+      />
+
+      <SettingsMenuItem
+        icon={Shield}
+        label="계정 보안"
+        description="비밀번호 변경"
+        href="/settings/security"
+        disabled
+      />
+
+      <SettingsMenuItem
+        icon={Bell}
+        label="알림 설정"
+        href="/settings/notifications"
+        disabled
+      />
+
+      <SettingsMenuItem
+        icon={Monitor}
+        label="화면 설정"
+        href="/settings/theme"
+        disabled
+      />
+
+      <SettingsMenuItem
+        icon={LogOut}
+        label="로그아웃"
+        onClick={handleLogout}
+        isLoading={isPending}
+      />
+    </div>
+  );
+}

--- a/components/settings/SettingsMenuItem.tsx
+++ b/components/settings/SettingsMenuItem.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { ChevronRight, Loader2, type LucideIcon } from "lucide-react";
+import Link from "next/link";
+import { cn } from "@/lib/utils/cn";
+
+interface SettingsMenuItemProps {
+  icon: LucideIcon;
+  label: string;
+  description?: string;
+  href?: string;
+  onClick?: () => void;
+  disabled?: boolean;
+  isLoading?: boolean;
+}
+
+export function SettingsMenuItem({
+  icon: Icon,
+  label,
+  description,
+  href,
+  onClick,
+  disabled = false,
+  isLoading = false,
+}: SettingsMenuItemProps) {
+  const content = (
+    <>
+      <div className="flex items-center gap-3 flex-1 min-w-0">
+        <div className="p-2 rounded-xl bg-gray-100 shrink-0">
+          <Icon className="w-5 h-5 text-gray-600" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="font-medium text-gray-900">{label}</p>
+          {description && (
+            <p className="text-sm text-gray-500 truncate">{description}</p>
+          )}
+        </div>
+      </div>
+      <div className="shrink-0">
+        {isLoading ? (
+          <Loader2 className="w-5 h-5 text-gray-400 animate-spin" />
+        ) : disabled ? (
+          <span className="text-xs text-gray-400 px-2 py-1 bg-gray-100 rounded-full">
+            준비 중
+          </span>
+        ) : (
+          <ChevronRight className="w-5 h-5 text-gray-400" />
+        )}
+      </div>
+    </>
+  );
+
+  const baseClassName = cn(
+    "flex items-center gap-3 w-full p-4 bg-white rounded-2xl shadow-sm transition-colors",
+    disabled
+      ? "opacity-60 cursor-not-allowed"
+      : "hover:bg-gray-50 active:bg-gray-100",
+  );
+
+  if (disabled) {
+    return <div className={baseClassName}>{content}</div>;
+  }
+
+  if (href) {
+    return (
+      <Link href={href} className={baseClassName}>
+        {content}
+      </Link>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={isLoading}
+      className={cn(baseClassName, "text-left")}
+    >
+      {content}
+    </button>
+  );
+}

--- a/components/settings/index.ts
+++ b/components/settings/index.ts
@@ -1,0 +1,2 @@
+export { SettingsMenu } from "./SettingsMenu";
+export { SettingsMenuItem } from "./SettingsMenuItem";


### PR DESCRIPTION
## Summary
- `/settings` 경로에 앱 설정 메인 페이지(허브) 추가
- 설정 메뉴 컴포넌트 생성 (SettingsMenu, SettingsMenuItem)
- Header에서 로그아웃 버튼 제거 (설정 페이지로 이동)

## Changes
- 프로필, 계정 보안, 알림, 화면 설정 메뉴 (준비 중 상태)
- 로그아웃 기능 구현
- 버전 정보 표시 (0.1.0)

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)