### PR TITLE
feat: 대시보드 메인 페이지를 분석 허브로 리팩토링 (#100)

### DIFF
--- a/app/(main)/dashboard/by-asset-type/page.tsx
+++ b/app/(main)/dashboard/by-asset-type/page.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { ArrowLeft } from "lucide-react";
+import Link from "next/link";
+import { SummaryCard } from "@/components/dashboard";
+import { useDashboardSummary } from "@/hooks/use-dashboard";
+
+const ASSET_TYPE_LABELS: Record<string, string> = {
+  equity: "주식",
+  bond: "채권",
+  cash: "현금",
+  alternative: "대체투자",
+  real_estate: "부동산",
+  commodity: "원자재",
+  crypto: "암호화폐",
+};
+
+const ASSET_TYPE_COLORS: Record<string, string> = {
+  equity: "#4F46E5",
+  bond: "#03B26C",
+  cash: "#8B95A1",
+  alternative: "#FF9F00",
+  real_estate: "#F04452",
+  commodity: "#8B5CF6",
+  crypto: "#EC4899",
+};
+
+export default function ByAssetTypeAnalysisPage() {
+  const { data, isLoading, error } = useDashboardSummary();
+
+  const byAssetClassItems =
+    data?.byAssetClass.map((assetClass) => ({
+      label: ASSET_TYPE_LABELS[assetClass.assetClass] ?? assetClass.assetClass,
+      value: assetClass.totalValue,
+      percentage: assetClass.percentage,
+      color: ASSET_TYPE_COLORS[assetClass.assetClass] ?? "#8B95A1",
+    })) ?? [];
+
+  const isEmpty = !isLoading && (!data || data.totalInvested === 0);
+
+  return (
+    <>
+      {/* 페이지 헤더 */}
+      <div className="flex items-center gap-3">
+        <Link
+          href="/dashboard"
+          className="p-2 -ml-2 rounded-lg hover:bg-gray-100 transition-colors"
+        >
+          <ArrowLeft className="w-5 h-5 text-gray-600" />
+        </Link>
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">자산군별 분석</h1>
+          <p className="text-sm text-gray-500">
+            주식, 채권, 현금 등 자산군 비중
+          </p>
+        </div>
+      </div>
+
+      {/* 로딩 상태 */}
+      {isLoading && (
+        <div className="bg-white rounded-2xl p-5 shadow-sm">
+          <div className="animate-pulse space-y-3">
+            <div className="h-4 w-24 bg-gray-200 rounded" />
+            <div className="h-6 w-full bg-gray-200 rounded" />
+            <div className="h-6 w-full bg-gray-200 rounded" />
+          </div>
+        </div>
+      )}
+
+      {/* 에러 상태 */}
+      {error && (
+        <div className="bg-white rounded-2xl p-6 shadow-sm">
+          <p className="text-sm text-gray-500">
+            데이터를 불러오는데 실패했습니다.
+          </p>
+        </div>
+      )}
+
+      {/* 빈 상태 */}
+      {isEmpty && !error && (
+        <div className="bg-white rounded-2xl p-8 shadow-sm text-center">
+          <p className="text-gray-500">아직 보유 종목이 없습니다.</p>
+          <p className="text-sm text-gray-400 mt-1">
+            거래를 등록하면 자산군별 비중을 확인할 수 있어요
+          </p>
+        </div>
+      )}
+
+      {/* 데이터 표시 */}
+      {!isLoading && !error && byAssetClassItems.length > 0 && (
+        <SummaryCard title="자산군별 비중" items={byAssetClassItems} />
+      )}
+    </>
+  );
+}

--- a/app/(main)/dashboard/by-owner/page.tsx
+++ b/app/(main)/dashboard/by-owner/page.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { ArrowLeft } from "lucide-react";
+import Link from "next/link";
+import { SummaryCard } from "@/components/dashboard";
+import { useDashboardSummary } from "@/hooks/use-dashboard";
+
+const MEMBER_COLORS = ["#4F46E5", "#03B26C", "#FF9F00", "#F04452", "#8B95A1"];
+
+export default function ByOwnerAnalysisPage() {
+  const { data, isLoading, error } = useDashboardSummary();
+
+  const byMemberItems =
+    data?.byMember.map((member, index) => ({
+      label: member.memberName,
+      value: member.totalValue,
+      percentage: member.percentage,
+      color: MEMBER_COLORS[index % MEMBER_COLORS.length],
+    })) ?? [];
+
+  const isEmpty = !isLoading && (!data || data.totalInvested === 0);
+
+  return (
+    <>
+      {/* 페이지 헤더 */}
+      <div className="flex items-center gap-3">
+        <Link
+          href="/dashboard"
+          className="p-2 -ml-2 rounded-lg hover:bg-gray-100 transition-colors"
+        >
+          <ArrowLeft className="w-5 h-5 text-gray-600" />
+        </Link>
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">소유자별 분석</h1>
+          <p className="text-sm text-gray-500">가족 구성원별 자산 비중</p>
+        </div>
+      </div>
+
+      {/* 로딩 상태 */}
+      {isLoading && (
+        <div className="bg-white rounded-2xl p-5 shadow-sm">
+          <div className="animate-pulse space-y-3">
+            <div className="h-4 w-24 bg-gray-200 rounded" />
+            <div className="h-6 w-full bg-gray-200 rounded" />
+            <div className="h-6 w-full bg-gray-200 rounded" />
+          </div>
+        </div>
+      )}
+
+      {/* 에러 상태 */}
+      {error && (
+        <div className="bg-white rounded-2xl p-6 shadow-sm">
+          <p className="text-sm text-gray-500">
+            데이터를 불러오는데 실패했습니다.
+          </p>
+        </div>
+      )}
+
+      {/* 빈 상태 */}
+      {isEmpty && !error && (
+        <div className="bg-white rounded-2xl p-8 shadow-sm text-center">
+          <p className="text-gray-500">아직 보유 종목이 없습니다.</p>
+          <p className="text-sm text-gray-400 mt-1">
+            거래를 등록하면 소유자별 비중을 확인할 수 있어요
+          </p>
+        </div>
+      )}
+
+      {/* 데이터 표시 */}
+      {!isLoading && !error && byMemberItems.length > 0 && (
+        <SummaryCard title="구성원별 자산" items={byMemberItems} />
+      )}
+    </>
+  );
+}

--- a/app/(main)/dashboard/by-risk/page.tsx
+++ b/app/(main)/dashboard/by-risk/page.tsx
@@ -1,0 +1,30 @@
+import { ArrowLeft } from "lucide-react";
+import Link from "next/link";
+
+export default function ByRiskAnalysisPage() {
+  return (
+    <>
+      {/* 페이지 헤더 */}
+      <div className="flex items-center gap-3">
+        <Link
+          href="/dashboard"
+          className="p-2 -ml-2 rounded-lg hover:bg-gray-100 transition-colors"
+        >
+          <ArrowLeft className="w-5 h-5 text-gray-600" />
+        </Link>
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">위험도별 분석</h1>
+          <p className="text-sm text-gray-500">안전/중립/공격 자산 비중</p>
+        </div>
+      </div>
+
+      {/* 준비 중 메시지 */}
+      <div className="bg-white rounded-2xl p-8 shadow-sm text-center">
+        <p className="text-gray-500 mb-2">위험도별 분석 기능을 준비 중이에요</p>
+        <p className="text-sm text-gray-400">
+          종목별 위험도 설정 후 비중을 분석할 수 있어요
+        </p>
+      </div>
+    </>
+  );
+}

--- a/app/(main)/dashboard/page.tsx
+++ b/app/(main)/dashboard/page.tsx
@@ -1,7 +1,7 @@
-import { BarChart3, PlusCircle } from "lucide-react";
 import {
+  AnalysisTypeSection,
+  BreakdownSection,
   DashboardSummarySection,
-  QuickActionCard,
 } from "@/components/dashboard";
 import { getUser } from "@/lib/supabase/auth";
 
@@ -16,26 +16,14 @@ export default async function DashboardPage() {
         <p className="text-sm text-gray-500">안녕하세요, {user?.email}님</p>
       </div>
 
-      {/* 총 자산 / 수익률 / 요약 카드 */}
+      {/* 총 자산 / 수익률 카드 */}
       <DashboardSummarySection />
 
-      {/* 빠른 액션 */}
-      <div className="space-y-3">
-        <QuickActionCard
-          icon={PlusCircle}
-          title="거래 등록"
-          description="매수/매도 기록 추가"
-          href="/assets/stock/transactions/new"
-          actionLabel="등록하기"
-        />
-        <QuickActionCard
-          icon={BarChart3}
-          title="보유 현황"
-          description="현재 보유 종목 확인"
-          href="/assets/stock/holdings"
-          actionLabel="확인하기"
-        />
-      </div>
+      {/* 자산 유형별 분석 */}
+      <AnalysisTypeSection />
+
+      {/* 비중 분석 */}
+      <BreakdownSection />
     </>
   );
 }

