### PR TITLE
[Infra] Next.js middleware → proxy 마이그레이션

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -1,7 +1,7 @@
 import type { NextRequest } from "next/server";
 import { updateSession } from "@/lib/supabase/middleware";
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   return await updateSession(request);
 }
 


### PR DESCRIPTION
## Summary
- Next.js 16에서 deprecated된 `middleware` 파일 컨벤션을 `proxy`로 마이그레이션
- `middleware.ts` → `proxy.ts` 변경 (함수명 `middleware` → `proxy`)
- 인증 로직 유틸(`lib/supabase/middleware.ts`)은 그대로 유지

## Test plan
- [x] `pnpm build` 성공 확인
- [x] 로그인 상태에서 `/login` 접근 시 `/home`으로 리다이렉트 확인
- [x] 비로그인 상태에서 `/home` 접근 시 `/login`으로 리다이렉트 확인

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)