### PR TITLE
feat: stock_prices 테이블 RLS 정책 추가 (#83)

### DIFF
--- a/supabase/migrations/20260109050224_add_stock_prices_rls.sql
+++ b/supabase/migrations/20260109050224_add_stock_prices_rls.sql
@@ -1,0 +1,15 @@
+-- stock_prices 테이블 RLS 정책 추가
+-- 시스템 테이블 (GitHub Actions에서 갱신) - 읽기 전용
+
+-- ============================================================================
+-- stock_prices (시스템 테이블 - 읽기 전용)
+-- ============================================================================
+ALTER TABLE public.stock_prices ENABLE ROW LEVEL SECURITY;
+
+-- 읽기: 인증된 사용자 모두 허용 (공용 가격 데이터)
+CREATE POLICY "Anyone can view stock_prices"
+  ON public.stock_prices FOR SELECT
+  USING (true);
+
+-- 쓰기: service_role만 허용 (RLS는 기본적으로 service_role 우회)
+-- 일반 사용자는 INSERT/UPDATE/DELETE 불가


### PR DESCRIPTION
## Summary
- `stock_prices` 테이블에 Row Level Security 정책 추가
- Supabase Security Advisor 경고 해결
- `stock_master`, `exchange_rates`와 동일한 패턴 적용 (시스템 테이블 - 읽기 전용)

## Changes
| 작업 | 권한 |
|------|------|
| SELECT | 인증된 사용자 모두 허용 |
| INSERT/UPDATE/DELETE | service_role만 허용 |

## Test plan
- [x] `pnpm supabase db reset` - 마이그레이션 정상 적용
- [x] `pnpm supabase db lint` - RLS 경고 없음 확인

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)