### PR TITLE
feat: 주식 분석 페이지 구현 (#101)

### DIFF
--- a/app/(main)/dashboard/stocks/page.tsx
+++ b/app/(main)/dashboard/stocks/page.tsx
@@ -1,32 +1,23 @@
-import { ArrowLeft } from "lucide-react";
-import Link from "next/link";
+import {
+  MarketBreakdownSection,
+  StockAllocationSection,
+  StockSummarySection,
+  TopPerformersSection,
+} from "@/components/dashboard/stocks";
+import { PageHeader } from "@/components/layout";
 
 export default function StocksAnalysisPage() {
   return (
     <>
-      {/* 페이지 헤더 */}
-      <div className="flex items-center gap-3">
-        <Link
-          href="/dashboard"
-          className="p-2 -ml-2 rounded-lg hover:bg-gray-100 transition-colors"
-        >
-          <ArrowLeft className="w-5 h-5 text-gray-600" />
-        </Link>
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900">주식 분석</h1>
-          <p className="text-sm text-gray-500">종목별 비중과 수익률</p>
-        </div>
-      </div>
-
-      {/* 준비 중 메시지 */}
-      <div className="bg-white rounded-2xl p-8 shadow-sm text-center">
-        <p className="text-gray-500 mb-2">
-          주식 상세 분석 기능을 준비 중이에요
-        </p>
-        <p className="text-sm text-gray-400">
-          종목별 비중, 수익률 차트 등을 곧 만나보실 수 있어요
-        </p>
-      </div>
+      <PageHeader
+        title="주식 분석"
+        subtitle="종목별 비중과 수익률"
+        backHref="/dashboard"
+      />
+      <StockSummarySection />
+      <StockAllocationSection />
+      <MarketBreakdownSection />
+      <TopPerformersSection />
     </>
   );
 }

--- a/app/api/dashboard/stocks/route.ts
+++ b/app/api/dashboard/stocks/route.ts
@@ -1,0 +1,220 @@
+import { NextResponse } from "next/server";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import { getExchangeRateSafe } from "@/lib/api/exchange";
+import { getHoldings } from "@/lib/api/holdings";
+import { getUserHouseholdId } from "@/lib/api/invitation";
+import { getStockPrices } from "@/lib/api/stock-price";
+import { createClient } from "@/lib/supabase/server";
+import type {
+  CurrencyBreakdown,
+  CurrencyType,
+  MarketBreakdown,
+  MarketType,
+  StockAnalysisData,
+  StockHoldingWithReturn,
+} from "@/types";
+
+/**
+ * GET /api/dashboard/stocks
+ * 주식 분석 데이터 조회
+ */
+export async function GET() {
+  try {
+    const supabase = await createClient();
+
+    // 인증 확인
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    // 사용자의 가구 조회
+    const householdId = await getUserHouseholdId(supabase, user.id);
+
+    if (!householdId) {
+      throw new APIError(
+        "HOUSEHOLD_NOT_FOUND",
+        "가구 정보를 찾을 수 없습니다.",
+        404,
+      );
+    }
+
+    // 환율 조회 (USD → KRW)
+    const exchangeRateResult = await getExchangeRateSafe(
+      supabase,
+      "USD",
+      "KRW",
+    );
+    const exchangeRate = exchangeRateResult?.rate ?? 1300;
+
+    // 보유 현황 조회 (페이지네이션 없이 전체)
+    const holdingsResult = await getHoldings(supabase, householdId, {
+      pagination: { page: 1, pageSize: 1000 },
+    });
+
+    const holdings = holdingsResult.data;
+
+    // 빈 holdings 처리
+    if (holdings.length === 0) {
+      const emptyData: StockAnalysisData = {
+        summary: {
+          totalValue: 0,
+          totalInvested: 0,
+          totalReturn: 0,
+          returnRate: 0,
+          holdingCount: 0,
+          missingPriceCount: 0,
+        },
+        holdings: [],
+        byMarket: [],
+        byCurrency: [],
+        exchangeRate,
+      };
+      return NextResponse.json(emptyData);
+    }
+
+    // 주가 조회
+    const stockQueries = holdings
+      .filter((h) => h.market === "KR" || h.market === "US")
+      .map((h) => ({
+        market: h.market as "KR" | "US",
+        code: h.ticker,
+      }));
+
+    const stockPrices = await getStockPrices(supabase, stockQueries);
+
+    // 각 종목별 현재가치 및 수익률 계산
+    let missingPriceCount = 0;
+    let totalValueSum = 0;
+    let totalInvestedSum = 0;
+
+    const holdingsWithReturn: StockHoldingWithReturn[] = holdings.map((h) => {
+      const priceKey = `${h.market}:${h.ticker}`;
+      const priceData = stockPrices[priceKey];
+      const currentPrice = priceData?.price ?? null;
+
+      if (currentPrice === null) {
+        missingPriceCount++;
+      }
+
+      // 현재가가 없으면 평균 매수가를 대신 사용
+      const effectivePrice = currentPrice ?? h.avgPrice;
+      const rawCurrentValue = h.quantity * effectivePrice;
+      const rawInvestedAmount = h.totalInvested;
+
+      // USD → KRW 환산
+      const isUSD = h.currency === "USD";
+      const currentValue = isUSD
+        ? rawCurrentValue * exchangeRate
+        : rawCurrentValue;
+      const investedAmountKRW = isUSD
+        ? rawInvestedAmount * exchangeRate
+        : rawInvestedAmount;
+
+      // 수익 계산
+      const returnAmount = currentValue - investedAmountKRW;
+      const returnRate =
+        investedAmountKRW > 0 ? (returnAmount / investedAmountKRW) * 100 : 0;
+
+      totalValueSum += currentValue;
+      totalInvestedSum += investedAmountKRW;
+
+      return {
+        ticker: h.ticker,
+        name: h.name,
+        market: h.market,
+        currency: h.currency,
+        quantity: h.quantity,
+        avgPrice: h.avgPrice,
+        currentPrice,
+        totalInvested: investedAmountKRW,
+        currentValue,
+        returnAmount,
+        returnRate,
+        allocationPercent: 0, // 나중에 계산
+      };
+    });
+
+    // 비중 계산
+    for (const holding of holdingsWithReturn) {
+      holding.allocationPercent =
+        totalValueSum > 0 ? (holding.currentValue / totalValueSum) * 100 : 0;
+    }
+
+    // 총 수익률 계산
+    const totalReturn = totalValueSum - totalInvestedSum;
+    const totalReturnRate =
+      totalInvestedSum > 0 ? (totalReturn / totalInvestedSum) * 100 : 0;
+
+    // 시장별 집계
+    const marketMap = new Map<MarketType, number>();
+    for (const h of holdingsWithReturn) {
+      const existing = marketMap.get(h.market) ?? 0;
+      marketMap.set(h.market, existing + h.currentValue);
+    }
+
+    const byMarket: MarketBreakdown[] = Array.from(marketMap.entries()).map(
+      ([market, value]) => ({
+        market,
+        totalValue: value,
+        percentage: totalValueSum > 0 ? (value / totalValueSum) * 100 : 0,
+      }),
+    );
+
+    // 통화별 집계
+    const currencyMap = new Map<CurrencyType, number>();
+    for (const h of holdingsWithReturn) {
+      const existing = currencyMap.get(h.currency) ?? 0;
+      currencyMap.set(h.currency, existing + h.currentValue);
+    }
+
+    const byCurrency: CurrencyBreakdown[] = Array.from(
+      currencyMap.entries(),
+    ).map(([currency, value]) => ({
+      currency,
+      totalValue: value,
+      percentage: totalValueSum > 0 ? (value / totalValueSum) * 100 : 0,
+    }));
+
+    // 평가금액 내림차순 정렬
+    holdingsWithReturn.sort((a, b) => b.currentValue - a.currentValue);
+
+    const result: StockAnalysisData = {
+      summary: {
+        totalValue: totalValueSum,
+        totalInvested: totalInvestedSum,
+        totalReturn,
+        returnRate: totalReturnRate,
+        holdingCount: holdings.length,
+        missingPriceCount,
+      },
+      holdings: holdingsWithReturn,
+      byMarket,
+      byCurrency,
+      exchangeRate,
+    };
+
+    return NextResponse.json(result);
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    console.error("Stock analysis error:", error);
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "서버 오류가 발생했습니다.",
+        },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,14 @@
   },
   "files": {
     "ignoreUnknown": true,
-    "includes": ["**", "!node_modules", "!.next", "!dist", "!build"]
+    "includes": [
+      "**",
+      "!node_modules",
+      "!.next",
+      "!dist",
+      "!build",
+      "!components/ui"
+    ]
   },
   "formatter": {
     "enabled": true,

--- a/components/dashboard/stocks/MarketBreakdownSection.tsx
+++ b/components/dashboard/stocks/MarketBreakdownSection.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { SummaryCard } from "@/components/dashboard/SummaryCard";
+import { useStockAnalysis } from "@/hooks/use-stock-analysis";
+import { formatCurrency } from "@/lib/utils/format";
+import type { CurrencyType, MarketType } from "@/types";
+
+const MARKET_LABELS: Record<MarketType, string> = {
+  KR: "국내",
+  US: "미국",
+  OTHER: "기타",
+};
+
+const MARKET_COLORS: Record<MarketType, string> = {
+  KR: "#4F46E5",
+  US: "#03B26C",
+  OTHER: "#8B95A1",
+};
+
+const CURRENCY_LABELS: Record<CurrencyType, string> = {
+  KRW: "원화 (KRW)",
+  USD: "달러 (USD)",
+};
+
+const CURRENCY_COLORS: Record<CurrencyType, string> = {
+  KRW: "#4F46E5",
+  USD: "#03B26C",
+};
+
+export function MarketBreakdownSection() {
+  const { data, isLoading } = useStockAnalysis();
+
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {[1, 2].map((i) => (
+          <div key={i} className="bg-white rounded-2xl p-5 shadow-sm">
+            <div className="animate-pulse">
+              <div className="h-4 w-24 bg-gray-200 rounded mb-4" />
+              <div className="space-y-3">
+                {[1, 2].map((j) => (
+                  <div key={j} className="h-6 bg-gray-200 rounded" />
+                ))}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (!data || data.holdings.length === 0) {
+    return null;
+  }
+
+  const marketItems = data.byMarket.map((m) => ({
+    label: MARKET_LABELS[m.market],
+    value: m.totalValue,
+    percentage: m.percentage,
+    color: MARKET_COLORS[m.market],
+  }));
+
+  const currencyItems = data.byCurrency.map((c) => ({
+    label: CURRENCY_LABELS[c.currency],
+    value: c.totalValue,
+    percentage: c.percentage,
+    color: CURRENCY_COLORS[c.currency],
+  }));
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <SummaryCard
+        title="시장별 비중"
+        items={marketItems}
+        valueFormatter={(v) => formatCurrency(v, "KRW")}
+      />
+      <SummaryCard
+        title="통화별 비중"
+        items={currencyItems}
+        valueFormatter={(v) => formatCurrency(v, "KRW")}
+      />
+    </div>
+  );
+}

--- a/components/dashboard/stocks/StockAllocationSection.tsx
+++ b/components/dashboard/stocks/StockAllocationSection.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useMemo } from "react";
+import { Cell, Pie, PieChart } from "recharts";
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import { useStockAnalysis } from "@/hooks/use-stock-analysis";
+import { formatCurrency } from "@/lib/utils/format";
+
+const CHART_COLORS = [
+  "#4F46E5", // 인디고
+  "#03B26C", // 초록
+  "#FF9F00", // 주황
+  "#F04452", // 빨강
+  "#8B95A1", // 회색
+  "#6366F1", // 보라
+];
+
+export function StockAllocationSection() {
+  const { data, isLoading } = useStockAnalysis();
+
+  const chartData = useMemo(() => {
+    if (!data || data.holdings.length === 0) return [];
+
+    // 상위 5개 + 기타
+    const top5 = data.holdings.slice(0, 5);
+    const others = data.holdings.slice(5);
+
+    const result = top5.map((h, index) => ({
+      name: h.name,
+      ticker: h.ticker,
+      value: h.currentValue,
+      percentage: h.allocationPercent,
+      fill: CHART_COLORS[index % CHART_COLORS.length],
+    }));
+
+    if (others.length > 0) {
+      const othersValue = others.reduce((sum, h) => sum + h.currentValue, 0);
+      const othersPercent = others.reduce(
+        (sum, h) => sum + h.allocationPercent,
+        0,
+      );
+      result.push({
+        name: `기타 (${others.length}종목)`,
+        ticker: "OTHER",
+        value: othersValue,
+        percentage: othersPercent,
+        fill: CHART_COLORS[5],
+      });
+    }
+
+    return result;
+  }, [data]);
+
+  const chartConfig = useMemo(() => {
+    const config: ChartConfig = {};
+    for (const item of chartData) {
+      config[item.ticker] = {
+        label: item.name,
+        color: item.fill,
+      };
+    }
+    return config;
+  }, [chartData]);
+
+  if (isLoading) {
+    return (
+      <div className="bg-white rounded-2xl p-5 shadow-sm">
+        <div className="animate-pulse">
+          <div className="h-4 w-24 bg-gray-200 rounded mb-4" />
+          <div className="flex gap-6">
+            <div className="size-48 bg-gray-200 rounded-full" />
+            <div className="flex-1 space-y-3">
+              {[1, 2, 3, 4, 5].map((i) => (
+                <div key={i} className="h-6 bg-gray-200 rounded" />
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data || data.holdings.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="bg-white rounded-2xl p-5 shadow-sm">
+      <h3 className="text-sm font-medium text-gray-900 mb-4">종목별 비중</h3>
+      <div className="flex flex-col md:flex-row gap-6">
+        {/* 도넛 차트 */}
+        <div className="flex-shrink-0">
+          <ChartContainer config={chartConfig} className="size-48">
+            <PieChart>
+              <ChartTooltip
+                content={
+                  <ChartTooltipContent
+                    formatter={(_value, _name, item) => (
+                      <div className="flex items-center justify-between gap-4">
+                        <span>{item.payload.name}</span>
+                        <span className="font-mono font-medium">
+                          {item.payload.percentage.toFixed(1)}%
+                        </span>
+                      </div>
+                    )}
+                  />
+                }
+              />
+              <Pie
+                data={chartData}
+                dataKey="value"
+                nameKey="name"
+                cx="50%"
+                cy="50%"
+                innerRadius={50}
+                outerRadius={80}
+                strokeWidth={2}
+                stroke="#fff"
+              >
+                {chartData.map((entry) => (
+                  <Cell key={entry.ticker} fill={entry.fill} />
+                ))}
+              </Pie>
+            </PieChart>
+          </ChartContainer>
+        </div>
+
+        {/* 범례 리스트 */}
+        <div className="flex-1 space-y-3">
+          {chartData.map((item) => (
+            <div
+              key={item.ticker}
+              className="flex items-center justify-between"
+            >
+              <div className="flex items-center gap-2">
+                <div
+                  className="size-3 rounded-full"
+                  style={{ backgroundColor: item.fill }}
+                />
+                <span className="text-sm text-gray-700">{item.name}</span>
+              </div>
+              <div className="text-right">
+                <span className="text-sm font-medium text-gray-900">
+                  {formatCurrency(item.value, "KRW")}
+                </span>
+                <span className="text-xs text-gray-500 ml-1">
+                  ({item.percentage.toFixed(1)}%)
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/stocks/StockSummarySection.tsx
+++ b/components/dashboard/stocks/StockSummarySection.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import {
+  AlertTriangle,
+  BarChart3,
+  HelpCircle,
+  TrendingDown,
+  TrendingUp,
+  Wallet,
+} from "lucide-react";
+import Link from "next/link";
+import { useMemo } from "react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useStockAnalysis } from "@/hooks/use-stock-analysis";
+import { cn } from "@/lib/utils/cn";
+import { formatCurrency } from "@/lib/utils/format";
+
+const POSITIVE_MESSAGES = [
+  (rate: number) => `잘하고 있어요! ${rate.toFixed(2)}% 수익 중`,
+  (rate: number) => `대단해요! ${rate.toFixed(2)}% 수익이에요`,
+  (rate: number) => `순항 중! ${rate.toFixed(2)}% 수익`,
+];
+
+const NEGATIVE_MESSAGES = [
+  "괜찮아요, 천천히 가봐요 💪",
+  "장기 투자의 힘을 믿어요 💪",
+  "흔들리지 않는 투자를 응원해요 💪",
+];
+
+export function StockSummarySection() {
+  const { data, isLoading, error } = useStockAnalysis();
+
+  const messageIndex = useMemo(() => {
+    const positiveIdx = Math.floor(Math.random() * POSITIVE_MESSAGES.length);
+    const negativeIdx = Math.floor(Math.random() * NEGATIVE_MESSAGES.length);
+    return { positiveIdx, negativeIdx };
+  }, []);
+
+  if (error) {
+    return (
+      <div className="bg-white rounded-2xl p-6 shadow-sm text-center">
+        <p className="text-gray-500">데이터를 불러오는데 실패했습니다.</p>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="bg-white rounded-2xl p-6 shadow-sm">
+            <div className="animate-pulse space-y-3">
+              <div className="h-4 w-16 bg-gray-200 rounded" />
+              <div className="h-9 w-32 bg-gray-200 rounded" />
+              <div className="h-4 w-48 bg-gray-200 rounded" />
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (!data || data.summary.holdingCount === 0) {
+    return (
+      <div className="bg-white rounded-2xl p-8 shadow-sm text-center">
+        <p className="text-gray-500 mb-2">아직 보유 종목이 없어요</p>
+        <Link
+          href="/assets/stock/transactions/new"
+          className="text-sm text-indigo-600 hover:text-indigo-700 font-medium"
+        >
+          첫 거래 기록하기 →
+        </Link>
+      </div>
+    );
+  }
+
+  const { summary } = data;
+  const isPositive = summary.returnRate >= 0;
+  const sign = isPositive ? "+" : "";
+  const TrendIcon = isPositive ? TrendingUp : TrendingDown;
+  const colorClass = isPositive ? "text-[#F04452]" : "text-[#3182F6]";
+  const bgColorClass = isPositive ? "bg-[#F04452]/10" : "bg-[#3182F6]/10";
+
+  const message = isPositive
+    ? POSITIVE_MESSAGES[messageIndex.positiveIdx](summary.returnRate)
+    : NEGATIVE_MESSAGES[messageIndex.negativeIdx];
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      {/* 총 평가금액 카드 */}
+      <div className="bg-white rounded-2xl p-6 shadow-sm">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-1">
+            <span className="text-sm text-gray-500">주식 평가금액</span>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  className="text-gray-400 hover:text-gray-500"
+                >
+                  <HelpCircle className="size-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="top">
+                <p>보유 주식의 현재 가치예요</p>
+                <p className="text-xs text-gray-400 mt-1.5">
+                  평가금액 = 보유수량 × 현재가
+                </p>
+              </TooltipContent>
+            </Tooltip>
+          </div>
+          <div className="p-1.5 rounded-full bg-gray-100">
+            <Wallet className="size-4 text-gray-500" />
+          </div>
+        </div>
+        <p className="text-3xl font-bold text-gray-900 mt-2">
+          {formatCurrency(summary.totalValue, "KRW")}
+        </p>
+        <p className="text-sm text-gray-500 mt-1">
+          투자원금 {formatCurrency(summary.totalInvested, "KRW")}
+        </p>
+      </div>
+
+      {/* 총 수익 카드 */}
+      <div className="bg-white rounded-2xl p-6 shadow-sm">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-1">
+            <span className="text-sm text-gray-500">주식 수익</span>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  className="text-gray-400 hover:text-gray-500"
+                >
+                  <HelpCircle className="size-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="top">
+                <p>투자 원금 대비 얼마나 수익이 났는지 보여드려요</p>
+                <p className="text-xs text-gray-400 mt-1.5">
+                  (평가금액 - 투자원금) ÷ 투자원금 × 100
+                </p>
+              </TooltipContent>
+            </Tooltip>
+          </div>
+          <div className={cn("p-1.5 rounded-full", bgColorClass)}>
+            <TrendIcon className={cn("size-4", colorClass)} />
+          </div>
+        </div>
+        <p className={cn("text-3xl font-bold mt-2", colorClass)}>
+          {sign}
+          {formatCurrency(summary.totalReturn, "KRW")}
+        </p>
+        <p className="text-sm text-gray-500 mt-1">{message}</p>
+        {summary.missingPriceCount > 0 && (
+          <div className="flex items-center gap-1 mt-3 text-xs text-[#FF9F00]">
+            <AlertTriangle className="size-3" />
+            <span>{summary.missingPriceCount}종목 현재가 없음</span>
+          </div>
+        )}
+      </div>
+
+      {/* 보유 종목 수 카드 */}
+      <div className="bg-white rounded-2xl p-6 shadow-sm">
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-gray-500">보유 종목</span>
+          <div className="p-1.5 rounded-full bg-indigo-50">
+            <BarChart3 className="size-4 text-indigo-600" />
+          </div>
+        </div>
+        <p className="text-3xl font-bold text-gray-900 mt-2">
+          {summary.holdingCount}
+          <span className="text-lg font-normal text-gray-500 ml-1">종목</span>
+        </p>
+        <Link
+          href="/assets/stock/holdings"
+          className="text-sm text-indigo-600 hover:text-indigo-700 mt-1 inline-block"
+        >
+          전체 보기 →
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/stocks/TopPerformersSection.tsx
+++ b/components/dashboard/stocks/TopPerformersSection.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { TrendingDown, Trophy } from "lucide-react";
+import { useMemo } from "react";
+import { useStockAnalysis } from "@/hooks/use-stock-analysis";
+import { cn } from "@/lib/utils/cn";
+import { formatCurrency } from "@/lib/utils/format";
+import type { StockHoldingWithReturn } from "@/types";
+
+interface PerformerCardProps {
+  title: string;
+  icon: React.ReactNode;
+  items: StockHoldingWithReturn[];
+  type: "gainer" | "loser";
+}
+
+function PerformerCard({ title, icon, items, type }: PerformerCardProps) {
+  const isGainer = type === "gainer";
+  const colorClass = isGainer ? "text-[#F04452]" : "text-[#3182F6]";
+
+  return (
+    <div className="bg-white rounded-2xl p-5 shadow-sm">
+      <div className="flex items-center gap-2 mb-4">
+        {icon}
+        <h3 className="text-sm font-medium text-gray-900">{title}</h3>
+      </div>
+      {items.length === 0 ? (
+        <p className="text-sm text-gray-500 text-center py-4">
+          {isGainer ? "수익 종목이 없어요" : "손실 종목이 없어요"}
+        </p>
+      ) : (
+        <div className="space-y-3">
+          {items.map((item, index) => (
+            <div
+              key={item.ticker}
+              className="flex items-center justify-between"
+            >
+              <div className="flex items-center gap-3">
+                <span className="size-6 rounded-full bg-gray-100 flex items-center justify-center text-xs font-medium text-gray-600">
+                  {index + 1}
+                </span>
+                <div>
+                  <p className="text-sm font-medium text-gray-900">
+                    {item.name}
+                  </p>
+                  <p className="text-xs text-gray-500">{item.ticker}</p>
+                </div>
+              </div>
+              <div className="text-right">
+                <p className={cn("text-sm font-medium", colorClass)}>
+                  {isGainer ? "+" : ""}
+                  {item.returnRate.toFixed(2)}%
+                </p>
+                <p className="text-xs text-gray-500">
+                  {isGainer ? "+" : ""}
+                  {formatCurrency(item.returnAmount, "KRW")}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function TopPerformersSection() {
+  const { data, isLoading } = useStockAnalysis();
+
+  const { gainers, losers } = useMemo(() => {
+    if (!data || data.holdings.length === 0) {
+      return { gainers: [], losers: [] };
+    }
+
+    // 수익률 기준 정렬
+    const sorted = [...data.holdings].sort(
+      (a, b) => b.returnRate - a.returnRate,
+    );
+
+    // 수익 TOP 5 (returnRate > 0인 것만)
+    const gainers = sorted.filter((h) => h.returnRate > 0).slice(0, 5);
+
+    // 손실 TOP 5 (returnRate < 0인 것만, 절대값 큰 순)
+    const losers = sorted
+      .filter((h) => h.returnRate < 0)
+      .reverse()
+      .slice(0, 5);
+
+    return { gainers, losers };
+  }, [data]);
+
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {[1, 2].map((i) => (
+          <div key={i} className="bg-white rounded-2xl p-5 shadow-sm">
+            <div className="animate-pulse">
+              <div className="h-4 w-24 bg-gray-200 rounded mb-4" />
+              <div className="space-y-3">
+                {[1, 2, 3, 4, 5].map((j) => (
+                  <div key={j} className="h-10 bg-gray-200 rounded" />
+                ))}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (!data || data.holdings.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <PerformerCard
+        title="수익 TOP 5"
+        icon={<Trophy className="size-4 text-[#FF9F00]" />}
+        items={gainers}
+        type="gainer"
+      />
+      <PerformerCard
+        title="손실 TOP 5"
+        icon={<TrendingDown className="size-4 text-[#3182F6]" />}
+        items={losers}
+        type="loser"
+      />
+    </div>
+  );
+}

--- a/components/dashboard/stocks/index.ts
+++ b/components/dashboard/stocks/index.ts
@@ -1,0 +1,4 @@
+export { MarketBreakdownSection } from "./MarketBreakdownSection";
+export { StockAllocationSection } from "./StockAllocationSection";
+export { StockSummarySection } from "./StockSummarySection";
+export { TopPerformersSection } from "./TopPerformersSection";

--- a/components/ui/chart.tsx
+++ b/components/ui/chart.tsx
@@ -1,0 +1,357 @@
+"use client";
+
+import * as React from "react";
+import * as RechartsPrimitive from "recharts";
+
+import { cn } from "@/lib/utils/cn";
+
+// Format: { THEME_NAME: CSS_SELECTOR }
+const THEMES = { light: "", dark: ".dark" } as const;
+
+export type ChartConfig = {
+  [k in string]: {
+    label?: React.ReactNode;
+    icon?: React.ComponentType;
+  } & (
+    | { color?: string; theme?: never }
+    | { color?: never; theme: Record<keyof typeof THEMES, string> }
+  );
+};
+
+type ChartContextProps = {
+  config: ChartConfig;
+};
+
+const ChartContext = React.createContext<ChartContextProps | null>(null);
+
+function useChart() {
+  const context = React.useContext(ChartContext);
+
+  if (!context) {
+    throw new Error("useChart must be used within a <ChartContainer />");
+  }
+
+  return context;
+}
+
+function ChartContainer({
+  id,
+  className,
+  children,
+  config,
+  ...props
+}: React.ComponentProps<"div"> & {
+  config: ChartConfig;
+  children: React.ComponentProps<
+    typeof RechartsPrimitive.ResponsiveContainer
+  >["children"];
+}) {
+  const uniqueId = React.useId();
+  const chartId = `chart-${id || uniqueId.replace(/:/g, "")}`;
+
+  return (
+    <ChartContext.Provider value={{ config }}>
+      <div
+        data-slot="chart"
+        data-chart={chartId}
+        className={cn(
+          "[&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border flex aspect-video justify-center text-xs [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
+          className,
+        )}
+        {...props}
+      >
+        <ChartStyle id={chartId} config={config} />
+        <RechartsPrimitive.ResponsiveContainer>
+          {children}
+        </RechartsPrimitive.ResponsiveContainer>
+      </div>
+    </ChartContext.Provider>
+  );
+}
+
+const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
+  const colorConfig = Object.entries(config).filter(
+    ([, config]) => config.theme || config.color,
+  );
+
+  if (!colorConfig.length) {
+    return null;
+  }
+
+  return (
+    <style
+      dangerouslySetInnerHTML={{
+        __html: Object.entries(THEMES)
+          .map(
+            ([theme, prefix]) => `
+${prefix} [data-chart=${id}] {
+${colorConfig
+  .map(([key, itemConfig]) => {
+    const color =
+      itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
+      itemConfig.color;
+    return color ? `  --color-${key}: ${color};` : null;
+  })
+  .join("\n")}
+}
+`,
+          )
+          .join("\n"),
+      }}
+    />
+  );
+};
+
+const ChartTooltip = RechartsPrimitive.Tooltip;
+
+function ChartTooltipContent({
+  active,
+  payload,
+  className,
+  indicator = "dot",
+  hideLabel = false,
+  hideIndicator = false,
+  label,
+  labelFormatter,
+  labelClassName,
+  formatter,
+  color,
+  nameKey,
+  labelKey,
+}: React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
+  React.ComponentProps<"div"> & {
+    hideLabel?: boolean;
+    hideIndicator?: boolean;
+    indicator?: "line" | "dot" | "dashed";
+    nameKey?: string;
+    labelKey?: string;
+  }) {
+  const { config } = useChart();
+
+  const tooltipLabel = React.useMemo(() => {
+    if (hideLabel || !payload?.length) {
+      return null;
+    }
+
+    const [item] = payload;
+    const key = `${labelKey || item?.dataKey || item?.name || "value"}`;
+    const itemConfig = getPayloadConfigFromPayload(config, item, key);
+    const value =
+      !labelKey && typeof label === "string"
+        ? config[label as keyof typeof config]?.label || label
+        : itemConfig?.label;
+
+    if (labelFormatter) {
+      return (
+        <div className={cn("font-medium", labelClassName)}>
+          {labelFormatter(value, payload)}
+        </div>
+      );
+    }
+
+    if (!value) {
+      return null;
+    }
+
+    return <div className={cn("font-medium", labelClassName)}>{value}</div>;
+  }, [
+    label,
+    labelFormatter,
+    payload,
+    hideLabel,
+    labelClassName,
+    config,
+    labelKey,
+  ]);
+
+  if (!active || !payload?.length) {
+    return null;
+  }
+
+  const nestLabel = payload.length === 1 && indicator !== "dot";
+
+  return (
+    <div
+      className={cn(
+        "border-border/50 bg-background grid min-w-[8rem] items-start gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl",
+        className,
+      )}
+    >
+      {!nestLabel ? tooltipLabel : null}
+      <div className="grid gap-1.5">
+        {payload
+          .filter((item) => item.type !== "none")
+          .map((item, index) => {
+            const key = `${nameKey || item.name || item.dataKey || "value"}`;
+            const itemConfig = getPayloadConfigFromPayload(config, item, key);
+            const indicatorColor = color || item.payload.fill || item.color;
+
+            return (
+              <div
+                key={item.dataKey}
+                className={cn(
+                  "[&>svg]:text-muted-foreground flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5",
+                  indicator === "dot" && "items-center",
+                )}
+              >
+                {formatter && item?.value !== undefined && item.name ? (
+                  formatter(item.value, item.name, item, index, item.payload)
+                ) : (
+                  <>
+                    {itemConfig?.icon ? (
+                      <itemConfig.icon />
+                    ) : (
+                      !hideIndicator && (
+                        <div
+                          className={cn(
+                            "shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)",
+                            {
+                              "h-2.5 w-2.5": indicator === "dot",
+                              "w-1": indicator === "line",
+                              "w-0 border-[1.5px] border-dashed bg-transparent":
+                                indicator === "dashed",
+                              "my-0.5": nestLabel && indicator === "dashed",
+                            },
+                          )}
+                          style={
+                            {
+                              "--color-bg": indicatorColor,
+                              "--color-border": indicatorColor,
+                            } as React.CSSProperties
+                          }
+                        />
+                      )
+                    )}
+                    <div
+                      className={cn(
+                        "flex flex-1 justify-between leading-none",
+                        nestLabel ? "items-end" : "items-center",
+                      )}
+                    >
+                      <div className="grid gap-1.5">
+                        {nestLabel ? tooltipLabel : null}
+                        <span className="text-muted-foreground">
+                          {itemConfig?.label || item.name}
+                        </span>
+                      </div>
+                      {item.value && (
+                        <span className="text-foreground font-mono font-medium tabular-nums">
+                          {item.value.toLocaleString()}
+                        </span>
+                      )}
+                    </div>
+                  </>
+                )}
+              </div>
+            );
+          })}
+      </div>
+    </div>
+  );
+}
+
+const ChartLegend = RechartsPrimitive.Legend;
+
+function ChartLegendContent({
+  className,
+  hideIcon = false,
+  payload,
+  verticalAlign = "bottom",
+  nameKey,
+}: React.ComponentProps<"div"> &
+  Pick<RechartsPrimitive.LegendProps, "payload" | "verticalAlign"> & {
+    hideIcon?: boolean;
+    nameKey?: string;
+  }) {
+  const { config } = useChart();
+
+  if (!payload?.length) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-center gap-4",
+        verticalAlign === "top" ? "pb-3" : "pt-3",
+        className,
+      )}
+    >
+      {payload
+        .filter((item) => item.type !== "none")
+        .map((item) => {
+          const key = `${nameKey || item.dataKey || "value"}`;
+          const itemConfig = getPayloadConfigFromPayload(config, item, key);
+
+          return (
+            <div
+              key={item.value}
+              className={cn(
+                "[&>svg]:text-muted-foreground flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3",
+              )}
+            >
+              {itemConfig?.icon && !hideIcon ? (
+                <itemConfig.icon />
+              ) : (
+                <div
+                  className="h-2 w-2 shrink-0 rounded-[2px]"
+                  style={{
+                    backgroundColor: item.color,
+                  }}
+                />
+              )}
+              {itemConfig?.label}
+            </div>
+          );
+        })}
+    </div>
+  );
+}
+
+// Helper to extract item config from a payload.
+function getPayloadConfigFromPayload(
+  config: ChartConfig,
+  payload: unknown,
+  key: string,
+) {
+  if (typeof payload !== "object" || payload === null) {
+    return undefined;
+  }
+
+  const payloadPayload =
+    "payload" in payload &&
+    typeof payload.payload === "object" &&
+    payload.payload !== null
+      ? payload.payload
+      : undefined;
+
+  let configLabelKey: string = key;
+
+  if (
+    key in payload &&
+    typeof payload[key as keyof typeof payload] === "string"
+  ) {
+    configLabelKey = payload[key as keyof typeof payload] as string;
+  } else if (
+    payloadPayload &&
+    key in payloadPayload &&
+    typeof payloadPayload[key as keyof typeof payloadPayload] === "string"
+  ) {
+    configLabelKey = payloadPayload[
+      key as keyof typeof payloadPayload
+    ] as string;
+  }
+
+  return configLabelKey in config
+    ? config[configLabelKey]
+    : config[key as keyof typeof config];
+}
+
+export {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+  ChartStyle,
+};

--- a/hooks/use-stock-analysis.ts
+++ b/hooks/use-stock-analysis.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { queries } from "@/lib/queries/keys";
+import type { StockAnalysisData } from "@/types";
+
+interface StockAnalysisError {
+  error: {
+    code: string;
+    message: string;
+  };
+}
+
+async function fetchStockAnalysis(): Promise<StockAnalysisData> {
+  const response = await fetch("/api/dashboard/stocks");
+  const json = await response.json();
+
+  if (!response.ok) {
+    const error = json as StockAnalysisError;
+    throw new Error(error.error.message);
+  }
+
+  return json as StockAnalysisData;
+}
+
+export function useStockAnalysis() {
+  return useQuery({
+    queryKey: queries.stocks.analysis.queryKey,
+    queryFn: fetchStockAnalysis,
+    staleTime: 5 * 60 * 1000, // 5분
+  });
+}

--- a/hooks/use-transaction.ts
+++ b/hooks/use-transaction.ts
@@ -100,6 +100,7 @@ export function useCreateTransaction() {
       queryClient.invalidateQueries({ queryKey: queries.transactions._def });
       queryClient.invalidateQueries({ queryKey: queries.holdings._def });
       queryClient.invalidateQueries({ queryKey: queries.dashboard._def });
+      queryClient.invalidateQueries({ queryKey: queries.stocks._def });
     },
   });
 }
@@ -144,6 +145,7 @@ export function useUpdateTransaction() {
       queryClient.invalidateQueries({ queryKey: queries.transactions._def });
       queryClient.invalidateQueries({ queryKey: queries.holdings._def });
       queryClient.invalidateQueries({ queryKey: queries.dashboard._def });
+      queryClient.invalidateQueries({ queryKey: queries.stocks._def });
     },
   });
 }
@@ -180,6 +182,7 @@ export function useDeleteTransaction() {
       queryClient.invalidateQueries({ queryKey: queries.transactions._def });
       queryClient.invalidateQueries({ queryKey: queries.holdings._def });
       queryClient.invalidateQueries({ queryKey: queries.dashboard._def });
+      queryClient.invalidateQueries({ queryKey: queries.stocks._def });
     },
   });
 }

--- a/lib/queries/keys.ts
+++ b/lib/queries/keys.ts
@@ -24,6 +24,7 @@ export const queries = createQueryKeyStore({
     search: (query: string) => ({ queryKey: [query] }),
     price: (symbol: string) => ({ queryKey: [symbol] }),
     prices: (symbols: string[]) => ({ queryKey: [symbols] }),
+    analysis: null,
   },
 
   exchange: {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-dom": "19.2.3",
     "react-error-boundary": "^6.0.1",
     "react-hook-form": "^7.69.0",
+    "recharts": "2.15.4",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "zod": "^4.2.1",
@@ -65,7 +66,7 @@
     "typescript": "^5"
   },
   "lint-staged": {
-    "*.{js,ts,jsx,tsx,json}": [
+    "!components/ui/**/*.{js,ts,jsx,tsx,json}": [
       "biome check --write"
     ]
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       react-hook-form:
         specifier: ^7.69.0
         version: 7.69.0(react@19.2.3)
+      recharts:
+        specifier: 2.15.4
+        version: 2.15.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -144,6 +147,10 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@babel/runtime@7.28.4':
+    resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
+    engines: {node: '>=6.9.0'}
 
   '@biomejs/biome@2.2.0':
     resolution: {integrity: sha512-3On3RSYLsX+n9KnoSgfoYlckYBoU6VRM22cw1gB4Y0OuUVSYd/O/2saOJMrA4HFfA1Ff0eacOvMN1yAAvHtzIw==}
@@ -1121,6 +1128,33 @@ packages:
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
     engines: {node: '>=12'}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.7':
+    resolution: {integrity: sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/node@20.19.27':
     resolution: {integrity: sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug==}
 
@@ -1222,6 +1256,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.0:
+    resolution: {integrity: sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
@@ -1235,12 +1313,18 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
   dotenv@17.2.3:
     resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
@@ -1265,8 +1349,15 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+
+  fast-equals@5.4.0:
+    resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
+    engines: {node: '>=6.0.0'}
 
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
@@ -1326,6 +1417,10 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
+
   is-fullwidth-code-point@5.1.0:
     resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
     engines: {node: '>=18'}
@@ -1340,6 +1435,9 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   jszip@3.10.1:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
@@ -1426,9 +1524,16 @@ packages:
     resolution: {integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==}
     engines: {node: '>=20.0.0'}
 
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
 
   lucide-react@0.562.0:
     resolution: {integrity: sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw==}
@@ -1500,6 +1605,10 @@ packages:
     resolution: {integrity: sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
@@ -1534,6 +1643,9 @@ packages:
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
   react-dom@19.2.3:
     resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
     peerDependencies:
@@ -1550,6 +1662,12 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
+
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -1571,6 +1689,12 @@ packages:
       '@types/react':
         optional: true
 
+  react-smooth@4.0.4:
+    resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
     engines: {node: '>=10'}
@@ -1580,6 +1704,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-transition-group@4.4.5:
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
 
   react@19.2.3:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
@@ -1591,6 +1721,16 @@ packages:
 
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
+  recharts-scale@0.4.5:
+    resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
+
+  recharts@2.15.4:
+    resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -1692,6 +1832,9 @@ packages:
     resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
     engines: {node: '>=18'}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -1737,6 +1880,9 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  victory-vendor@36.9.2:
+    resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
@@ -1795,6 +1941,8 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@babel/runtime@7.28.4': {}
 
   '@biomejs/biome@2.2.0':
     optionalDependencies:
@@ -2604,6 +2752,30 @@ snapshots:
 
   '@tanstack/table-core@8.21.3': {}
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.7':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/node@20.19.27':
     dependencies:
       undici-types: 6.21.0
@@ -2695,15 +2867,60 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.0: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.0
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   data-uri-to-buffer@4.0.1: {}
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
+  decimal.js-light@2.5.1: {}
+
   detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
+
+  dom-helpers@5.2.1:
+    dependencies:
+      '@babel/runtime': 7.28.4
+      csstype: 3.2.3
 
   dotenv@17.2.3: {}
 
@@ -2747,7 +2964,11 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.2
       '@esbuild/win32-x64': 0.27.2
 
+  eventemitter3@4.0.7: {}
+
   eventemitter3@5.0.1: {}
+
+  fast-equals@5.4.0: {}
 
   fetch-blob@3.2.0:
     dependencies:
@@ -2796,6 +3017,8 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  internmap@2.0.3: {}
+
   is-fullwidth-code-point@5.1.0:
     dependencies:
       get-east-asian-width: 1.4.0
@@ -2805,6 +3028,8 @@ snapshots:
   isarray@1.0.0: {}
 
   jiti@2.6.1: {}
+
+  js-tokens@4.0.0: {}
 
   jszip@3.10.1:
     dependencies:
@@ -2885,6 +3110,8 @@ snapshots:
       rfdc: 1.4.1
       wrap-ansi: 9.0.2
 
+  lodash@4.17.21: {}
+
   log-update@6.1.0:
     dependencies:
       ansi-escapes: 7.2.0
@@ -2892,6 +3119,10 @@ snapshots:
       slice-ansi: 7.1.2
       strip-ansi: 7.1.2
       wrap-ansi: 9.0.2
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
 
   lucide-react@0.562.0(react@19.2.3):
     dependencies:
@@ -2954,6 +3185,8 @@ snapshots:
 
   npm-normalize-package-bin@5.0.0: {}
 
+  object-assign@4.1.1: {}
+
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
@@ -2982,6 +3215,12 @@ snapshots:
 
   process-nextick-args@2.0.1: {}
 
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+
   react-dom@19.2.3(react@19.2.3):
     dependencies:
       react: 19.2.3
@@ -2995,6 +3234,10 @@ snapshots:
   react-hook-form@7.69.0(react@19.2.3):
     dependencies:
       react: 19.2.3
+
+  react-is@16.13.1: {}
+
+  react-is@18.3.1: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.7)(react@19.2.3):
     dependencies:
@@ -3015,6 +3258,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
+  react-smooth@4.0.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      fast-equals: 5.4.0
+      prop-types: 15.8.1
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      react-transition-group: 4.4.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+
   react-style-singleton@2.2.3(@types/react@19.2.7)(react@19.2.3):
     dependencies:
       get-nonce: 1.0.1
@@ -3022,6 +3273,15 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.7
+
+  react-transition-group@4.4.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      '@babel/runtime': 7.28.4
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   react@19.2.3: {}
 
@@ -3036,6 +3296,23 @@ snapshots:
       safe-buffer: 5.1.2
       string_decoder: 1.1.1
       util-deprecate: 1.0.2
+
+  recharts-scale@0.4.5:
+    dependencies:
+      decimal.js-light: 2.5.1
+
+  recharts@2.15.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      clsx: 2.1.1
+      eventemitter3: 4.0.7
+      lodash: 4.17.21
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      react-is: 18.3.1
+      react-smooth: 4.0.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      recharts-scale: 0.4.5
+      tiny-invariant: 1.3.3
+      victory-vendor: 36.9.2
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -3152,6 +3429,8 @@ snapshots:
       minizlib: 3.1.0
       yallist: 5.0.0
 
+  tiny-invariant@1.3.3: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -3187,6 +3466,23 @@ snapshots:
       '@types/react': 19.2.7
 
   util-deprecate@1.0.2: {}
+
+  victory-vendor@36.9.2:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.7
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   web-streams-polyfill@3.3.3: {}
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -75,3 +75,48 @@ export interface AssetClassSummary {
   totalValue: number;
   percentage: number;
 }
+
+// 주식 분석 페이지용 타입
+export interface StockAnalysisData {
+  summary: StockAnalysisSummary;
+  holdings: StockHoldingWithReturn[];
+  byMarket: MarketBreakdown[];
+  byCurrency: CurrencyBreakdown[];
+  exchangeRate: number;
+}
+
+export interface StockAnalysisSummary {
+  totalValue: number;
+  totalInvested: number;
+  totalReturn: number;
+  returnRate: number;
+  holdingCount: number;
+  missingPriceCount: number;
+}
+
+export interface StockHoldingWithReturn {
+  ticker: string;
+  name: string;
+  market: MarketType;
+  currency: CurrencyType;
+  quantity: number;
+  avgPrice: number;
+  currentPrice: number | null;
+  totalInvested: number;
+  currentValue: number;
+  returnAmount: number;
+  returnRate: number;
+  allocationPercent: number;
+}
+
+export interface MarketBreakdown {
+  market: MarketType;
+  totalValue: number;
+  percentage: number;
+}
+
+export interface CurrencyBreakdown {
+  currency: CurrencyType;
+  totalValue: number;
+  percentage: number;
+}


### PR DESCRIPTION
## Summary
- `/dashboard/stocks` 주식 분석 페이지 구현
- 주식 요약 카드 (평가금액, 수익률, 종목수), 종목별 비중 도넛 차트, 시장별/통화별 비중, 수익/손실 TOP 5 표시
- shadcn/ui 차트 컴포넌트 추가 (recharts 기반)

## Test plan
- [x] `/dashboard` 접속 → "주식/ETF" 카드 클릭
- [x] `/dashboard/stocks` 페이지에서 요약 카드, 차트, TOP 리스트 확인
- [x] 거래 기록 추가 후 주식 분석 페이지 데이터 갱신 확인
- [x] 뒤로가기 버튼 → `/dashboard` 이동 확인

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)