### PR TITLE
feat: 계좌 CRUD API 구현

### DIFF
--- a/app/api/accounts/[id]/route.ts
+++ b/app/api/accounts/[id]/route.ts
@@ -1,0 +1,117 @@
+import { NextResponse } from "next/server";
+import { deleteAccount, updateAccount } from "@/lib/api/account";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import { createClient } from "@/lib/supabase/server";
+import { updateAccountSchema } from "@/schemas/account";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * PATCH /api/accounts/[id]
+ * 계좌 수정
+ */
+export async function PATCH(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const supabase = await createClient();
+
+    // 인증 확인
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    // 요청 body 파싱 및 검증
+    const body = await request.json();
+    const result = updateAccountSchema.safeParse(body);
+
+    if (!result.success) {
+      const firstError = result.error.issues[0];
+      throw new APIError(
+        "VALIDATION_ERROR",
+        firstError?.message ?? "유효하지 않은 요청입니다.",
+        400,
+      );
+    }
+
+    const input = result.data;
+
+    // 계좌 수정 (소유권 확인은 updateAccount 내부에서 처리)
+    const account = await updateAccount(supabase, id, user.id, {
+      name: input.name,
+      broker: input.broker,
+      accountNumber: input.accountNumber,
+      accountType: input.accountType,
+      isDefault: input.isDefault,
+      memo: input.memo,
+    });
+
+    return NextResponse.json({ data: account });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    console.error("Account update error:", error);
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "서버 오류가 발생했습니다.",
+        },
+      },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * DELETE /api/accounts/[id]
+ * 계좌 삭제
+ */
+export async function DELETE(_request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const supabase = await createClient();
+
+    // 인증 확인
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    // 계좌 삭제 (소유권 확인은 deleteAccount 내부에서 처리)
+    await deleteAccount(supabase, id, user.id);
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    console.error("Account delete error:", error);
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "서버 오류가 발생했습니다.",
+        },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/accounts/route.ts
+++ b/app/api/accounts/route.ts
@@ -1,0 +1,136 @@
+import { NextResponse } from "next/server";
+import { createAccount, getAccounts } from "@/lib/api/account";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import { getUserHouseholdId } from "@/lib/api/invitation";
+import { createClient } from "@/lib/supabase/server";
+import { createAccountSchema } from "@/schemas/account";
+
+/**
+ * GET /api/accounts
+ * 계좌 목록 조회
+ */
+export async function GET() {
+  try {
+    const supabase = await createClient();
+
+    // 인증 확인
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    // 사용자의 가구 조회
+    const householdId = await getUserHouseholdId(supabase, user.id);
+
+    if (!householdId) {
+      throw new APIError(
+        "HOUSEHOLD_NOT_FOUND",
+        "가구 정보를 찾을 수 없습니다.",
+        404,
+      );
+    }
+
+    // 계좌 목록 조회
+    const accounts = await getAccounts(supabase, householdId);
+
+    return NextResponse.json({ data: accounts });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    console.error("Account list error:", error);
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "서버 오류가 발생했습니다.",
+        },
+      },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * POST /api/accounts
+ * 계좌 생성
+ */
+export async function POST(request: Request) {
+  try {
+    const supabase = await createClient();
+
+    // 인증 확인
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    // 요청 body 파싱 및 검증
+    const body = await request.json();
+    const result = createAccountSchema.safeParse(body);
+
+    if (!result.success) {
+      const firstError = result.error.issues[0];
+      throw new APIError(
+        "VALIDATION_ERROR",
+        firstError?.message ?? "유효하지 않은 요청입니다.",
+        400,
+      );
+    }
+
+    const input = result.data;
+
+    // 사용자의 가구 조회
+    const householdId = await getUserHouseholdId(supabase, user.id);
+
+    if (!householdId) {
+      throw new APIError(
+        "HOUSEHOLD_NOT_FOUND",
+        "가구 정보를 찾을 수 없습니다.",
+        404,
+      );
+    }
+
+    // 계좌 생성
+    const account = await createAccount(supabase, {
+      householdId,
+      ownerId: user.id,
+      name: input.name,
+      broker: input.broker,
+      accountNumber: input.accountNumber,
+      accountType: input.accountType,
+      isDefault: input.isDefault,
+      memo: input.memo,
+    });
+
+    return NextResponse.json({ data: account }, { status: 201 });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    console.error("Account creation error:", error);
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "서버 오류가 발생했습니다.",
+        },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/lib/api/account.ts
+++ b/lib/api/account.ts
@@ -1,0 +1,275 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Account, AccountType, Database } from "@/types";
+import { APIError } from "./error";
+
+export interface CreateAccountParams {
+  householdId: string;
+  ownerId: string;
+  name: string;
+  broker?: string;
+  accountNumber?: string;
+  accountType: AccountType;
+  isDefault?: boolean;
+  memo?: string;
+}
+
+export interface UpdateAccountParams {
+  name?: string;
+  broker?: string | null;
+  accountNumber?: string | null;
+  accountType?: AccountType;
+  isDefault?: boolean;
+  memo?: string | null;
+}
+
+export interface AccountWithOwner {
+  id: string;
+  householdId: string;
+  ownerId: string;
+  ownerName: string;
+  name: string;
+  broker: string | null;
+  accountNumber: string | null;
+  accountType: AccountType | null;
+  isDefault: boolean;
+  memo: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * 가구의 모든 계좌 조회
+ */
+export async function getAccounts(
+  supabase: SupabaseClient<Database>,
+  householdId: string,
+): Promise<AccountWithOwner[]> {
+  const { data, error } = await supabase
+    .from("accounts")
+    .select("*")
+    .eq("household_id", householdId)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    console.error("Accounts fetch error:", error);
+    throw new APIError("ACCOUNT_ERROR", "계좌 목록 조회에 실패했습니다.", 500);
+  }
+
+  // 소유자 정보 조회
+  const ownerIds = [...new Set((data ?? []).map((a) => a.owner_id))];
+  const { data: profiles } = await supabase
+    .from("profiles")
+    .select("id, name")
+    .in("id", ownerIds);
+
+  const ownerMap = new Map((profiles ?? []).map((p) => [p.id, p.name]));
+
+  return (data ?? []).map((account) => ({
+    id: account.id,
+    householdId: account.household_id,
+    ownerId: account.owner_id,
+    ownerName: ownerMap.get(account.owner_id) ?? "알 수 없음",
+    name: account.name,
+    broker: account.broker,
+    accountNumber: account.account_number,
+    accountType: account.account_type,
+    isDefault: account.is_default ?? false,
+    memo: account.memo,
+    createdAt: account.created_at,
+    updatedAt: account.updated_at,
+  }));
+}
+
+/**
+ * 계좌 생성
+ * - is_default가 true이면 동일 소유자의 다른 계좌 is_default를 false로 변경
+ */
+export async function createAccount(
+  supabase: SupabaseClient<Database>,
+  params: CreateAccountParams,
+): Promise<Account> {
+  const {
+    householdId,
+    ownerId,
+    name,
+    broker,
+    accountNumber,
+    accountType,
+    isDefault,
+    memo,
+  } = params;
+
+  // 동일 이름 계좌 중복 확인
+  const { data: existing } = await supabase
+    .from("accounts")
+    .select("id")
+    .eq("household_id", householdId)
+    .eq("owner_id", ownerId)
+    .eq("name", name)
+    .single();
+
+  if (existing) {
+    throw new APIError(
+      "ACCOUNT_DUPLICATE",
+      "동일한 이름의 계좌가 이미 존재합니다.",
+      400,
+    );
+  }
+
+  // is_default가 true이면 동일 소유자의 다른 계좌 is_default를 false로
+  if (isDefault) {
+    await supabase
+      .from("accounts")
+      .update({ is_default: false })
+      .eq("household_id", householdId)
+      .eq("owner_id", ownerId);
+  }
+
+  const { data, error } = await supabase
+    .from("accounts")
+    .insert({
+      household_id: householdId,
+      owner_id: ownerId,
+      name,
+      broker: broker || null,
+      account_number: accountNumber || null,
+      account_type: accountType,
+      is_default: isDefault ?? false,
+      memo: memo || null,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    console.error("Account insert error:", error);
+    throw new APIError("ACCOUNT_ERROR", "계좌 생성에 실패했습니다.", 500);
+  }
+
+  return data;
+}
+
+/**
+ * 계좌 수정
+ * - 소유권 확인 필수
+ * - is_default가 true이면 동일 소유자의 다른 계좌 is_default를 false로 변경
+ */
+export async function updateAccount(
+  supabase: SupabaseClient<Database>,
+  accountId: string,
+  ownerId: string,
+  params: UpdateAccountParams,
+): Promise<Account> {
+  // 계좌 존재 및 소유권 확인
+  const { data: existingAccount } = await supabase
+    .from("accounts")
+    .select("*")
+    .eq("id", accountId)
+    .single();
+
+  if (!existingAccount) {
+    throw new APIError("ACCOUNT_NOT_FOUND", "계좌를 찾을 수 없습니다.", 404);
+  }
+
+  if (existingAccount.owner_id !== ownerId) {
+    throw new APIError(
+      "ACCOUNT_FORBIDDEN",
+      "본인의 계좌만 수정할 수 있습니다.",
+      403,
+    );
+  }
+
+  // 이름 변경 시 중복 확인
+  if (params.name && params.name !== existingAccount.name) {
+    const { data: duplicate } = await supabase
+      .from("accounts")
+      .select("id")
+      .eq("household_id", existingAccount.household_id)
+      .eq("owner_id", ownerId)
+      .eq("name", params.name)
+      .single();
+
+    if (duplicate) {
+      throw new APIError(
+        "ACCOUNT_DUPLICATE",
+        "동일한 이름의 계좌가 이미 존재합니다.",
+        400,
+      );
+    }
+  }
+
+  // is_default가 true이면 동일 소유자의 다른 계좌 is_default를 false로
+  if (params.isDefault === true) {
+    await supabase
+      .from("accounts")
+      .update({ is_default: false })
+      .eq("household_id", existingAccount.household_id)
+      .eq("owner_id", ownerId)
+      .neq("id", accountId);
+  }
+
+  const { data, error } = await supabase
+    .from("accounts")
+    .update({
+      ...(params.name !== undefined && { name: params.name }),
+      ...(params.broker !== undefined && { broker: params.broker }),
+      ...(params.accountNumber !== undefined && {
+        account_number: params.accountNumber,
+      }),
+      ...(params.accountType !== undefined && {
+        account_type: params.accountType,
+      }),
+      ...(params.isDefault !== undefined && { is_default: params.isDefault }),
+      ...(params.memo !== undefined && { memo: params.memo }),
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", accountId)
+    .select()
+    .single();
+
+  if (error) {
+    console.error("Account update error:", error);
+    throw new APIError("ACCOUNT_ERROR", "계좌 수정에 실패했습니다.", 500);
+  }
+
+  return data;
+}
+
+/**
+ * 계좌 삭제
+ * - 소유권 확인 필수
+ * - 연결된 거래의 account_id는 DB cascade로 null 처리
+ */
+export async function deleteAccount(
+  supabase: SupabaseClient<Database>,
+  accountId: string,
+  ownerId: string,
+): Promise<void> {
+  // 계좌 존재 및 소유권 확인
+  const { data: existingAccount } = await supabase
+    .from("accounts")
+    .select("id, owner_id")
+    .eq("id", accountId)
+    .single();
+
+  if (!existingAccount) {
+    throw new APIError("ACCOUNT_NOT_FOUND", "계좌를 찾을 수 없습니다.", 404);
+  }
+
+  if (existingAccount.owner_id !== ownerId) {
+    throw new APIError(
+      "ACCOUNT_FORBIDDEN",
+      "본인의 계좌만 삭제할 수 있습니다.",
+      403,
+    );
+  }
+
+  const { error } = await supabase
+    .from("accounts")
+    .delete()
+    .eq("id", accountId);
+
+  if (error) {
+    console.error("Account delete error:", error);
+    throw new APIError("ACCOUNT_ERROR", "계좌 삭제에 실패했습니다.", 500);
+  }
+}

--- a/schemas/account.ts
+++ b/schemas/account.ts
@@ -1,0 +1,74 @@
+import { z } from "zod";
+
+/**
+ * 계좌 유형 enum 값
+ */
+const accountTypeValues = [
+  "stock",
+  "savings",
+  "deposit",
+  "checking",
+  "isa",
+  "pension",
+  "cma",
+  "other",
+] as const;
+
+/**
+ * 계좌 생성 요청 스키마
+ */
+export const createAccountSchema = z.object({
+  name: z
+    .string()
+    .min(1, "계좌명은 필수입니다.")
+    .max(50, "계좌명은 50자 이내여야 합니다."),
+  broker: z
+    .string()
+    .max(50, "증권사/은행명은 50자 이내여야 합니다.")
+    .optional(),
+  accountNumber: z
+    .string()
+    .max(50, "계좌번호는 50자 이내여야 합니다.")
+    .optional(),
+  accountType: z.enum(accountTypeValues, {
+    message: "계좌 유형을 선택해주세요.",
+  }),
+  isDefault: z.boolean().optional().default(false),
+  memo: z.string().max(500, "메모는 500자 이내여야 합니다.").optional(),
+});
+
+export type CreateAccountInput = z.infer<typeof createAccountSchema>;
+
+/**
+ * 계좌 수정 요청 스키마
+ */
+export const updateAccountSchema = z.object({
+  name: z
+    .string()
+    .min(1, "계좌명은 필수입니다.")
+    .max(50, "계좌명은 50자 이내여야 합니다.")
+    .optional(),
+  broker: z
+    .string()
+    .max(50, "증권사/은행명은 50자 이내여야 합니다.")
+    .nullable()
+    .optional(),
+  accountNumber: z
+    .string()
+    .max(50, "계좌번호는 50자 이내여야 합니다.")
+    .nullable()
+    .optional(),
+  accountType: z
+    .enum(accountTypeValues, {
+      message: "유효한 계좌 유형이 아닙니다.",
+    })
+    .optional(),
+  isDefault: z.boolean().optional(),
+  memo: z
+    .string()
+    .max(500, "메모는 500자 이내여야 합니다.")
+    .nullable()
+    .optional(),
+});
+
+export type UpdateAccountInput = z.infer<typeof updateAccountSchema>;

--- a/types/index.ts
+++ b/types/index.ts
@@ -13,6 +13,7 @@ export type Database = SupabaseDatabase;
 export type Json = SupabaseJson;
 
 // Supabase Enum 타입 (편의를 위해)
+export type AccountType = Enums<"account_type">;
 export type AssetType = Enums<"asset_type">;
 export type CurrencyType = Enums<"currency_type">;
 export type MarketType = Enums<"market_type">;
@@ -23,6 +24,7 @@ export type UserRole = Enums<"user_role">;
 export type AllocationCategory = Enums<"allocation_category">;
 
 // 테이블 Row 타입 (편의를 위해)
+export type Account = Tables<"accounts">;
 export type Profile = Tables<"profiles">;
 export type Household = Tables<"households">;
 export type HouseholdMember = Tables<"household_members">;
@@ -42,6 +44,7 @@ export type Holding = Tables<"holdings">;
 export type StockPrice = Tables<"stock_prices">;
 
 // Insert 타입 (편의를 위해)
+export type AccountInsert = TablesInsert<"accounts">;
 export type TransactionInsert = TablesInsert<"transactions">;
 export type HouseholdStockSettingInsert =
   TablesInsert<"household_stock_settings">;
@@ -49,6 +52,7 @@ export type TagInsert = TablesInsert<"tags">;
 export type HoldingTagInsert = TablesInsert<"holding_tags">;
 
 // Update 타입 (편의를 위해)
+export type AccountUpdate = TablesUpdate<"accounts">;
 export type TransactionUpdate = TablesUpdate<"transactions">;
 export type HouseholdStockSettingUpdate =
   TablesUpdate<"household_stock_settings">;


### PR DESCRIPTION
## Summary
- 계좌 CRUD API 엔드포인트 구현 (GET, POST, PATCH, DELETE)
- Zod 스키마 기반 입력값 검증
- 소유권 기반 접근 제어 및 기본 계좌 자동 관리

## API Endpoints

| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/accounts` | 가구의 계좌 목록 조회 |
| POST | `/api/accounts` | 계좌 생성 |
| PATCH | `/api/accounts/[id]` | 계좌 수정 |
| DELETE | `/api/accounts/[id]` | 계좌 삭제 |

## Changes
- `schemas/account.ts`: createAccountSchema, updateAccountSchema
- `lib/api/account.ts`: getAccounts, createAccount, updateAccount, deleteAccount
- `app/api/accounts/route.ts`: GET, POST
- `app/api/accounts/[id]/route.ts`: PATCH, DELETE
- `types/index.ts`: AccountType, Account, AccountInsert, AccountUpdate 타입 추가

## Test plan
- [x] 타입 체크 통과 확인
- [x] 빌드 성공 확인
- [ ] API 엔드포인트 테스트 (Postman/curl)

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)