### PR TITLE
feat: 국내 MarketTrendSection 구현 (#165)

### DIFF
--- a/app/(main)/assets/stock/page.tsx
+++ b/app/(main)/assets/stock/page.tsx
@@ -1,4 +1,8 @@
-import { MyStockSection, PortfolioNavSection } from "@/components/assets/stock";
+import {
+  MarketTrendSection,
+  MyStockSection,
+  PortfolioNavSection,
+} from "@/components/assets/stock";
 import { StockSummarySection } from "@/components/dashboard/stocks";
 import { PageHeader } from "@/components/layout";
 
@@ -7,6 +11,9 @@ export default function StockMainPage() {
     <>
       <PageHeader title="주식" backHref="/assets" />
       <StockSummarySection />
+      <div className="mt-6">
+        <MarketTrendSection />
+      </div>
       <div className="mt-6">
         <PortfolioNavSection />
       </div>

--- a/app/api/market-trend/domestic/route.ts
+++ b/app/api/market-trend/domestic/route.ts
@@ -1,0 +1,103 @@
+import { NextResponse } from "next/server";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import {
+  getDomesticFluctuationRank,
+  getDomesticVolumeRank,
+} from "@/lib/kis/client";
+import type {
+  KISFluctuationRankOutput,
+  KISVolumeRankOutput,
+} from "@/lib/kis/types";
+import type { DomesticMarketTrendData, MarketTrendItem } from "@/types";
+
+/**
+ * 전일 대비 부호를 변환
+ */
+function parseChangeSign(sign: string): "up" | "down" | "flat" {
+  // 1:상한, 2:상승, 3:보합, 4:하한, 5:하락
+  if (sign === "1" || sign === "2") return "up";
+  if (sign === "4" || sign === "5") return "down";
+  return "flat";
+}
+
+/**
+ * 거래량 순위 응답을 MarketTrendItem으로 변환
+ */
+function mapVolumeRank(item: KISVolumeRankOutput): MarketTrendItem {
+  return {
+    rank: Number.parseInt(item.data_rank, 10),
+    ticker: item.mksc_shrn_iscd,
+    name: item.hts_kor_isnm,
+    price: Number.parseInt(item.stck_prpr, 10),
+    change: Number.parseInt(item.prdy_vrss, 10),
+    changeRate: Number.parseFloat(item.prdy_ctrt),
+    changeSign: parseChangeSign(item.prdy_vrss_sign),
+    volume: Number.parseInt(item.acml_vol, 10),
+  };
+}
+
+/**
+ * 등락률 순위 응답을 MarketTrendItem으로 변환
+ */
+function mapFluctuationRank(item: KISFluctuationRankOutput): MarketTrendItem {
+  return {
+    rank: Number.parseInt(item.data_rank, 10),
+    ticker: item.stck_shrn_iscd,
+    name: item.hts_kor_isnm,
+    price: Number.parseInt(item.stck_prpr, 10),
+    change: Number.parseInt(item.prdy_vrss, 10),
+    changeRate: Number.parseFloat(item.prdy_ctrt),
+    changeSign: parseChangeSign(item.prdy_vrss_sign),
+    volume: Number.parseInt(item.acml_vol, 10),
+  };
+}
+
+/**
+ * 국내 시장 동향 조회
+ * GET /api/market-trend/domestic
+ *
+ * 인증 불필요 (공개 데이터)
+ * 1분 캐싱 (Cache-Control 헤더)
+ */
+export async function GET() {
+  try {
+    // 병렬로 3개 API 호출
+    const [volumeRank, gainers, losers] = await Promise.all([
+      getDomesticVolumeRank("KOSPI", 5),
+      getDomesticFluctuationRank("KOSPI", "up", 5),
+      getDomesticFluctuationRank("KOSPI", "down", 5),
+    ]);
+
+    const result: DomesticMarketTrendData = {
+      volumeRank: volumeRank.map(mapVolumeRank),
+      gainers: gainers.map(mapFluctuationRank),
+      losers: losers.map(mapFluctuationRank),
+      updatedAt: new Date().toISOString(),
+    };
+
+    return NextResponse.json(result, {
+      headers: {
+        "Cache-Control": "public, s-maxage=60, stale-while-revalidate=30",
+      },
+    });
+  } catch (error) {
+    console.error("시장 동향 조회 실패:", error);
+
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    return NextResponse.json(
+      toErrorResponse(
+        new APIError(
+          "MARKET_TREND_ERROR",
+          "시장 동향 조회에 실패했습니다.",
+          500,
+        ),
+      ),
+      { status: 500 },
+    );
+  }
+}

--- a/components/assets/stock/MarketTrendSection.tsx
+++ b/components/assets/stock/MarketTrendSection.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+import { AnimatePresence, motion } from "framer-motion";
+import { BarChart3, TrendingDown, TrendingUp } from "lucide-react";
+import { useEffect, useRef } from "react";
+import { useDomesticMarketTrend } from "@/hooks/use-market-trend";
+import { cn } from "@/lib/utils/cn";
+import { formatCurrency } from "@/lib/utils/format";
+import type { MarketTrendItem } from "@/types";
+
+// ============================================================================
+// 타입 정의
+// ============================================================================
+
+type RankChange = "up" | "down" | "new" | "same";
+
+interface TrendCardProps {
+  title: string;
+  icon: React.ReactNode;
+  items: MarketTrendItem[];
+  type: "volume" | "gainer" | "loser";
+  previousItems: MarketTrendItem[];
+}
+
+// ============================================================================
+// 애니메이션 설정
+// ============================================================================
+
+const itemVariants = {
+  initial: { opacity: 0, y: 20 },
+  animate: { opacity: 1, y: 0 },
+  exit: { opacity: 0, y: -20 },
+};
+
+// ============================================================================
+// 유틸리티 함수
+// ============================================================================
+
+/**
+ * 순위 변동 계산
+ */
+function getRankChange(
+  ticker: string,
+  currentRank: number,
+  previousItems: MarketTrendItem[],
+): RankChange {
+  const prevItem = previousItems.find((item) => item.ticker === ticker);
+
+  if (!prevItem) return "new";
+
+  if (currentRank < prevItem.rank) return "up";
+  if (currentRank > prevItem.rank) return "down";
+  return "same";
+}
+
+/**
+ * 거래량 포맷팅 (만주 단위)
+ */
+function formatVolume(volume: number): string {
+  if (volume >= 10000) {
+    return `${(volume / 10000).toFixed(0)}만주`;
+  }
+  return `${volume.toLocaleString()}주`;
+}
+
+// ============================================================================
+// 컴포넌트
+// ============================================================================
+
+function TrendCard({
+  title,
+  icon,
+  items,
+  type,
+  previousItems,
+}: TrendCardProps) {
+  const isVolume = type === "volume";
+  const isGainer = type === "gainer";
+
+  return (
+    <div className="bg-white rounded-2xl p-5 shadow-sm">
+      <div className="flex items-center gap-2 mb-4">
+        {icon}
+        <h3 className="text-sm font-medium text-gray-900">{title}</h3>
+      </div>
+
+      {items.length === 0 ? (
+        <p className="text-sm text-gray-500 text-center py-4">
+          데이터를 불러올 수 없습니다
+        </p>
+      ) : (
+        <AnimatePresence mode="popLayout">
+          <div className="space-y-2">
+            {items.map((item) => {
+              const rankChange = getRankChange(
+                item.ticker,
+                item.rank,
+                previousItems,
+              );
+
+              return (
+                <motion.div
+                  key={item.ticker}
+                  layout
+                  variants={itemVariants}
+                  initial="initial"
+                  animate="animate"
+                  exit="exit"
+                  transition={{
+                    layout: { type: "spring", stiffness: 300, damping: 30 },
+                    opacity: { duration: 0.2 },
+                    y: { duration: 0.2 },
+                  }}
+                  className={cn(
+                    "flex items-center justify-between py-2 px-2 rounded-lg transition-colors duration-500",
+                    rankChange === "up" && "bg-green-50",
+                    rankChange === "down" && "bg-red-50",
+                    rankChange === "new" && "bg-yellow-50",
+                  )}
+                >
+                  <div className="flex items-center gap-3">
+                    <span className="size-6 rounded-full bg-gray-100 flex items-center justify-center text-xs font-medium text-gray-600">
+                      {item.rank}
+                    </span>
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium text-gray-900 truncate">
+                        {item.name}
+                      </p>
+                      <p className="text-xs text-gray-500">{item.ticker}</p>
+                    </div>
+                  </div>
+                  <div className="text-right flex-shrink-0">
+                    {isVolume ? (
+                      <>
+                        <p className="text-sm font-medium text-gray-900">
+                          {formatVolume(item.volume ?? 0)}
+                        </p>
+                        <p
+                          className={cn(
+                            "text-xs",
+                            item.changeSign === "up"
+                              ? "text-[#F04452]"
+                              : item.changeSign === "down"
+                                ? "text-[#3182F6]"
+                                : "text-gray-500",
+                          )}
+                        >
+                          {item.changeSign === "up" ? "+" : ""}
+                          {item.changeRate.toFixed(2)}%
+                        </p>
+                      </>
+                    ) : (
+                      <>
+                        <p
+                          className={cn(
+                            "text-sm font-medium",
+                            isGainer ? "text-[#F04452]" : "text-[#3182F6]",
+                          )}
+                        >
+                          {isGainer ? "+" : ""}
+                          {item.changeRate.toFixed(2)}%
+                        </p>
+                        <p className="text-xs text-gray-500">
+                          {formatCurrency(item.price, "KRW")}
+                        </p>
+                      </>
+                    )}
+                  </div>
+                </motion.div>
+              );
+            })}
+          </div>
+        </AnimatePresence>
+      )}
+    </div>
+  );
+}
+
+function LoadingSkeleton() {
+  return (
+    <section>
+      <h2 className="text-lg font-semibold text-gray-900 mb-4">
+        국내 시장 동향
+      </h2>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="bg-white rounded-2xl p-5 shadow-sm">
+            <div className="animate-pulse">
+              <div className="h-4 w-24 bg-gray-200 rounded mb-4" />
+              <div className="space-y-3">
+                {[1, 2, 3, 4, 5].map((j) => (
+                  <div key={j} className="h-12 bg-gray-200 rounded" />
+                ))}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function ErrorState() {
+  return (
+    <section>
+      <h2 className="text-lg font-semibold text-gray-900 mb-4">
+        국내 시장 동향
+      </h2>
+      <div className="bg-white rounded-2xl p-6 shadow-sm text-center">
+        <p className="text-gray-500">시장 데이터를 불러올 수 없습니다</p>
+      </div>
+    </section>
+  );
+}
+
+export function MarketTrendSection() {
+  const { data, isLoading, error } = useDomesticMarketTrend();
+
+  // 이전 데이터를 저장하여 순위 변동 감지
+  const prevDataRef = useRef<{
+    volumeRank: MarketTrendItem[];
+    gainers: MarketTrendItem[];
+    losers: MarketTrendItem[];
+  }>({
+    volumeRank: [],
+    gainers: [],
+    losers: [],
+  });
+
+  // 데이터가 업데이트되면 이전 데이터 저장
+  useEffect(() => {
+    if (data) {
+      // 다음 렌더링 사이클에서 비교를 위해 현재 데이터를 저장
+      const timeoutId = setTimeout(() => {
+        prevDataRef.current = {
+          volumeRank: data.volumeRank,
+          gainers: data.gainers,
+          losers: data.losers,
+        };
+      }, 1000); // 애니메이션이 끝난 후 저장
+
+      return () => clearTimeout(timeoutId);
+    }
+  }, [data]);
+
+  if (isLoading) {
+    return <LoadingSkeleton />;
+  }
+
+  if (error || !data) {
+    return <ErrorState />;
+  }
+
+  return (
+    <section>
+      <h2 className="text-lg font-semibold text-gray-900 mb-4">
+        국내 시장 동향
+      </h2>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <TrendCard
+          title="거래량 TOP 5"
+          icon={<BarChart3 className="size-4 text-indigo-600" />}
+          items={data.volumeRank}
+          type="volume"
+          previousItems={prevDataRef.current.volumeRank}
+        />
+        <TrendCard
+          title="급등주 TOP 5"
+          icon={<TrendingUp className="size-4 text-[#F04452]" />}
+          items={data.gainers}
+          type="gainer"
+          previousItems={prevDataRef.current.gainers}
+        />
+        <TrendCard
+          title="급락주 TOP 5"
+          icon={<TrendingDown className="size-4 text-[#3182F6]" />}
+          items={data.losers}
+          type="loser"
+          previousItems={prevDataRef.current.losers}
+        />
+      </div>
+    </section>
+  );
+}

--- a/components/assets/stock/index.ts
+++ b/components/assets/stock/index.ts
@@ -1,3 +1,4 @@
+export * from "./MarketTrendSection";
 export * from "./MyStockSection";
 export * from "./PortfolioNavSection";
 export * from "./StockTabNav";

--- a/hooks/use-market-trend.ts
+++ b/hooks/use-market-trend.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { queries } from "@/lib/queries/keys";
+import type { DomesticMarketTrendData } from "@/types";
+
+interface MarketTrendError {
+  error: {
+    code: string;
+    message: string;
+  };
+}
+
+async function fetchDomesticMarketTrend(): Promise<DomesticMarketTrendData> {
+  const response = await fetch("/api/market-trend/domestic");
+  const json = await response.json();
+
+  if (!response.ok) {
+    const error = json as MarketTrendError;
+    throw new Error(error.error.message);
+  }
+
+  return json as DomesticMarketTrendData;
+}
+
+/**
+ * 국내 시장 동향 조회 훅
+ * - 1분마다 자동 갱신
+ * - 에러 발생 시 자동 갱신 중지
+ * - 30초 staleTime
+ */
+export function useDomesticMarketTrend() {
+  return useQuery({
+    queryKey: queries.marketTrend.domestic.queryKey,
+    queryFn: fetchDomesticMarketTrend,
+    staleTime: 30 * 1000, // 30초
+    retry: 2, // 최대 2회 재시도 (총 3회 시도)
+    refetchInterval: (query) => {
+      // 에러 상태이거나 실패 횟수가 3회 이상이면 자동 갱신 중지
+      if (
+        query.state.status === "error" ||
+        query.state.fetchFailureCount >= 3
+      ) {
+        return false;
+      }
+      return 60 * 1000; // 1분마다 자동 갱신
+    },
+  });
+}

--- a/lib/kis/types.ts
+++ b/lib/kis/types.ts
@@ -159,3 +159,64 @@ export interface StockPriceRow {
   change_rate: number | null;
   fetched_at: string;
 }
+
+// ============================================================================
+// 국내 주식 순위 타입
+// ============================================================================
+
+/**
+ * 국내 주식 거래량 순위 응답
+ * API: /uapi/domestic-stock/v1/quotations/volume-rank
+ */
+export interface KISVolumeRankOutput {
+  hts_kor_isnm: string; // HTS 한글 종목명
+  mksc_shrn_iscd: string; // 유가증권 단축 종목코드
+  data_rank: string; // 데이터 순위
+  stck_prpr: string; // 주식 현재가
+  prdy_vrss_sign: string; // 전일 대비 부호
+  prdy_vrss: string; // 전일 대비
+  prdy_ctrt: string; // 전일 대비율
+  acml_vol: string; // 누적 거래량
+  prdy_vol: string; // 전일 거래량
+  lstn_stcn: string; // 상장 주수
+  avrg_vol: string; // 평균 거래량
+  n_befr_clpr_vrss_prpr_rate: string; // N일전종가대비현재가대비율
+  vol_inrt: string; // 거래량증가율
+  vol_tnrt: string; // 거래량 회전율
+  nday_vol_tnrt: string; // N일 거래량 회전율
+  avrg_tr_pbmn: string; // 평균 거래 대금
+  tr_pbmn_tnrt: string; // 거래대금회전율
+  nday_tr_pbmn_tnrt: string; // N일 거래대금 회전율
+  acml_tr_pbmn: string; // 누적 거래 대금
+}
+
+/**
+ * 국내 주식 등락률 순위 응답
+ * API: /uapi/domestic-stock/v1/ranking/fluctuation
+ */
+export interface KISFluctuationRankOutput {
+  stck_shrn_iscd: string; // 주식 단축 종목코드
+  data_rank: string; // 데이터 순위
+  hts_kor_isnm: string; // HTS 한글 종목명
+  stck_prpr: string; // 주식 현재가
+  prdy_vrss: string; // 전일 대비
+  prdy_vrss_sign: string; // 전일 대비 부호
+  prdy_ctrt: string; // 전일 대비율
+  acml_vol: string; // 누적 거래량
+  stck_hgpr: string; // 주식 최고가
+  hgpr_hour: string; // 최고가 시간
+  acml_hgpr_date: string; // 누적 최고가 일자
+  stck_lwpr: string; // 주식 최저가
+  lwpr_hour: string; // 최저가 시간
+  acml_lwpr_date: string; // 누적 최저가 일자
+  lwpr_vrss_prpr_rate: string; // 최저가 대비 현재가 비율
+  dsgt_date_clpr_vrss_prpr_rate: string; // 지정 일자 종가 대비 현재가 비율
+  cnnt_ascn_dynu: string; // 연속 상승 일수
+  hgpr_vrss_prpr_rate: string; // 최고가 대비 현재가 비율
+  cnnt_down_dynu: string; // 연속 하락 일수
+  oprc_vrss_prpr_sign: string; // 시가2 대비 현재가 부호
+  oprc_vrss_prpr: string; // 시가2 대비 현재가
+  oprc_vrss_prpr_rate: string; // 시가2 대비 현재가 비율
+  prd_rsfl: string; // 기간 등락
+  prd_rsfl_rate: string; // 기간 등락 비율
+}

--- a/lib/queries/keys.ts
+++ b/lib/queries/keys.ts
@@ -39,6 +39,11 @@ export const queries = createQueryKeyStore({
     byRisk: null,
   },
 
+  marketTrend: {
+    all: null,
+    domestic: null,
+  },
+
   household: {
     all: null,
     members: null,

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "framer-motion": "^12.25.0",
     "lucide-react": "^0.562.0",
     "next": "16.1.1",
     "react": "19.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      framer-motion:
+        specifier: ^12.25.0
+        version: 12.25.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       lucide-react:
         specifier: ^0.562.0
         version: 0.562.0(react@19.2.3)
@@ -1371,6 +1374,20 @@ packages:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
 
+  framer-motion@12.25.0:
+    resolution: {integrity: sha512-mlWqd0rApIjeyhTCSNCqPYsUAEhkcUukZxH3ke6KbstBRPcxhEpuIjmiUQvB+1E9xkEm5SpNHBgHCapH/QHTWg==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1558,6 +1575,12 @@ packages:
   minizlib@3.1.0:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
+
+  motion-dom@12.24.11:
+    resolution: {integrity: sha512-DlWOmsXMJrV8lzZyd+LKjG2CXULUs++bkq8GZ2Sr0R0RRhs30K2wtY+LKiTjhmJU3W61HK+rB0GLz6XmPvTA1A==}
+
+  motion-utils@12.24.10:
+    resolution: {integrity: sha512-x5TFgkCIP4pPsRLpKoI86jv/q8t8FQOiM/0E8QKBzfMozWHfkKap2gA1hOki+B5g3IsBNpxbUnfOum1+dgvYww==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -2983,6 +3006,15 @@ snapshots:
     dependencies:
       fetch-blob: 3.2.0
 
+  framer-motion@12.25.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      motion-dom: 12.24.11
+      motion-utils: 12.24.10
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+
   fsevents@2.3.3:
     optional: true
 
@@ -3144,6 +3176,12 @@ snapshots:
   minizlib@3.1.0:
     dependencies:
       minipass: 7.1.2
+
+  motion-dom@12.24.11:
+    dependencies:
+      motion-utils: 12.24.10
+
+  motion-utils@12.24.10: {}
 
   ms@2.1.3: {}
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -161,3 +161,22 @@ export interface ByRiskAnalysisData {
   byRiskLevel: RiskLevelSummary[];
   exchangeRate: number;
 }
+
+// 시장 동향 타입
+export interface MarketTrendItem {
+  rank: number;
+  ticker: string;
+  name: string;
+  price: number;
+  change: number;
+  changeRate: number;
+  changeSign: "up" | "down" | "flat";
+  volume?: number;
+}
+
+export interface DomesticMarketTrendData {
+  volumeRank: MarketTrendItem[];
+  gainers: MarketTrendItem[];
+  losers: MarketTrendItem[];
+  updatedAt: string;
+}


### PR DESCRIPTION
## Summary
- 국내 주식 시장 동향 섹션 구현 (거래량 TOP 5, 급등주 TOP 5, 급락주 TOP 5)
- KIS API 연동 (거래량순위, 등락률순위)
- Framer Motion 애니메이션 (순위 변동 시 슬라이드/페이드 효과)
- 1분마다 자동 갱신, 에러 3회 이상 시 갱신 중지

## Changes
- `lib/kis/types.ts` - KISVolumeRankOutput, KISFluctuationRankOutput 타입 추가
- `lib/kis/client.ts` - getDomesticVolumeRank, getDomesticFluctuationRank 함수 추가
- `types/index.ts` - MarketTrendItem, DomesticMarketTrendData 타입 추가
- `lib/queries/keys.ts` - marketTrend 쿼리 키 추가
- `app/api/market-trend/domestic/route.ts` - 신규 생성
- `hooks/use-market-trend.ts` - 신규 생성
- `components/assets/stock/MarketTrendSection.tsx` - 신규 생성
- `app/(main)/assets/stock/page.tsx` - MarketTrendSection 추가
- `package.json` - framer-motion 의존성 추가

## Test plan
- [x] `/assets/stock` 페이지에서 국내 시장 동향 섹션 표시 확인
- [ ] 3개 카드 (거래량/급등/급락) 레이아웃 확인
- [x] 로딩 스켈레톤 UI 확인
- [ ] 에러 시 메시지 표시 확인
- [x] 1분 자동 갱신 동작 확인 (평일 장중)

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)