### PR TITLE
refactor: 주식 보유현황 페이지에서 자산유형 필터 제거 (#156)

### DIFF
--- a/components/holdings/HoldingsFilters.tsx
+++ b/components/holdings/HoldingsFilters.tsx
@@ -7,9 +7,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { ASSET_TYPE_OPTIONS, MARKET_OPTIONS } from "@/constants/enums";
+import { MARKET_OPTIONS } from "@/constants/enums";
 import type { HoldingsFilters as Filters } from "@/lib/api/holdings";
-import type { AssetType, MarketType } from "@/types";
+import type { MarketType } from "@/types";
 
 interface Member {
   id: string;
@@ -31,13 +31,6 @@ export function HoldingsFilters({
     onFiltersChange({
       ...filters,
       ownerId: value === "all" ? undefined : value,
-    });
-  };
-
-  const handleAssetTypeChange = (value: string) => {
-    onFiltersChange({
-      ...filters,
-      assetType: value === "all" ? undefined : (value as AssetType),
     });
   };
 
@@ -71,26 +64,6 @@ export function HoldingsFilters({
           </Select>
         </div>
       )}
-
-      <div className="flex items-center gap-2">
-        <span className="text-sm text-gray-500">자산유형</span>
-        <Select
-          value={filters.assetType ?? "all"}
-          onValueChange={handleAssetTypeChange}
-        >
-          <SelectTrigger className="w-[100px]">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">전체</SelectItem>
-            {ASSET_TYPE_OPTIONS.map((option) => (
-              <SelectItem key={option.value} value={option.value}>
-                {option.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
 
       <div className="flex items-center gap-2">
         <span className="text-sm text-gray-500">시장</span>


### PR DESCRIPTION
## Summary
- 주식 전용 페이지(`/assets/stock/holdings`)에서 불필요한 자산유형 필터 UI 제거
- 소유자, 시장 필터만 유지

## Changes
- `HoldingsFilters.tsx`에서 자산유형 Select 컴포넌트 제거
- 관련 import(`ASSET_TYPE_OPTIONS`, `AssetType`) 및 핸들러 함수 정리

## Test plan
- [x] 주식 보유현황 페이지에서 자산유형 필터가 사라졌는지 확인
- [x] 소유자 필터 (멤버 2명 이상일 때) 정상 동작 확인
- [x] 시장 필터 정상 동작 확인

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)