### PR TITLE
feat: 소유자별 분석 페이지 구현 (#102)

### DIFF
--- a/app/(main)/dashboard/by-owner/page.tsx
+++ b/app/(main)/dashboard/by-owner/page.tsx
@@ -1,51 +1,25 @@
 "use client";
 
-import { ArrowLeft } from "lucide-react";
-import Link from "next/link";
-import { SummaryCard } from "@/components/dashboard";
-import { useDashboardSummary } from "@/hooks/use-dashboard";
-
-const MEMBER_COLORS = ["#4F46E5", "#03B26C", "#FF9F00", "#F04452", "#8B95A1"];
+import {
+  OwnerAllocationChart,
+  OwnerAssetList,
+  OwnerSummaryCards,
+} from "@/components/dashboard/by-owner";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { useOwnerAnalysis } from "@/hooks/use-owner-analysis";
 
 export default function ByOwnerAnalysisPage() {
-  const { data, isLoading, error } = useDashboardSummary();
+  const { data, isLoading, error } = useOwnerAnalysis();
 
-  const byMemberItems =
-    data?.byMember.map((member, index) => ({
-      label: member.memberName,
-      value: member.totalValue,
-      percentage: member.percentage,
-      color: MEMBER_COLORS[index % MEMBER_COLORS.length],
-    })) ?? [];
-
-  const isEmpty = !isLoading && (!data || data.totalInvested === 0);
+  const isEmpty = !isLoading && (!data || data.summary.length === 0);
 
   return (
     <>
-      {/* 페이지 헤더 */}
-      <div className="flex items-center gap-3">
-        <Link
-          href="/dashboard"
-          className="p-2 -ml-2 rounded-lg hover:bg-gray-100 transition-colors"
-        >
-          <ArrowLeft className="w-5 h-5 text-gray-600" />
-        </Link>
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900">소유자별 분석</h1>
-          <p className="text-sm text-gray-500">가족 구성원별 자산 비중</p>
-        </div>
-      </div>
-
-      {/* 로딩 상태 */}
-      {isLoading && (
-        <div className="bg-white rounded-2xl p-5 shadow-sm">
-          <div className="animate-pulse space-y-3">
-            <div className="h-4 w-24 bg-gray-200 rounded" />
-            <div className="h-6 w-full bg-gray-200 rounded" />
-            <div className="h-6 w-full bg-gray-200 rounded" />
-          </div>
-        </div>
-      )}
+      <PageHeader
+        title="소유자별 분석"
+        subtitle="가족 구성원별 자산 비중"
+        backHref="/dashboard"
+      />
 
       {/* 에러 상태 */}
       {error && (
@@ -67,8 +41,20 @@ export default function ByOwnerAnalysisPage() {
       )}
 
       {/* 데이터 표시 */}
-      {!isLoading && !error && byMemberItems.length > 0 && (
-        <SummaryCard title="구성원별 자산" items={byMemberItems} />
+      {!error && (
+        <>
+          {/* 소유자별 요약 카드 */}
+          <OwnerSummaryCards data={data?.summary ?? []} isLoading={isLoading} />
+
+          {/* 차트 섹션 */}
+          <OwnerAllocationChart
+            data={data?.summary ?? []}
+            isLoading={isLoading}
+          />
+
+          {/* 소유자별 상세 리스트 */}
+          <OwnerAssetList data={data?.holdings ?? []} isLoading={isLoading} />
+        </>
       )}
     </>
   );

--- a/app/api/dashboard/by-owner/route.ts
+++ b/app/api/dashboard/by-owner/route.ts
@@ -1,0 +1,226 @@
+import { NextResponse } from "next/server";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import { getExchangeRateSafe } from "@/lib/api/exchange";
+import { getHoldings } from "@/lib/api/holdings";
+import { getUserHouseholdId } from "@/lib/api/invitation";
+import { getStockPrices } from "@/lib/api/stock-price";
+import { createClient } from "@/lib/supabase/server";
+import type {
+  MemberSummary,
+  OwnerAnalysisData,
+  OwnerHoldings,
+  StockHoldingWithReturn,
+} from "@/types";
+
+/**
+ * GET /api/dashboard/by-owner
+ * 소유자별 분석 데이터 조회
+ */
+export async function GET() {
+  try {
+    const supabase = await createClient();
+
+    // 인증 확인
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    // 사용자의 가구 조회
+    const householdId = await getUserHouseholdId(supabase, user.id);
+
+    if (!householdId) {
+      throw new APIError(
+        "HOUSEHOLD_NOT_FOUND",
+        "가구 정보를 찾을 수 없습니다.",
+        404,
+      );
+    }
+
+    // 환율 조회 (USD → KRW)
+    const exchangeRateResult = await getExchangeRateSafe(
+      supabase,
+      "USD",
+      "KRW",
+    );
+    const exchangeRate = exchangeRateResult?.rate ?? 1300;
+
+    // 보유 현황 조회 (페이지네이션 없이 전체)
+    const holdingsResult = await getHoldings(supabase, householdId, {
+      pagination: { page: 1, pageSize: 1000 },
+    });
+
+    const holdings = holdingsResult.data;
+
+    // 빈 holdings 처리
+    if (holdings.length === 0) {
+      const emptyData: OwnerAnalysisData = {
+        summary: [],
+        holdings: [],
+        exchangeRate,
+      };
+      return NextResponse.json(emptyData);
+    }
+
+    // 주가 조회
+    const stockQueries = holdings
+      .filter((h) => h.market === "KR" || h.market === "US")
+      .map((h) => ({
+        market: h.market as "KR" | "US",
+        code: h.ticker,
+      }));
+
+    const stockPrices = await getStockPrices(supabase, stockQueries);
+
+    // 소유자별로 종목 그룹화
+    const ownerMap = new Map<
+      string,
+      {
+        name: string;
+        stocks: StockHoldingWithReturn[];
+        totalValue: number;
+        totalInvested: number;
+      }
+    >();
+
+    let totalValueSum = 0;
+
+    for (const h of holdings) {
+      const priceKey = `${h.market}:${h.ticker}`;
+      const priceData = stockPrices[priceKey];
+      const currentPrice = priceData?.price ?? null;
+
+      // 현재가가 없으면 평균 매수가를 대신 사용
+      const effectivePrice = currentPrice ?? h.avgPrice;
+      const rawCurrentValue = h.quantity * effectivePrice;
+      const rawInvestedAmount = h.totalInvested;
+
+      // USD → KRW 환산
+      const isUSD = h.currency === "USD";
+      const currentValue = isUSD
+        ? rawCurrentValue * exchangeRate
+        : rawCurrentValue;
+      const investedAmountKRW = isUSD
+        ? rawInvestedAmount * exchangeRate
+        : rawInvestedAmount;
+
+      // 수익 계산
+      const returnAmount = currentValue - investedAmountKRW;
+      const returnRate =
+        investedAmountKRW > 0 ? (returnAmount / investedAmountKRW) * 100 : 0;
+
+      totalValueSum += currentValue;
+
+      const stock: StockHoldingWithReturn = {
+        ticker: h.ticker,
+        name: h.name,
+        market: h.market,
+        currency: h.currency,
+        quantity: h.quantity,
+        avgPrice: h.avgPrice,
+        currentPrice,
+        totalInvested: investedAmountKRW,
+        currentValue,
+        returnAmount,
+        returnRate,
+        allocationPercent: 0, // 나중에 계산
+      };
+
+      const ownerId = h.owner.id;
+      const ownerName = h.owner.name;
+
+      const existing = ownerMap.get(ownerId);
+      if (existing) {
+        existing.stocks.push(stock);
+        existing.totalValue += currentValue;
+        existing.totalInvested += investedAmountKRW;
+      } else {
+        ownerMap.set(ownerId, {
+          name: ownerName,
+          stocks: [stock],
+          totalValue: currentValue,
+          totalInvested: investedAmountKRW,
+        });
+      }
+    }
+
+    // 비중 계산 및 정렬
+    for (const [, owner] of ownerMap) {
+      for (const stock of owner.stocks) {
+        stock.allocationPercent =
+          owner.totalValue > 0
+            ? (stock.currentValue / owner.totalValue) * 100
+            : 0;
+      }
+      // 평가금액 내림차순 정렬
+      owner.stocks.sort((a, b) => b.currentValue - a.currentValue);
+    }
+
+    // 소유자별 요약 생성
+    const summary: MemberSummary[] = Array.from(ownerMap.entries()).map(
+      ([memberId, { name, totalValue, totalInvested }]) => {
+        const memberReturn = totalValue - totalInvested;
+        const memberReturnRate =
+          totalInvested > 0 ? (memberReturn / totalInvested) * 100 : 0;
+        return {
+          memberId,
+          memberName: name,
+          totalValue,
+          totalInvested,
+          totalReturn: memberReturn,
+          returnRate: memberReturnRate,
+          percentage:
+            totalValueSum > 0 ? (totalValue / totalValueSum) * 100 : 0,
+        };
+      },
+    );
+
+    // 평가금액 내림차순 정렬
+    summary.sort((a, b) => b.totalValue - a.totalValue);
+
+    // 소유자별 보유 종목 생성
+    const ownerHoldings: OwnerHoldings[] = Array.from(ownerMap.entries()).map(
+      ([ownerId, { name, stocks }]) => ({
+        ownerId,
+        ownerName: name,
+        stocks,
+      }),
+    );
+
+    // summary 순서와 동일하게 정렬
+    ownerHoldings.sort((a, b) => {
+      const aIndex = summary.findIndex((s) => s.memberId === a.ownerId);
+      const bIndex = summary.findIndex((s) => s.memberId === b.ownerId);
+      return aIndex - bIndex;
+    });
+
+    const result: OwnerAnalysisData = {
+      summary,
+      holdings: ownerHoldings,
+      exchangeRate,
+    };
+
+    return NextResponse.json(result);
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    console.error("Owner analysis error:", error);
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "서버 오류가 발생했습니다.",
+        },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/dashboard/summary/route.ts
+++ b/app/api/dashboard/summary/route.ts
@@ -154,23 +154,39 @@ export async function GET() {
       totalInvested > 0 ? (totalReturn / totalInvested) * 100 : 0;
 
     // 멤버별 집계
-    const memberMap = new Map<string, { name: string; value: number }>();
+    const memberMap = new Map<
+      string,
+      { name: string; value: number; invested: number }
+    >();
     for (const h of holdingsWithValue) {
       const existing = memberMap.get(h.ownerId);
       if (existing) {
         existing.value += h.currentValue;
+        existing.invested += h.investedAmountKRW;
       } else {
-        memberMap.set(h.ownerId, { name: h.ownerName, value: h.currentValue });
+        memberMap.set(h.ownerId, {
+          name: h.ownerName,
+          value: h.currentValue,
+          invested: h.investedAmountKRW,
+        });
       }
     }
 
     const byMember: MemberSummary[] = Array.from(memberMap.entries()).map(
-      ([memberId, { name, value }]) => ({
-        memberId,
-        memberName: name,
-        totalValue: value,
-        percentage: totalValue > 0 ? (value / totalValue) * 100 : 0,
-      }),
+      ([memberId, { name, value, invested }]) => {
+        const memberReturn = value - invested;
+        const memberReturnRate =
+          invested > 0 ? (memberReturn / invested) * 100 : 0;
+        return {
+          memberId,
+          memberName: name,
+          totalValue: value,
+          totalInvested: invested,
+          totalReturn: memberReturn,
+          returnRate: memberReturnRate,
+          percentage: totalValue > 0 ? (value / totalValue) * 100 : 0,
+        };
+      },
     );
 
     // 자산군별 집계

--- a/components/dashboard/by-owner/OwnerAllocationChart.tsx
+++ b/components/dashboard/by-owner/OwnerAllocationChart.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  Bar,
+  BarChart,
+  Cell,
+  Pie,
+  PieChart,
+  Tooltip as RechartsTooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import { formatCompactNumber, formatCurrency } from "@/lib/utils/format";
+import type { MemberSummary } from "@/types";
+
+const MEMBER_COLORS = ["#4F46E5", "#03B26C", "#FF9F00", "#F04452", "#8B95A1"];
+
+interface OwnerAllocationChartProps {
+  data: MemberSummary[];
+  isLoading?: boolean;
+}
+
+export function OwnerAllocationChart({
+  data,
+  isLoading,
+}: OwnerAllocationChartProps) {
+  const chartData = useMemo(() => {
+    return data.map((member, index) => ({
+      id: member.memberId,
+      name: member.memberName,
+      value: member.totalValue,
+      percentage: member.percentage,
+      fill: MEMBER_COLORS[index % MEMBER_COLORS.length],
+    }));
+  }, [data]);
+
+  const chartConfig = useMemo(() => {
+    const config: ChartConfig = {};
+    for (const item of chartData) {
+      config[item.id] = {
+        label: item.name,
+        color: item.fill,
+      };
+    }
+    return config;
+  }, [chartData]);
+
+  if (isLoading) {
+    return (
+      <div className="bg-white rounded-2xl p-5 shadow-sm">
+        <div className="animate-pulse">
+          <div className="h-4 w-24 bg-gray-200 rounded mb-4" />
+          <div className="flex gap-6">
+            <div className="size-48 bg-gray-200 rounded-full" />
+            <div className="flex-1 space-y-3">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="h-6 bg-gray-200 rounded" />
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (data.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* 파이차트 섹션 */}
+      <div className="bg-white rounded-2xl p-5 shadow-sm">
+        <h3 className="text-sm font-medium text-gray-900 mb-4">
+          소유자별 비중
+        </h3>
+        <div className="flex flex-col md:flex-row gap-6">
+          {/* 도넛 차트 */}
+          <div className="flex-shrink-0">
+            <ChartContainer config={chartConfig} className="size-48">
+              <PieChart>
+                <ChartTooltip
+                  content={
+                    <ChartTooltipContent
+                      formatter={(_value, _name, item) => (
+                        <div className="flex items-center justify-between gap-4">
+                          <span>{item.payload.name}</span>
+                          <span className="font-mono font-medium">
+                            {item.payload.percentage.toFixed(1)}%
+                          </span>
+                        </div>
+                      )}
+                    />
+                  }
+                />
+                <Pie
+                  data={chartData}
+                  dataKey="value"
+                  nameKey="name"
+                  cx="50%"
+                  cy="50%"
+                  innerRadius={50}
+                  outerRadius={80}
+                  strokeWidth={2}
+                  stroke="#fff"
+                >
+                  {chartData.map((entry) => (
+                    <Cell key={entry.id} fill={entry.fill} />
+                  ))}
+                </Pie>
+              </PieChart>
+            </ChartContainer>
+          </div>
+
+          {/* 범례 리스트 */}
+          <div className="flex-1 space-y-3">
+            {chartData.map((item) => (
+              <div key={item.id} className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <div
+                    className="size-3 rounded-full"
+                    style={{ backgroundColor: item.fill }}
+                  />
+                  <span className="text-sm text-gray-700">{item.name}</span>
+                </div>
+                <div className="text-right">
+                  <span className="text-sm font-medium text-gray-900">
+                    {formatCurrency(item.value, "KRW")}
+                  </span>
+                  <span className="text-xs text-gray-500 ml-1">
+                    ({item.percentage.toFixed(1)}%)
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* 바차트 섹션 */}
+      <div className="bg-white rounded-2xl p-5 shadow-sm">
+        <h3 className="text-sm font-medium text-gray-900 mb-4">
+          소유자별 자산 비교
+        </h3>
+        <ChartContainer config={chartConfig} className="h-[200px] w-full">
+          <BarChart
+            data={chartData}
+            layout="vertical"
+            margin={{ left: 0, right: 20 }}
+          >
+            <XAxis
+              type="number"
+              tickFormatter={(value) => formatCompactNumber(value)}
+              fontSize={12}
+              tickLine={false}
+              axisLine={false}
+            />
+            <YAxis
+              type="category"
+              dataKey="name"
+              width={60}
+              fontSize={12}
+              tickLine={false}
+              axisLine={false}
+            />
+            <RechartsTooltip
+              formatter={(value: number) => [
+                formatCurrency(value, "KRW"),
+                "평가금액",
+              ]}
+              labelStyle={{ color: "#374151" }}
+              contentStyle={{
+                backgroundColor: "white",
+                border: "1px solid #e5e7eb",
+                borderRadius: "8px",
+                boxShadow: "0 4px 6px -1px rgb(0 0 0 / 0.1)",
+              }}
+            />
+            <Bar dataKey="value" radius={[0, 4, 4, 0]}>
+              {chartData.map((entry) => (
+                <Cell key={entry.id} fill={entry.fill} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ChartContainer>
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/by-owner/OwnerAssetList.tsx
+++ b/components/dashboard/by-owner/OwnerAssetList.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import {
+  ChevronDown,
+  ChevronUp,
+  TrendingDown,
+  TrendingUp,
+  User,
+} from "lucide-react";
+import { useState } from "react";
+import { cn } from "@/lib/utils/cn";
+import { formatCurrency, formatPercent } from "@/lib/utils/format";
+import type { OwnerHoldings } from "@/types";
+
+const MEMBER_COLORS = ["#4F46E5", "#03B26C", "#FF9F00", "#F04452", "#8B95A1"];
+
+interface OwnerAssetListProps {
+  data: OwnerHoldings[];
+  isLoading?: boolean;
+}
+
+export function OwnerAssetList({ data, isLoading }: OwnerAssetListProps) {
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+
+  const toggleExpand = (ownerId: string) => {
+    setExpanded((prev) => ({
+      ...prev,
+      [ownerId]: !prev[ownerId],
+    }));
+  };
+
+  if (isLoading) {
+    return (
+      <div className="bg-white rounded-2xl p-5 shadow-sm">
+        <div className="animate-pulse space-y-4">
+          <div className="h-4 w-32 bg-gray-200 rounded" />
+          {[1, 2].map((i) => (
+            <div key={i} className="space-y-3">
+              <div className="h-12 bg-gray-200 rounded" />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (data.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="bg-white rounded-2xl p-5 shadow-sm">
+      <h3 className="text-sm font-medium text-gray-900 mb-4">
+        소유자별 보유 종목
+      </h3>
+      <div className="space-y-3">
+        {data.map((owner, index) => {
+          const isExpanded = expanded[owner.ownerId] ?? false;
+          const memberColor = MEMBER_COLORS[index % MEMBER_COLORS.length];
+
+          return (
+            <div
+              key={owner.ownerId}
+              className="border border-gray-100 rounded-xl overflow-hidden"
+            >
+              {/* 헤더 (클릭 가능) */}
+              <button
+                type="button"
+                onClick={() => toggleExpand(owner.ownerId)}
+                className="w-full flex items-center justify-between p-4 hover:bg-gray-50 transition-colors"
+              >
+                <div className="flex items-center gap-3">
+                  <div
+                    className="size-8 rounded-full flex items-center justify-center"
+                    style={{ backgroundColor: `${memberColor}20` }}
+                  >
+                    <User className="size-4" style={{ color: memberColor }} />
+                  </div>
+                  <div className="text-left">
+                    <span className="text-sm font-medium text-gray-900">
+                      {owner.ownerName}
+                    </span>
+                    <span className="text-xs text-gray-400 ml-2">
+                      {owner.stocks.length}종목
+                    </span>
+                  </div>
+                </div>
+                {isExpanded ? (
+                  <ChevronUp className="size-5 text-gray-400" />
+                ) : (
+                  <ChevronDown className="size-5 text-gray-400" />
+                )}
+              </button>
+
+              {/* 상세 종목 리스트 */}
+              {isExpanded && (
+                <div className="border-t border-gray-100 bg-gray-50/50">
+                  {owner.stocks.map((stock) => {
+                    const isPositive = stock.returnRate >= 0;
+                    const TrendIcon = isPositive ? TrendingUp : TrendingDown;
+                    const colorClass = isPositive
+                      ? "text-[#F04452]"
+                      : "text-[#3182F6]";
+
+                    return (
+                      <div
+                        key={stock.ticker}
+                        className="flex items-center justify-between px-4 py-3 border-b border-gray-100 last:border-b-0"
+                      >
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-2">
+                            <span className="text-sm font-medium text-gray-900 truncate">
+                              {stock.name}
+                            </span>
+                            <span className="text-xs text-gray-400 shrink-0">
+                              {stock.ticker}
+                            </span>
+                          </div>
+                          <div className="flex items-center gap-2 mt-0.5">
+                            <span className="text-xs text-gray-500">
+                              {stock.quantity.toLocaleString()}주
+                            </span>
+                            <span className="text-xs text-gray-300">·</span>
+                            <span className="text-xs text-gray-500">
+                              {stock.market}
+                            </span>
+                          </div>
+                        </div>
+                        <div className="text-right shrink-0 ml-4">
+                          <p className="text-sm font-medium text-gray-900">
+                            {formatCurrency(stock.currentValue, "KRW")}
+                          </p>
+                          <div className="flex items-center justify-end gap-1 mt-0.5">
+                            <TrendIcon className={cn("size-3", colorClass)} />
+                            <span
+                              className={cn("text-xs font-medium", colorClass)}
+                            >
+                              {formatPercent(stock.returnRate)}
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/by-owner/OwnerSummaryCards.tsx
+++ b/components/dashboard/by-owner/OwnerSummaryCards.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { TrendingDown, TrendingUp, User } from "lucide-react";
+import { cn } from "@/lib/utils/cn";
+import { formatCurrency, formatPercent } from "@/lib/utils/format";
+import type { MemberSummary } from "@/types";
+
+const MEMBER_COLORS = ["#4F46E5", "#03B26C", "#FF9F00", "#F04452", "#8B95A1"];
+
+interface OwnerSummaryCardsProps {
+  data: MemberSummary[];
+  isLoading?: boolean;
+}
+
+export function OwnerSummaryCards({ data, isLoading }: OwnerSummaryCardsProps) {
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {[1, 2].map((i) => (
+          <div key={i} className="bg-white rounded-2xl p-5 shadow-sm">
+            <div className="animate-pulse space-y-3">
+              <div className="h-5 w-20 bg-gray-200 rounded" />
+              <div className="h-8 w-32 bg-gray-200 rounded" />
+              <div className="h-4 w-24 bg-gray-200 rounded" />
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (data.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      {data.map((member, index) => {
+        const isPositive = member.returnRate >= 0;
+        const TrendIcon = isPositive ? TrendingUp : TrendingDown;
+        const colorClass = isPositive ? "text-[#F04452]" : "text-[#3182F6]";
+        const memberColor = MEMBER_COLORS[index % MEMBER_COLORS.length];
+
+        return (
+          <div
+            key={member.memberId}
+            className="bg-white rounded-2xl p-5 shadow-sm"
+          >
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <div
+                  className="size-8 rounded-full flex items-center justify-center"
+                  style={{ backgroundColor: `${memberColor}20` }}
+                >
+                  <User className="size-4" style={{ color: memberColor }} />
+                </div>
+                <span className="text-sm font-medium text-gray-900">
+                  {member.memberName}
+                </span>
+              </div>
+              <span className="text-xs text-gray-400">
+                {member.percentage.toFixed(1)}%
+              </span>
+            </div>
+
+            <p className="text-2xl font-bold text-gray-900 mt-3">
+              {formatCurrency(member.totalValue, "KRW")}
+            </p>
+
+            <div className="flex items-center gap-1.5 mt-2">
+              <TrendIcon className={cn("size-3.5", colorClass)} />
+              <span className={cn("text-sm font-medium", colorClass)}>
+                {formatPercent(member.returnRate)}
+              </span>
+              <span className="text-xs text-gray-400">
+                ({isPositive ? "+" : ""}
+                {formatCurrency(member.totalReturn, "KRW")})
+              </span>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/dashboard/by-owner/index.ts
+++ b/components/dashboard/by-owner/index.ts
@@ -1,0 +1,3 @@
+export { OwnerAllocationChart } from "./OwnerAllocationChart";
+export { OwnerAssetList } from "./OwnerAssetList";
+export { OwnerSummaryCards } from "./OwnerSummaryCards";

--- a/hooks/use-owner-analysis.ts
+++ b/hooks/use-owner-analysis.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+import { queries } from "@/lib/queries/keys";
+import type { OwnerAnalysisData } from "@/types";
+
+async function fetchOwnerAnalysis(): Promise<OwnerAnalysisData> {
+  const response = await fetch("/api/dashboard/by-owner");
+
+  if (!response.ok) {
+    throw new Error("소유자별 분석 데이터를 불러오는데 실패했습니다.");
+  }
+
+  return response.json();
+}
+
+export function useOwnerAnalysis() {
+  return useQuery({
+    queryKey: queries.dashboard.byOwner.queryKey,
+    queryFn: fetchOwnerAnalysis,
+    staleTime: 5 * 60 * 1000, // 5분
+  });
+}

--- a/lib/queries/keys.ts
+++ b/lib/queries/keys.ts
@@ -35,6 +35,7 @@ export const queries = createQueryKeyStore({
   dashboard: {
     all: null,
     summary: null,
+    byOwner: null,
   },
 
   household: {

--- a/types/index.ts
+++ b/types/index.ts
@@ -67,6 +67,9 @@ export interface MemberSummary {
   memberId: string;
   memberName: string;
   totalValue: number;
+  totalInvested: number;
+  totalReturn: number;
+  returnRate: number;
   percentage: number;
 }
 
@@ -119,4 +122,17 @@ export interface CurrencyBreakdown {
   currency: CurrencyType;
   totalValue: number;
   percentage: number;
+}
+
+// 소유자별 분석 페이지용 타입
+export interface OwnerAnalysisData {
+  summary: MemberSummary[];
+  holdings: OwnerHoldings[];
+  exchangeRate: number;
+}
+
+export interface OwnerHoldings {
+  ownerId: string;
+  ownerName: string;
+  stocks: StockHoldingWithReturn[];
 }


### PR DESCRIPTION
## Summary
- 소유자별 요약 카드 구현 (총 자산, 수익률)
- 소유자별 비중 파이차트 및 바차트 추가
- 소유자별 보유 종목 접힘/펼침 리스트 구현
- `/api/dashboard/by-owner` API 신규 생성
- `MemberSummary` 타입 확장 (투자금액, 수익률 필드 추가)

## Test plan
- [x] `/dashboard/by-owner` 페이지 접속 확인
- [x] 소유자별 요약 카드 렌더링 확인
- [x] 파이차트/바차트 정상 표시 확인
- [x] 접힘/펼침 동작 확인
- [x] 뒤로가기 → `/dashboard` 이동 확인

Closes #102

🤖 Generated with [Claude Code](https://claude.ai/code)