### PR TITLE
[DB] transactions 테이블에 account_id 컬럼 추가

### DIFF
--- a/supabase/migrations/20260110110736_add_account_id_to_transactions.sql
+++ b/supabase/migrations/20260110110736_add_account_id_to_transactions.sql
@@ -1,0 +1,22 @@
+-- account_type enum 생성
+create type account_type as enum (
+  'stock',     -- 주식/증권 계좌
+  'savings',   -- 예금 계좌 (보통예금)
+  'deposit',   -- 적금 계좌 (정기예금, 정기적금)
+  'checking',  -- 입출금 계좌 (월급통장 등)
+  'isa',       -- ISA 계좌 (절세 계좌)
+  'pension',   -- 연금 계좌 (IRP, 퇴직연금)
+  'cma',       -- CMA 계좌
+  'other'      -- 기타 계좌
+);
+
+-- accounts 테이블의 account_type 컬럼을 enum으로 변경
+alter table public.accounts
+  alter column account_type type account_type using account_type::account_type;
+
+-- transactions 테이블에 account_id 컬럼 추가 (nullable - 기존 데이터 호환)
+alter table public.transactions
+  add column account_id uuid references public.accounts(id) on delete set null;
+
+-- 인덱스 추가
+create index transactions_account_id_idx on public.transactions(account_id);

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -37,7 +37,7 @@ export type Database = {
       accounts: {
         Row: {
           account_number: string | null;
-          account_type: string | null;
+          account_type: Database["public"]["Enums"]["account_type"] | null;
           broker: string | null;
           created_at: string;
           household_id: string;
@@ -50,7 +50,7 @@ export type Database = {
         };
         Insert: {
           account_number?: string | null;
-          account_type?: string | null;
+          account_type?: Database["public"]["Enums"]["account_type"] | null;
           broker?: string | null;
           created_at?: string;
           household_id: string;
@@ -63,7 +63,7 @@ export type Database = {
         };
         Update: {
           account_number?: string | null;
-          account_type?: string | null;
+          account_type?: Database["public"]["Enums"]["account_type"] | null;
           broker?: string | null;
           created_at?: string;
           household_id?: string;
@@ -482,6 +482,7 @@ export type Database = {
       };
       transactions: {
         Row: {
+          account_id: string | null;
           created_at: string;
           household_id: string;
           id: string;
@@ -494,6 +495,7 @@ export type Database = {
           type: Database["public"]["Enums"]["transaction_type"];
         };
         Insert: {
+          account_id?: string | null;
           created_at?: string;
           household_id: string;
           id?: string;
@@ -506,6 +508,7 @@ export type Database = {
           type: Database["public"]["Enums"]["transaction_type"];
         };
         Update: {
+          account_id?: string | null;
           created_at?: string;
           household_id?: string;
           id?: string;
@@ -518,6 +521,13 @@ export type Database = {
           type?: Database["public"]["Enums"]["transaction_type"];
         };
         Relationships: [
+          {
+            foreignKeyName: "transactions_account_id_fkey";
+            columns: ["account_id"];
+            isOneToOne: false;
+            referencedRelation: "accounts";
+            referencedColumns: ["id"];
+          },
           {
             foreignKeyName: "transactions_household_id_fkey";
             columns: ["household_id"];
@@ -605,10 +615,17 @@ export type Database = {
           isSetofReturn: true;
         };
       };
-      show_limit: { Args: never; Returns: number };
-      show_trgm: { Args: { "": string }; Returns: string[] };
     };
     Enums: {
+      account_type:
+        | "stock"
+        | "savings"
+        | "deposit"
+        | "checking"
+        | "isa"
+        | "pension"
+        | "cma"
+        | "other";
       allocation_category:
         | "equity_kr"
         | "equity_us"
@@ -774,6 +791,16 @@ export const Constants = {
   },
   public: {
     Enums: {
+      account_type: [
+        "stock",
+        "savings",
+        "deposit",
+        "checking",
+        "isa",
+        "pension",
+        "cma",
+        "other",
+      ],
       allocation_category: [
         "equity_kr",
         "equity_us",


### PR DESCRIPTION
## Summary
- `account_type` enum 생성 (stock, savings, deposit, checking, isa, pension, cma, other)
- `accounts.account_type` 컬럼을 text → enum으로 변경
- `transactions.account_id` 컬럼 추가 (nullable, FK to accounts)
- DATABASE.md 문서 업데이트

## Test plan
- [x] 로컬 Supabase DB 리셋 후 마이그레이션 적용 확인
- [x] Supabase 타입 재생성 확인
- [ ] 거래 등록 시 account_id 연결 테스트 (후속 이슈)

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)