### PR TITLE
#110 [DB] holdings View 수정 - 계좌별 집계 지원

### DIFF
--- a/supabase/migrations/20260110135000_update_holdings_view_with_account.sql
+++ b/supabase/migrations/20260110135000_update_holdings_view_with_account.sql
@@ -1,0 +1,52 @@
+-- holdings View 수정 - 계좌별 집계 지원
+-- 이슈: #110
+
+-- 기존 View 삭제
+drop view if exists public.holdings;
+
+-- 계좌 정보가 포함된 새 View 생성
+create view public.holdings
+with (security_invoker = on) as
+select
+  t.household_id,
+  t.owner_id,
+  t.account_id,
+  a.name as account_name,
+  t.ticker,
+  s.name,
+  s.asset_type,
+  s.market,
+  s.currency,
+  s.risk_level,
+  -- 현재 보유 수량
+  sum(case when t.type = 'buy' then t.quantity else -t.quantity end) as quantity,
+  -- 평균 매수가 (매수 거래만 계산)
+  case
+    when sum(case when t.type = 'buy' then t.quantity else 0 end) > 0
+    then sum(case when t.type = 'buy' then t.quantity * t.price else 0 end) /
+         sum(case when t.type = 'buy' then t.quantity else 0 end)
+    else 0
+  end as avg_price,
+  -- 총 매수 금액
+  sum(case when t.type = 'buy' then t.quantity * t.price else 0 end) as total_invested,
+  -- 최초 거래일
+  min(t.transacted_at) as first_transaction_at,
+  -- 최근 거래일
+  max(t.transacted_at) as last_transaction_at
+from public.transactions t
+join public.household_stock_settings s
+  on t.household_id = s.household_id and t.ticker = s.ticker
+left join public.accounts a
+  on t.account_id = a.id
+group by
+  t.household_id,
+  t.owner_id,
+  t.account_id,
+  a.name,
+  t.ticker,
+  s.name,
+  s.asset_type,
+  s.market,
+  s.currency,
+  s.risk_level
+having sum(case when t.type = 'buy' then t.quantity else -t.quantity end) > 0;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -548,6 +548,8 @@ export type Database = {
     Views: {
       holdings: {
         Row: {
+          account_id: string | null;
+          account_name: string | null;
           asset_type: Database["public"]["Enums"]["asset_type"] | null;
           avg_price: number | null;
           currency: Database["public"]["Enums"]["currency_type"] | null;
@@ -563,6 +565,13 @@ export type Database = {
           total_invested: number | null;
         };
         Relationships: [
+          {
+            foreignKeyName: "transactions_account_id_fkey";
+            columns: ["account_id"];
+            isOneToOne: false;
+            referencedRelation: "accounts";
+            referencedColumns: ["id"];
+          },
           {
             foreignKeyName: "transactions_household_id_fkey";
             columns: ["household_id"];


### PR DESCRIPTION
## Summary
- holdings View를 수정하여 계좌별로 보유 현황을 집계할 수 있도록 변경
- GROUP BY에 `account_id` 추가, `account_name` 컬럼 추가 (LEFT JOIN)
- Supabase 타입 재생성

## Changes
- `supabase/migrations/20260110135000_update_holdings_view_with_account.sql` - View 재생성
- `types/supabase.ts` - 타입 자동 생성

## Test plan
- [x] `pnpm supabase db reset` 성공
- [x] `pnpm supabase:types` 성공
- [x] `pnpm type-check` 성공

Closes #110

🤖 Generated with [Claude Code](https://claude.ai/code)