### PR TITLE
feat: PortfolioNavSection 구현

### DIFF
--- a/app/(main)/assets/stock/page.tsx
+++ b/app/(main)/assets/stock/page.tsx
@@ -1,3 +1,4 @@
+import { PortfolioNavSection } from "@/components/assets/stock";
 import { StockSummarySection } from "@/components/dashboard/stocks";
 import { PageHeader } from "@/components/layout";
 
@@ -6,6 +7,9 @@ export default function StockMainPage() {
     <>
       <PageHeader title="주식" backHref="/assets" />
       <StockSummarySection />
+      <div className="mt-6">
+        <PortfolioNavSection />
+      </div>
     </>
   );
 }

--- a/components/assets/stock/PortfolioNavSection.tsx
+++ b/components/assets/stock/PortfolioNavSection.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { BarChart3, Receipt, Settings } from "lucide-react";
+import { AnalysisCard } from "@/components/dashboard/AnalysisCard";
+
+const navItems = [
+  {
+    icon: BarChart3,
+    label: "보유 현황",
+    description: "어떤 주식을 갖고 있는지 확인해 보세요",
+    href: "/assets/stock/holdings",
+    color: "text-blue-600",
+    bgColor: "bg-blue-50",
+  },
+  {
+    icon: Receipt,
+    label: "거래 내역",
+    description: "지금까지의 매수·매도 기록을 확인해 보세요",
+    href: "/assets/stock/transactions",
+    color: "text-green-600",
+    bgColor: "bg-green-50",
+  },
+  {
+    icon: Settings,
+    label: "종목 설정",
+    description: "종목을 내 방식대로 관리해 보세요",
+    href: "/assets/stock/settings",
+    color: "text-gray-600",
+    bgColor: "bg-gray-100",
+  },
+];
+
+export function PortfolioNavSection() {
+  return (
+    <section>
+      <h2 className="text-lg font-semibold text-gray-900 mb-4">관리</h2>
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        {navItems.map((item) => (
+          <AnalysisCard key={item.href} {...item} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/assets/stock/index.ts
+++ b/components/assets/stock/index.ts
@@ -1,1 +1,2 @@
+export * from "./PortfolioNavSection";
 export * from "./StockTabNav";

--- a/components/dashboard/stocks/StockSummarySection.tsx
+++ b/components/dashboard/stocks/StockSummarySection.tsx
@@ -176,12 +176,6 @@ export function StockSummarySection() {
           {summary.holdingCount}
           <span className="text-lg font-normal text-gray-500 ml-1">종목</span>
         </p>
-        <Link
-          href="/assets/stock/holdings"
-          className="text-sm text-indigo-600 hover:text-indigo-700 mt-1 inline-block"
-        >
-          전체 보기 →
-        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- 주식 메인 페이지에 보유현황, 거래내역, 종목설정으로 이동하는 카드형 네비게이션 섹션 추가
- 기존 StockSummarySection의 중복 "전체 보기" 링크 제거
- AnalysisCard 패턴 재사용하여 일관된 UI 제공

## Test plan
- [x] `/assets/stock` 페이지에서 PortfolioNavSection 카드 3개 표시 확인
- [x] 보유 현황 카드 클릭 시 `/assets/stock/holdings`로 이동 확인
- [x] 거래 내역 카드 클릭 시 `/assets/stock/transactions`로 이동 확인
- [x] 종목 설정 카드 클릭 시 `/assets/stock/settings`로 이동 확인

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)