--- a/app/(main)/dashboard/stocks/page.tsx
+++ b/app/(main)/dashboard/stocks/page.tsx
@@ -1,0 +1,32 @@
+import { ArrowLeft } from "lucide-react";
+import Link from "next/link";
+
+export default function StocksAnalysisPage() {
+  return (
+    <>
+      {/* 페이지 헤더 */}
+      <div className="flex items-center gap-3">
+        <Link
+          href="/dashboard"
+          className="p-2 -ml-2 rounded-lg hover:bg-gray-100 transition-colors"
+        >
+          <ArrowLeft className="w-5 h-5 text-gray-600" />
+        </Link>
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">주식 분석</h1>
+          <p className="text-sm text-gray-500">종목별 비중과 수익률</p>
+        </div>
+      </div>
+
+      {/* 준비 중 메시지 */}
+      <div className="bg-white rounded-2xl p-8 shadow-sm text-center">
+        <p className="text-gray-500 mb-2">
+          주식 상세 분석 기능을 준비 중이에요
+        </p>
+        <p className="text-sm text-gray-400">
+          종목별 비중, 수익률 차트 등을 곧 만나보실 수 있어요
+        </p>
+      </div>
+    </>
+  );
+}

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -10,7 +10,7 @@ import { createClient } from "@/lib/supabase/server";
 export async function GET(request: NextRequest) {
   const { searchParams, origin } = request.nextUrl;
   const code = searchParams.get("code");
-  const next = searchParams.get("next") ?? "/dashboard";
+  const next = searchParams.get("next") ?? "/home";
 
   if (code) {
     const supabase = await createClient();

--- a/app/globals.css
+++ b/app/globals.css
@@ -6,6 +6,9 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-positive: var(--positive);
+  --color-negative: var(--negative);
+  --color-warning: var(--warning);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
   --color-sidebar-ring: var(--sidebar-ring);
@@ -48,6 +51,9 @@
 
 :root {
   --radius: 0.625rem;
+  --positive: #F04452;
+  --negative: #3182F6;
+  --warning: #FF9F00;
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);

--- a/components/auth/SetPasswordForm.tsx
+++ b/components/auth/SetPasswordForm.tsx
@@ -62,7 +62,7 @@ export function SetPasswordForm() {
       }
     }
 
-    router.replace("/dashboard");
+    router.replace("/home");
   };
 
   return (

--- a/components/auth/SignInForm.tsx
+++ b/components/auth/SignInForm.tsx
@@ -40,7 +40,7 @@ export function SignInForm() {
       return;
     }
 
-    router.push("/dashboard");
+    router.push("/home");
     router.refresh();
   };
 

