### PR TITLE
feat: 국내 휴장일 조회 및 캐싱 (#176)

### DIFF
--- a/.github/workflows/sync-holiday.yml
+++ b/.github/workflows/sync-holiday.yml
@@ -1,0 +1,39 @@
+name: Sync Market Holidays
+
+on:
+  schedule:
+    # 매주 월요일 00:00 KST (일요일 15:00 UTC)
+    - cron: '0 15 * * 0'
+  workflow_dispatch:
+    # 수동 실행 가능
+
+env:
+  SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+  SUPABASE_SECRET_KEY: ${{ secrets.SUPABASE_SECRET_KEY }}
+  KIS_BASE_URL: ${{ secrets.KIS_BASE_URL }}
+  KIS_APP_KEY: ${{ secrets.KIS_APP_KEY }}
+  KIS_APP_SECRET: ${{ secrets.KIS_APP_SECRET }}
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Sync market holidays
+        run: pnpm sync:holiday

--- a/app/api/market-holiday/kr/route.ts
+++ b/app/api/market-holiday/kr/route.ts
@@ -1,0 +1,163 @@
+import { NextResponse } from "next/server";
+import type { MarketHolidayCache, MarketHolidayItem } from "@/lib/kis/types";
+import { getSystemConfigClient } from "@/lib/supabase/system-config-client";
+
+const HOLIDAY_KEY = "market_holidays_kr";
+
+export interface MarketHolidayResponse {
+  isHoliday: boolean;
+  todayDate: string; // YYYYMMDD
+  holidayInfo?: MarketHolidayItem;
+  nextTradingDate?: string; // YYYYMMDD
+  updatedAt: string;
+}
+
+/**
+ * 오늘 날짜를 YYYYMMDD 형식으로 반환
+ */
+function formatToday(): string {
+  return new Date().toISOString().slice(0, 10).replace(/-/g, "");
+}
+
+/**
+ * 다음 거래일 찾기
+ */
+function findNextTradingDate(
+  today: string,
+  holidays: MarketHolidayItem[],
+): string | undefined {
+  const holidaySet = new Set(holidays.map((h) => h.date));
+
+  // 오늘부터 최대 30일 후까지 검색
+  const todayDate = parseDate(today);
+
+  for (let i = 1; i <= 30; i++) {
+    const nextDate = new Date(todayDate);
+    nextDate.setDate(nextDate.getDate() + i);
+
+    const dateStr = formatDateToYYYYMMDD(nextDate);
+    const dayOfWeek = nextDate.getDay();
+
+    // 주말이 아니고 휴장일 목록에 없으면 거래일
+    if (dayOfWeek !== 0 && dayOfWeek !== 6 && !holidaySet.has(dateStr)) {
+      return dateStr;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * YYYYMMDD 문자열을 Date로 파싱
+ */
+function parseDate(dateStr: string): Date {
+  const year = Number.parseInt(dateStr.slice(0, 4), 10);
+  const month = Number.parseInt(dateStr.slice(4, 6), 10) - 1;
+  const day = Number.parseInt(dateStr.slice(6, 8), 10);
+  return new Date(year, month, day);
+}
+
+/**
+ * Date를 YYYYMMDD 형식으로 변환
+ */
+function formatDateToYYYYMMDD(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}${month}${day}`;
+}
+
+/**
+ * 국내 시장 휴장일 조회
+ * GET /api/market-holiday/kr
+ *
+ * 응답:
+ * - isHoliday: 오늘이 휴장일인지 여부
+ * - todayDate: 오늘 날짜 (YYYYMMDD)
+ * - holidayInfo: 휴장일 정보 (휴장일인 경우)
+ * - nextTradingDate: 다음 거래일 (휴장일인 경우)
+ * - updatedAt: 마지막 동기화 시각
+ */
+export async function GET() {
+  try {
+    const supabase = getSystemConfigClient();
+
+    const { data, error } = await supabase
+      .from("system_config")
+      .select("value, updated_at")
+      .eq("key", HOLIDAY_KEY)
+      .single();
+
+    const today = formatToday();
+
+    if (error || !data) {
+      // 캐시 미스 시 휴장일 아님으로 처리
+      return NextResponse.json<MarketHolidayResponse>(
+        {
+          isHoliday: false,
+          todayDate: today,
+          updatedAt: new Date().toISOString(),
+        },
+        {
+          headers: {
+            "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=60",
+          },
+        },
+      );
+    }
+
+    const cache = data.value as unknown as MarketHolidayCache;
+
+    // 오늘이 휴장일인지 확인
+    const todayHoliday = cache.holidays.find((h) => h.date === today);
+
+    if (todayHoliday) {
+      // 다음 거래일 계산
+      const nextTradingDate = findNextTradingDate(today, cache.holidays);
+
+      return NextResponse.json<MarketHolidayResponse>(
+        {
+          isHoliday: true,
+          todayDate: today,
+          holidayInfo: todayHoliday,
+          nextTradingDate,
+          updatedAt: cache.syncedAt,
+        },
+        {
+          headers: {
+            "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=60",
+          },
+        },
+      );
+    }
+
+    return NextResponse.json<MarketHolidayResponse>(
+      {
+        isHoliday: false,
+        todayDate: today,
+        updatedAt: cache.syncedAt,
+      },
+      {
+        headers: {
+          "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=60",
+        },
+      },
+    );
+  } catch (error) {
+    console.error("휴장일 조회 실패:", error);
+
+    // 에러 시에도 휴장일 아님으로 처리 (서비스 연속성)
+    return NextResponse.json<MarketHolidayResponse>(
+      {
+        isHoliday: false,
+        todayDate: formatToday(),
+        updatedAt: new Date().toISOString(),
+      },
+      {
+        headers: {
+          "Cache-Control": "public, s-maxage=60",
+        },
+      },
+    );
+  }
+}

--- a/hooks/use-market-holiday.ts
+++ b/hooks/use-market-holiday.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import type { MarketHolidayResponse } from "@/app/api/market-holiday/kr/route";
+import { queries } from "@/lib/queries/keys";
+
+/**
+ * 국내 시장 휴장일 API 호출
+ */
+async function fetchMarketHoliday(): Promise<MarketHolidayResponse> {
+  const response = await fetch("/api/market-holiday/kr");
+
+  if (!response.ok) {
+    throw new Error("휴장일 조회 실패");
+  }
+
+  return response.json();
+}
+
+/**
+ * 국내 시장 휴장일 조회 훅
+ *
+ * - 1시간 staleTime (휴장일은 자주 변경되지 않음)
+ * - 에러 시 자동 갱신 중지 (retry: 1)
+ */
+export function useMarketHoliday() {
+  return useQuery({
+    queryKey: queries.marketTrend.holiday.queryKey,
+    queryFn: fetchMarketHoliday,
+    staleTime: 60 * 60 * 1000, // 1시간
+    retry: 1,
+  });
+}

--- a/hooks/use-market-trend.ts
+++ b/hooks/use-market-trend.ts
@@ -23,16 +23,27 @@ async function fetchDomesticMarketTrend(): Promise<DomesticMarketTrendData> {
   return json as DomesticMarketTrendData;
 }
 
+interface UseDomesticMarketTrendOptions {
+  enabled?: boolean;
+}
+
 /**
  * 국내 시장 동향 조회 훅
  * - 1분마다 자동 갱신
  * - 에러 발생 시 자동 갱신 중지
  * - 30초 staleTime
+ *
+ * @param options.enabled 쿼리 활성화 여부 (기본값: true)
  */
-export function useDomesticMarketTrend() {
+export function useDomesticMarketTrend(
+  options: UseDomesticMarketTrendOptions = {},
+) {
+  const { enabled = true } = options;
+
   return useQuery({
     queryKey: queries.marketTrend.domestic.queryKey,
     queryFn: fetchDomesticMarketTrend,
+    enabled,
     staleTime: 30 * 1000, // 30초
     retry: 2, // 최대 2회 재시도 (총 3회 시도)
     refetchInterval: (query) => {

--- a/lib/kis/types.ts
+++ b/lib/kis/types.ts
@@ -220,3 +220,37 @@ export interface KISFluctuationRankOutput {
   prd_rsfl: string; // 기간 등락
   prd_rsfl_rate: string; // 기간 등락 비율
 }
+
+// ============================================================================
+// 휴장일 조회 타입
+// ============================================================================
+
+/**
+ * 국내 주식 휴장일 조회 응답
+ * API: /uapi/domestic-stock/v1/quotations/chk-holiday
+ * tr_id: CTCA0903R
+ */
+export interface KISHolidayOutput {
+  bass_dt: string; // 기준일자 (YYYYMMDD)
+  wday_dvsn_cd: string; // 요일구분코드 (01:일 ~ 07:토)
+  bzdy_yn: string; // 영업일여부 (Y/N)
+  tr_day_yn: string; // 거래일여부 (Y/N)
+  opnd_yn: string; // 개장일여부 (Y/N)
+  sttl_day_yn: string; // 결제일여부 (Y/N)
+}
+
+/**
+ * 휴장일 캐시 데이터 (system_config 저장용)
+ */
+export interface MarketHolidayCache {
+  holidays: MarketHolidayItem[];
+  syncedAt: string; // ISO8601
+}
+
+/**
+ * 휴장일 항목
+ */
+export interface MarketHolidayItem {
+  date: string; // YYYYMMDD
+  dayOfWeek: string; // 요일 (월, 화, ...)
+}

--- a/lib/queries/keys.ts
+++ b/lib/queries/keys.ts
@@ -42,6 +42,7 @@ export const queries = createQueryKeyStore({
   marketTrend: {
     all: null,
     domestic: null,
+    holiday: null,
   },
 
   household: {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "supabase:types": "supabase gen types typescript --local > types/supabase.ts",
     "sync:stocks": "tsx scripts/sync-stock-master.ts",
     "sync:exchange-rates": "tsx scripts/sync-exchange-rates.ts",
+    "sync:holiday": "tsx scripts/sync-holiday.ts",
     "prepare": "husky"
   },
   "dependencies": {

--- a/scripts/sync-holiday.ts
+++ b/scripts/sync-holiday.ts
@@ -1,0 +1,111 @@
+/**
+ * KIS API에서 휴장일 데이터를 조회하여 system_config에 저장하는 스크립트
+ *
+ * 사용법:
+ *   pnpm sync:holiday
+ *
+ * 환경변수:
+ *   SUPABASE_URL 또는 NEXT_PUBLIC_SUPABASE_URL
+ *   SUPABASE_SECRET_KEY
+ *   KIS_BASE_URL
+ *   KIS_APP_KEY
+ *   KIS_APP_SECRET
+ */
+
+import { config } from "dotenv";
+
+// 로컬 환경에서 .env.local 로드 (GitHub Actions에서는 이미 환경변수가 설정됨)
+config({ path: ".env.local" });
+
+import type {
+  KISHolidayOutput,
+  MarketHolidayCache,
+  MarketHolidayItem,
+} from "@/lib/kis/types";
+import type { Json } from "@/types/supabase";
+
+// system_config 키
+const HOLIDAY_KEY = "market_holidays_kr";
+
+// 요일 코드 → 한글 변환
+const DAY_OF_WEEK_MAP: Record<string, string> = {
+  "01": "일",
+  "02": "월",
+  "03": "화",
+  "04": "수",
+  "05": "목",
+  "06": "금",
+  "07": "토",
+};
+
+/**
+ * 휴장일 필터링 (개장일이 아닌 날만)
+ */
+function filterHolidays(items: KISHolidayOutput[]): MarketHolidayItem[] {
+  return items
+    .filter((item) => item.opnd_yn === "N")
+    .map((item) => ({
+      date: item.bass_dt,
+      dayOfWeek: DAY_OF_WEEK_MAP[item.wday_dvsn_cd] ?? "",
+    }));
+}
+
+/**
+ * 메인 함수
+ */
+async function main() {
+  console.log("=== 휴장일 동기화 시작 ===\n");
+
+  // dotenv 로드 후 dynamic import (환경변수 의존 모듈)
+  const { getDomesticHolidays } = await import("@/lib/kis/client");
+  const { getSystemConfigClient } = await import(
+    "@/lib/supabase/system-config-client"
+  );
+
+  // 오늘 날짜 (YYYYMMDD)
+  const today = new Date().toISOString().slice(0, 10).replace(/-/g, "");
+  console.log(`[기준일자] ${today}\n`);
+
+  console.log("[KIS API 휴장일 조회]");
+  const rawItems = await getDomesticHolidays(today);
+  console.log(`  조회된 일자: ${rawItems.length}개`);
+
+  const holidays = filterHolidays(rawItems);
+  console.log(`  휴장일: ${holidays.length}개`);
+
+  if (holidays.length > 0) {
+    console.log("  휴장일 목록:");
+    for (const h of holidays) {
+      console.log(`    - ${h.date} (${h.dayOfWeek})`);
+    }
+  }
+
+  console.log("\n[Supabase UPSERT]");
+  const supabase = getSystemConfigClient();
+
+  const cache: MarketHolidayCache = {
+    holidays,
+    syncedAt: new Date().toISOString(),
+  };
+
+  const { error } = await supabase.from("system_config").upsert(
+    {
+      key: HOLIDAY_KEY,
+      value: cache as unknown as Json,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: "key" },
+  );
+
+  if (error) {
+    throw new Error(`UPSERT 오류: ${error.message}`);
+  }
+
+  console.log("  UPSERT 완료");
+  console.log("\n=== 휴장일 동기화 완료 ===");
+}
+
+main().catch((error) => {
+  console.error("동기화 실패:", error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- KIS API를 활용한 국내 휴장일 조회 기능 추가
- 매주 월요일 00:00 KST GitHub Actions 크론잡으로 휴장일 데이터 동기화
- MarketTrendSection에서 휴장일일 때 안내 메시지 표시

## Changes
- `lib/kis/types.ts` - 휴장일 관련 타입 추가
- `lib/kis/client.ts` - `getDomesticHolidays()` 함수 추가
- `scripts/sync-holiday.ts` - 휴장일 동기화 스크립트
- `.github/workflows/sync-holiday.yml` - 크론잡 워크플로우
- `app/api/market-holiday/kr/route.ts` - 휴장일 조회 API
- `hooks/use-market-holiday.ts` - React Query 훅
- `components/assets/stock/MarketTrendSection.tsx` - 휴장일 UI

## Test plan
- [x] `pnpm sync:holiday` 실행하여 휴장일 동기화 확인
- [x] `/api/market-holiday/kr` API 응답 확인
- [x] 휴장일 데이터가 있을 때 MarketTrendSection UI 확인
- [x] GitHub Secrets에 KIS 환경변수 등록 (KIS_BASE_URL, KIS_APP_KEY, KIS_APP_SECRET)

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)