### PR TITLE
feat: 주식 메인 페이지 레이아웃 구현

### DIFF
--- a/app/(main)/assets/stock/page.tsx
+++ b/app/(main)/assets/stock/page.tsx
@@ -1,0 +1,11 @@
+import { StockSummarySection } from "@/components/dashboard/stocks";
+import { PageHeader } from "@/components/layout";
+
+export default function StockMainPage() {
+  return (
+    <>
+      <PageHeader title="주식" backHref="/assets" />
+      <StockSummarySection />
+    </>
+  );
+}

--- a/components/assets/common/AssetTypeCard.tsx
+++ b/components/assets/common/AssetTypeCard.tsx
@@ -29,7 +29,7 @@ const ASSET_TYPE_CONFIG: Record<AssetType, AssetTypeConfig> = {
     label: "주식/ETF",
     color: "text-indigo-600",
     bgColor: "bg-indigo-50",
-    href: "/assets/stock/holdings",
+    href: "/assets/stock",
   },
   cash: {
     icon: Wallet,


### PR DESCRIPTION
## Summary
- `/assets/stock` 허브 페이지 생성
- PageHeader (backHref: /assets) + StockSummarySection 구성
- AssetTypeCard의 stock href를 `/assets/stock`으로 변경

## Test plan
- [x] `/assets/stock` 접속 시 메인 페이지 표시 확인
- [x] PageHeader에 "주식" 제목과 뒤로가기 버튼(→ /assets) 확인
- [x] StockSummarySection에 평가금액, 수익, 보유종목 카드 표시 확인
- [x] `/assets` 페이지에서 "주식/ETF" 카드 클릭 시 `/assets/stock`으로 이동 확인

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)