--- a/components/dashboard/AnalysisCard.tsx
+++ b/components/dashboard/AnalysisCard.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import type { LucideIcon } from "lucide-react";
+import Link from "next/link";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils/cn";
+
+interface AnalysisCardProps {
+  icon: LucideIcon;
+  label: string;
+  description: string;
+  href: string;
+  color: string;
+  bgColor: string;
+  disabled?: boolean;
+}
+
+export function AnalysisCard({
+  icon: Icon,
+  label,
+  description,
+  href,
+  color,
+  bgColor,
+  disabled = false,
+}: AnalysisCardProps) {
+  if (disabled) {
+    const handleClick = () => {
+      toast.info(`${label} 분석은 준비 중이에요`, {
+        description: "조금만 기다려주세요!",
+      });
+    };
+
+    return (
+      <button
+        type="button"
+        onClick={handleClick}
+        className="w-full text-left bg-white rounded-2xl p-5 shadow-sm hover:shadow-md transition-shadow opacity-80 hover:opacity-100"
+      >
+        <div className={cn("p-2.5 rounded-xl w-fit mb-3", bgColor)}>
+          <Icon className={cn("w-5 h-5", color)} />
+        </div>
+        <p className="font-medium text-gray-900 mb-1">{label}</p>
+        <p className="text-sm text-gray-500 leading-relaxed">{description}</p>
+      </button>
+    );
+  }
+
+  return (
+    <Link
+      href={href}
+      className="block bg-white rounded-2xl p-5 shadow-sm hover:shadow-md transition-shadow"
+    >
+      <div className={cn("p-2.5 rounded-xl w-fit mb-3", bgColor)}>
+        <Icon className={cn("w-5 h-5", color)} />
+      </div>
+      <p className="font-medium text-gray-900 mb-1">{label}</p>
+      <p className="text-sm text-gray-500 leading-relaxed">{description}</p>
+    </Link>
+  );
+}

--- a/components/dashboard/AnalysisTypeSection.tsx
+++ b/components/dashboard/AnalysisTypeSection.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { Home, Package, TrendingUp, Wallet } from "lucide-react";
+import { AnalysisCard } from "./AnalysisCard";
+
+const ANALYSIS_TYPES = [
+  {
+    type: "stocks",
+    icon: TrendingUp,
+    label: "주식/ETF",
+    description: "종목별 비중과 수익률을 분석하세요",
+    href: "/dashboard/stocks",
+    color: "text-indigo-600",
+    bgColor: "bg-indigo-50",
+    disabled: false,
+  },
+  {
+    type: "cash",
+    icon: Wallet,
+    label: "현금/예적금",
+    description: "예금, 적금, CMA 등 분석",
+    href: "/dashboard/cash",
+    color: "text-emerald-600",
+    bgColor: "bg-emerald-50",
+    disabled: true,
+  },
+  {
+    type: "real-estate",
+    icon: Home,
+    label: "부동산",
+    description: "부동산 자산 분석",
+    href: "/dashboard/real-estate",
+    color: "text-rose-600",
+    bgColor: "bg-rose-50",
+    disabled: true,
+  },
+  {
+    type: "other",
+    icon: Package,
+    label: "기타",
+    description: "금, 코인 등 기타 자산 분석",
+    href: "/dashboard/other",
+    color: "text-amber-600",
+    bgColor: "bg-amber-50",
+    disabled: true,
+  },
+] as const;
+
+export function AnalysisTypeSection() {
+  return (
+    <div className="space-y-3">
+      <h2 className="text-lg font-semibold text-gray-900">자산 유형별 분석</h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        {ANALYSIS_TYPES.map((item) => (
+          <AnalysisCard
+            key={item.type}
+            icon={item.icon}
+            label={item.label}
+            description={item.description}
+            href={item.href}
+            color={item.color}
+            bgColor={item.bgColor}
+            disabled={item.disabled}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/BreakdownSection.tsx
+++ b/components/dashboard/BreakdownSection.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { PieChart, Shield, Users } from "lucide-react";
+import { AnalysisCard } from "./AnalysisCard";
+
+const BREAKDOWN_TYPES = [
+  {
+    type: "by-owner",
+    icon: Users,
+    label: "소유자별",
+    description: "가족 구성원별 자산 비중을 확인하세요",
+    href: "/dashboard/by-owner",
+    color: "text-blue-600",
+    bgColor: "bg-blue-50",
+    disabled: false,
+  },
+  {
+    type: "by-risk",
+    icon: Shield,
+    label: "위험도별",
+    description: "안전/중립/공격 자산 비중 분석",
+    href: "/dashboard/by-risk",
+    color: "text-orange-600",
+    bgColor: "bg-orange-50",
+    disabled: true,
+  },
+  {
+    type: "by-asset-type",
+    icon: PieChart,
+    label: "자산군별",
+    description: "주식, 채권, 현금 등 자산군 비중",
+    href: "/dashboard/by-asset-type",
+    color: "text-purple-600",
+    bgColor: "bg-purple-50",
+    disabled: false,
+  },
+] as const;
+
+export function BreakdownSection() {
+  return (
+    <div className="space-y-3">
+      <h2 className="text-lg font-semibold text-gray-900">비중 분석</h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        {BREAKDOWN_TYPES.map((item) => (
+          <AnalysisCard
+            key={item.type}
+            icon={item.icon}
+            label={item.label}
+            description={item.description}
+            href={item.href}
+            color={item.color}
+            bgColor={item.bgColor}
+            disabled={item.disabled}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/DashboardSummarySection.tsx
+++ b/components/dashboard/DashboardSummarySection.tsx
@@ -1,34 +1,8 @@
 "use client";
 
 import { useDashboardSummary } from "@/hooks/use-dashboard";
-import { SummaryCard } from "./SummaryCard";
 import { TotalAssetCard } from "./TotalAssetCard";
 import { TotalReturnCard } from "./TotalReturnCard";
-
-// 자산 유형 라벨 매핑
-const ASSET_TYPE_LABELS: Record<string, string> = {
-  equity: "주식",
-  bond: "채권",
-  cash: "현금",
-  alternative: "대체투자",
-  real_estate: "부동산",
-  commodity: "원자재",
-  crypto: "암호화폐",
-};
-
-// 자산 유형 색상 매핑
-const ASSET_TYPE_COLORS: Record<string, string> = {
-  equity: "#4F46E5",
-  bond: "#03B26C",
-  cash: "#8B95A1",
-  alternative: "#FF9F00",
-  real_estate: "#F04452",
-  commodity: "#8B5CF6",
-  crypto: "#EC4899",
-};
-
-// 멤버 색상 (순서대로 할당)
-const MEMBER_COLORS = ["#4F46E5", "#03B26C", "#FF9F00", "#F04452", "#8B95A1"];
 
 export function DashboardSummarySection() {
   const { data, isLoading, error } = useDashboardSummary();
@@ -43,35 +17,15 @@ export function DashboardSummarySection() {
     );
   }
 
-  // 멤버별 요약 데이터 변환
-  const byMemberItems =
-    data?.byMember.map((member, index) => ({
-      label: member.memberName,
-      value: member.totalValue,
-      percentage: member.percentage,
-      color: MEMBER_COLORS[index % MEMBER_COLORS.length],
-    })) ?? [];
-
-  // 자산군별 요약 데이터 변환
-  const byAssetClassItems =
-    data?.byAssetClass.map((assetClass) => ({
-      label: ASSET_TYPE_LABELS[assetClass.assetClass] ?? assetClass.assetClass,
-      value: assetClass.totalValue,
-      percentage: assetClass.percentage,
-      color: ASSET_TYPE_COLORS[assetClass.assetClass] ?? "#8B95A1",
-    })) ?? [];
-
   const isEmpty = !isLoading && data && data.totalInvested === 0;
 
   if (isEmpty) {
     return (
       <>
-        {/* 총 자산 / 수익률 카드 */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <TotalAssetCard totalValue={0} totalInvested={0} isLoading={false} />
           <TotalReturnCard totalReturn={0} returnRate={0} isLoading={false} />
         </div>
-        {/* 빈 상태 메시지 */}
         <div className="bg-white rounded-2xl p-6 shadow-sm text-center">
           <p className="text-gray-500">
             아직 보유 종목이 없습니다. 거래를 등록해주세요.
@@ -82,52 +36,18 @@ export function DashboardSummarySection() {
   }
 
   return (
-    <>
-      {/* 총 자산 / 수익률 카드 */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <TotalAssetCard
-          totalValue={data?.totalValue ?? 0}
-          totalInvested={data?.totalInvested ?? 0}
-          isLoading={isLoading}
-        />
-        <TotalReturnCard
-          totalReturn={data?.totalReturn ?? 0}
-          returnRate={data?.returnRate ?? 0}
-          missingPriceCount={data?.missingPriceCount}
-          isLoading={isLoading}
-        />
-      </div>
-
-      {/* 구성원별 / 자산군별 요약 카드 */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {isLoading ? (
-          <>
-            <div className="bg-white rounded-2xl p-5 shadow-sm">
-              <div className="animate-pulse space-y-3">
-                <div className="h-4 w-24 bg-gray-200 rounded" />
-                <div className="h-6 w-full bg-gray-200 rounded" />
-                <div className="h-6 w-full bg-gray-200 rounded" />
-              </div>
-            </div>
-            <div className="bg-white rounded-2xl p-5 shadow-sm">
-              <div className="animate-pulse space-y-3">
-                <div className="h-4 w-24 bg-gray-200 rounded" />
-                <div className="h-6 w-full bg-gray-200 rounded" />
-                <div className="h-6 w-full bg-gray-200 rounded" />
-              </div>
-            </div>
-          </>
-        ) : (
-          <>
-            {byMemberItems.length > 0 && (
-              <SummaryCard title="구성원별 자산" items={byMemberItems} />
-            )}
-            {byAssetClassItems.length > 0 && (
-              <SummaryCard title="자산군별 비중" items={byAssetClassItems} />
-            )}
-          </>
-        )}
-      </div>
-    </>
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <TotalAssetCard
+        totalValue={data?.totalValue ?? 0}
+        totalInvested={data?.totalInvested ?? 0}
+        isLoading={isLoading}
+      />
+      <TotalReturnCard
+        totalReturn={data?.totalReturn ?? 0}
+        returnRate={data?.returnRate ?? 0}
+        missingPriceCount={data?.missingPriceCount}
+        isLoading={isLoading}
+      />
+    </div>
   );
 }

--- a/components/dashboard/TotalAssetCard.tsx
+++ b/components/dashboard/TotalAssetCard.tsx
@@ -1,3 +1,9 @@
+import { HelpCircle, Wallet } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { formatCurrency } from "@/lib/utils/format";
 
 interface TotalAssetCardProps {
@@ -17,7 +23,7 @@ export function TotalAssetCard({
         <div className="animate-pulse space-y-3">
           <div className="h-4 w-16 bg-gray-200 rounded" />
           <div className="h-9 w-40 bg-gray-200 rounded" />
-          <div className="h-4 w-32 bg-gray-200 rounded" />
+          <div className="h-4 w-48 bg-gray-200 rounded" />
         </div>
       </div>
     );
@@ -25,12 +31,35 @@ export function TotalAssetCard({
 
   return (
     <div className="bg-white rounded-2xl p-6 shadow-sm">
-      <span className="text-sm text-gray-500">총 자산</span>
-      <p className="text-3xl font-bold text-gray-900 mt-1">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1">
+          <span className="text-sm text-gray-500">총 자산</span>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                className="text-gray-400 hover:text-gray-500"
+              >
+                <HelpCircle className="size-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              <p>보유 중인 모든 자산의 현재 가치예요</p>
+              <p className="text-xs text-gray-400 mt-1.5">
+                평가금액 = 보유수량 × 현재가
+              </p>
+            </TooltipContent>
+          </Tooltip>
+        </div>
+        <div className="p-1.5 rounded-full bg-gray-100">
+          <Wallet className="size-4 text-gray-500" />
+        </div>
+      </div>
+      <p className="text-3xl font-bold text-gray-900 mt-2">
         {formatCurrency(totalValue, "KRW")}
       </p>
-      <p className="text-sm text-gray-500 mt-2">
-        투자원금 {formatCurrency(totalInvested, "KRW")}
+      <p className="text-sm text-gray-500 mt-1">
+        무려 {formatCurrency(totalInvested, "KRW")}이나 투자했어요
       </p>
     </div>
   );

--- a/components/dashboard/TotalReturnCard.tsx
+++ b/components/dashboard/TotalReturnCard.tsx
@@ -1,6 +1,29 @@
-import { AlertTriangle } from "lucide-react";
+import {
+  AlertTriangle,
+  HelpCircle,
+  TrendingDown,
+  TrendingUp,
+} from "lucide-react";
+import { useMemo } from "react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils/cn";
-import { formatCurrency, formatPercent } from "@/lib/utils/format";
+import { formatCurrency } from "@/lib/utils/format";
+
+const POSITIVE_MESSAGES = [
+  (rate: number) => `잘하고 있어요! ${rate.toFixed(2)}% 수익 중`,
+  (rate: number) => `대단해요! ${rate.toFixed(2)}% 수익이에요`,
+  (rate: number) => `순항 중! ${rate.toFixed(2)}% 수익`,
+];
+
+const NEGATIVE_MESSAGES = [
+  "괜찮아요, 천천히 가봐요 💪",
+  "장기 투자의 힘을 믿어요 💪",
+  "흔들리지 않는 투자를 응원해요 💪",
+];
 
 interface TotalReturnCardProps {
   totalReturn: number;
@@ -15,42 +38,67 @@ export function TotalReturnCard({
   missingPriceCount = 0,
   isLoading,
 }: TotalReturnCardProps) {
+  const messageIndex = useMemo(() => {
+    const positiveIdx = Math.floor(Math.random() * POSITIVE_MESSAGES.length);
+    const negativeIdx = Math.floor(Math.random() * NEGATIVE_MESSAGES.length);
+    return { positiveIdx, negativeIdx };
+  }, []);
+
   if (isLoading) {
     return (
       <div className="bg-white rounded-2xl p-6 shadow-sm">
         <div className="animate-pulse space-y-3">
           <div className="h-4 w-16 bg-gray-200 rounded" />
-          <div className="h-9 w-24 bg-gray-200 rounded" />
-          <div className="h-4 w-32 bg-gray-200 rounded" />
+          <div className="h-9 w-32 bg-gray-200 rounded" />
+          <div className="h-4 w-48 bg-gray-200 rounded" />
         </div>
       </div>
     );
   }
 
   const isPositive = returnRate >= 0;
+  const sign = isPositive ? "+" : "";
+  const TrendIcon = isPositive ? TrendingUp : TrendingDown;
+  const colorClass = isPositive ? "text-[#F04452]" : "text-[#3182F6]";
+  const bgColorClass = isPositive ? "bg-[#F04452]/10" : "bg-[#3182F6]/10";
+
+  const message = isPositive
+    ? POSITIVE_MESSAGES[messageIndex.positiveIdx](returnRate)
+    : NEGATIVE_MESSAGES[messageIndex.negativeIdx];
 
   return (
     <div className="bg-white rounded-2xl p-6 shadow-sm">
-      <span className="text-sm text-gray-500">총 수익률</span>
-      <p
-        className={cn(
-          "text-3xl font-bold mt-1",
-          isPositive ? "text-positive" : "text-negative",
-        )}
-      >
-        {formatPercent(returnRate)}
-      </p>
-      <p
-        className={cn(
-          "text-sm mt-2",
-          isPositive ? "text-positive" : "text-negative",
-        )}
-      >
-        {isPositive ? "+" : ""}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1">
+          <span className="text-sm text-gray-500">총 수익</span>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                className="text-gray-400 hover:text-gray-500"
+              >
+                <HelpCircle className="size-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              <p>투자 원금 대비 현재 얼마나 수익이 났는지 보여드려요</p>
+              <p className="text-xs text-gray-400 mt-1.5">
+                (평가금액 - 투자원금) ÷ 투자원금 × 100
+              </p>
+            </TooltipContent>
+          </Tooltip>
+        </div>
+        <div className={cn("p-1.5 rounded-full", bgColorClass)}>
+          <TrendIcon className={cn("size-4", colorClass)} />
+        </div>
+      </div>
+      <p className={cn("text-3xl font-bold mt-2", colorClass)}>
+        {sign}
         {formatCurrency(totalReturn, "KRW")}
       </p>
+      <p className="text-sm text-gray-500 mt-1">{message}</p>
       {missingPriceCount > 0 && (
-        <div className="flex items-center gap-1 mt-3 text-xs text-warning">
+        <div className="flex items-center gap-1 mt-3 text-xs text-[#FF9F00]">
           <AlertTriangle className="size-3" />
           <span>{missingPriceCount}종목 현재가 없음</span>
         </div>

--- a/components/dashboard/index.ts
+++ b/components/dashboard/index.ts
@@ -1,3 +1,6 @@
+export { AnalysisCard } from "./AnalysisCard";
+export { AnalysisTypeSection } from "./AnalysisTypeSection";
+export { BreakdownSection } from "./BreakdownSection";
 export { DashboardSummarySection } from "./DashboardSummarySection";
 export { QuickActionCard } from "./QuickActionCard";
 export { SummaryCard } from "./SummaryCard";

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils/cn";
+
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  );
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return (
+    <TooltipProvider>
+      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+    </TooltipProvider>
+  );
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  );
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-tooltip": "^1.2.8",
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.89.0",
     "@tanstack/react-query": "^5.90.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-tooltip':
+        specifier: ^1.2.8
+        version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@supabase/ssr':
         specifier: ^0.8.0
         version: 0.8.0(@supabase/supabase-js@2.89.0)
@@ -864,6 +867,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-tooltip@1.2.8':
+    resolution: {integrity: sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-use-callback-ref@1.1.1':
@@ -2361,6 +2377,26 @@ snapshots:
       react: 19.2.3
     optionalDependencies:
       '@types/react': 19.2.7
+
+  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.7)(react@19.2.3)':
     dependencies:


### PR DESCRIPTION
## Summary
- 대시보드 메인 페이지를 분석 허브 구조로 리팩토링
- 총 자산/총 수익 카드 UX 개선 (툴팁, 응원 메시지, 한국식 색상)
- 분석 서브페이지 생성 (주식, 비중별)
- 로그인 후 리다이렉트를 /home으로 변경

## Changes
- **대시보드 허브화**: 자산 유형별 분석 섹션 + 비중 분석 섹션 추가
- **서브페이지**: `/dashboard/stocks`, `/dashboard/by-owner`, `/dashboard/by-risk`, `/dashboard/by-asset-type`
- **카드 개선**:
  - 친절한 툴팁 (계산식 포함)
  - 수익/손실 시 랜덤 응원 메시지
  - 한국식 색상 (상승=빨강 #F04452, 하락=파랑 #3182F6)
- **shadcn/ui Tooltip** 컴포넌트 추가

## Test plan
- [ ] `/dashboard` 페이지에서 총 자산/총 수익 카드 확인
- [ ] 툴팁 hover 시 설명 텍스트 확인
- [ ] 수익/손실 상태별 색상 및 메시지 확인
- [ ] 분석 카드 클릭 시 서브페이지 이동 확인
- [ ] "준비 중" 카드 클릭 시 toast 메시지 확인
- [ ] 로그인 후 `/home`으로 리다이렉트 확인

Closes #100

🤖 Generated with [Claude Code](https://claude.ai/code)