### PR TITLE
feat: KIS 해외주식 시장 동향 API 구현

### DIFF
--- a/app/api/market-trend/overseas/news/route.ts
+++ b/app/api/market-trend/overseas/news/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from "next/server";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import { getOverseasNews } from "@/lib/kis/client";
+import type { KISOverseasNewsOutput } from "@/lib/kis/types";
+import type { OverseasNewsData, OverseasNewsItem } from "@/types";
+
+/**
+ * 뉴스 응답을 OverseasNewsItem으로 변환
+ */
+function mapNews(item: KISOverseasNewsOutput): OverseasNewsItem {
+  // 날짜/시간 포맷팅: YYYYMMDD + HHMMSS -> ISO8601
+  const date = item.data_dt;
+  const time = item.data_tm;
+  const datetime =
+    date && time
+      ? `${date.slice(0, 4)}-${date.slice(4, 6)}-${date.slice(6, 8)}T${time.slice(0, 2)}:${time.slice(2, 4)}:${time.slice(4, 6)}`
+      : new Date().toISOString();
+
+  return {
+    newsKey: item.news_key,
+    title: item.title,
+    source: item.source,
+    datetime,
+    ticker: item.symb || undefined,
+    tickerName: item.symb_name || undefined,
+  };
+}
+
+/**
+ * 해외뉴스 조회
+ * GET /api/market-trend/overseas/news
+ *
+ * 인증 불필요 (공개 데이터)
+ * 5분 캐싱 (Cache-Control 헤더)
+ */
+export async function GET() {
+  try {
+    const news = await getOverseasNews(10);
+
+    const result: OverseasNewsData = {
+      news: news.map(mapNews),
+      updatedAt: new Date().toISOString(),
+    };
+
+    return NextResponse.json(result, {
+      headers: {
+        "Cache-Control": "public, s-maxage=300, stale-while-revalidate=60",
+      },
+    });
+  } catch (error) {
+    console.error("해외뉴스 조회 실패:", error);
+
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    return NextResponse.json(
+      toErrorResponse(
+        new APIError(
+          "OVERSEAS_NEWS_ERROR",
+          "해외뉴스 조회에 실패했습니다.",
+          500,
+        ),
+      ),
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/market-trend/overseas/route.ts
+++ b/app/api/market-trend/overseas/route.ts
@@ -1,0 +1,111 @@
+import { NextResponse } from "next/server";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import {
+  getOverseasPriceFluct,
+  getOverseasVolumeSurge,
+} from "@/lib/kis/client";
+import type {
+  KISOverseasPriceFluctOutput,
+  KISOverseasVolumeSurgeOutput,
+} from "@/lib/kis/types";
+import type { MarketTrendItem, OverseasMarketTrendData } from "@/types";
+
+/**
+ * 해외주식 대비 부호를 변환
+ */
+function parseChangeSign(sign: string): "up" | "down" | "flat" {
+  // 1:상한, 2:상승, 3:보합, 4:하한, 5:하락
+  if (sign === "1" || sign === "2") return "up";
+  if (sign === "4" || sign === "5") return "down";
+  return "flat";
+}
+
+/**
+ * 가격급등락 응답을 MarketTrendItem으로 변환
+ */
+function mapPriceFluct(
+  item: KISOverseasPriceFluctOutput,
+  rank: number,
+): MarketTrendItem {
+  return {
+    rank,
+    ticker: item.symb,
+    name: item.knam || item.enam,
+    price: Number.parseFloat(item.last),
+    change: Number.parseFloat(item.diff),
+    changeRate: Number.parseFloat(item.rate),
+    changeSign: parseChangeSign(item.sign),
+    volume: Number.parseInt(item.tvol, 10),
+  };
+}
+
+/**
+ * 거래량급증 응답을 MarketTrendItem으로 변환
+ */
+function mapVolumeSurge(
+  item: KISOverseasVolumeSurgeOutput,
+  rank: number,
+): MarketTrendItem {
+  return {
+    rank,
+    ticker: item.symb,
+    name: item.knam || item.enam,
+    price: Number.parseFloat(item.last),
+    change: Number.parseFloat(item.diff),
+    changeRate: Number.parseFloat(item.rate),
+    changeSign: parseChangeSign(item.sign),
+    volume: Number.parseInt(item.tvol, 10),
+  };
+}
+
+/**
+ * 해외주식 시장 동향 조회
+ * GET /api/market-trend/overseas
+ *
+ * 인증 불필요 (공개 데이터)
+ * 1분 캐싱 (Cache-Control 헤더)
+ */
+export async function GET() {
+  try {
+    // 병렬로 3개 API 호출 (NASDAQ 기준)
+    const [volumeSurge, gainers, losers] = await Promise.all([
+      getOverseasVolumeSurge("NAS", 5),
+      getOverseasPriceFluct("NAS", "up", 5),
+      getOverseasPriceFluct("NAS", "down", 5),
+    ]);
+
+    const result: OverseasMarketTrendData = {
+      volumeSurge: volumeSurge.map((item, idx) =>
+        mapVolumeSurge(item, idx + 1),
+      ),
+      gainers: gainers.map((item, idx) => mapPriceFluct(item, idx + 1)),
+      losers: losers.map((item, idx) => mapPriceFluct(item, idx + 1)),
+      updatedAt: new Date().toISOString(),
+    };
+
+    return NextResponse.json(result, {
+      headers: {
+        "Cache-Control": "public, s-maxage=60, stale-while-revalidate=30",
+      },
+    });
+  } catch (error) {
+    console.error("해외주식 시장 동향 조회 실패:", error);
+
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    return NextResponse.json(
+      toErrorResponse(
+        new APIError(
+          "OVERSEAS_MARKET_TREND_ERROR",
+          "해외주식 시장 동향 조회에 실패했습니다.",
+          500,
+        ),
+      ),
+      { status: 500 },
+    );
+  }
+}

--- a/lib/kis/types.ts
+++ b/lib/kis/types.ts
@@ -222,6 +222,75 @@ export interface KISFluctuationRankOutput {
 }
 
 // ============================================================================
+// 해외주식 순위 타입
+// ============================================================================
+
+/**
+ * 해외주식 가격급등락 응답
+ * API: /uapi/overseas-stock/v1/ranking/price-fluct
+ */
+export interface KISOverseasPriceFluctOutput {
+  rsym: string; // 실시간조회심볼
+  excd: string; // 거래소코드
+  symb: string; // 종목코드
+  knam: string; // 종목명
+  last: string; // 현재가
+  sign: string; // 기호
+  diff: string; // 대비
+  rate: string; // 등락율
+  tvol: string; // 거래량
+  pask: string; // 매도호가
+  pbid: string; // 매수호가
+  n_base: string; // 기준가격
+  n_diff: string; // 기준가격대비
+  n_rate: string; // 기준가격대비율
+  enam: string; // 영문종목명
+  e_ordyn: string; // 매매가능
+}
+
+/**
+ * 해외주식 거래량급증 응답
+ * API: /uapi/overseas-stock/v1/ranking/volume-surge
+ */
+export interface KISOverseasVolumeSurgeOutput {
+  rsym: string; // 실시간조회심볼
+  excd: string; // 거래소코드
+  symb: string; // 종목코드
+  knam: string; // 종목명
+  last: string; // 현재가
+  sign: string; // 기호
+  diff: string; // 대비
+  rate: string; // 등락율
+  tvol: string; // 거래량
+  pask: string; // 매도호가
+  pbid: string; // 매수호가
+  n_tvol: string; // 기준거래량
+  n_diff: string; // 증가량
+  n_rate: string; // 증가율
+  enam: string; // 영문종목명
+  e_ordyn: string; // 매매가능
+}
+
+/**
+ * 해외뉴스 응답
+ * API: /uapi/overseas-price/v1/quotations/news-title
+ */
+export interface KISOverseasNewsOutput {
+  info_gb: string; // 뉴스구분
+  news_key: string; // 뉴스키
+  data_dt: string; // 조회일자
+  data_tm: string; // 조회시간
+  class_cd: string; // 중분류
+  class_name: string; // 중분류명
+  source: string; // 자료원
+  nation_cd: string; // 국가코드
+  exchange_cd: string; // 거래소코드
+  symb: string; // 종목코드
+  symb_name: string; // 종목명
+  title: string; // 제목
+}
+
+// ============================================================================
 // 휴장일 조회 타입
 // ============================================================================
 

--- a/lib/queries/keys.ts
+++ b/lib/queries/keys.ts
@@ -42,6 +42,8 @@ export const queries = createQueryKeyStore({
   marketTrend: {
     all: null,
     domestic: null,
+    overseas: null,
+    overseasNews: null,
     holiday: null,
   },
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -184,3 +184,27 @@ export interface DomesticMarketTrendData {
   losers: MarketTrendItem[];
   updatedAt: string;
 }
+
+// 해외 시장 동향 데이터 (거래량/가격)
+export interface OverseasMarketTrendData {
+  volumeSurge: MarketTrendItem[];
+  gainers: MarketTrendItem[];
+  losers: MarketTrendItem[];
+  updatedAt: string;
+}
+
+// 해외 뉴스 항목
+export interface OverseasNewsItem {
+  newsKey: string;
+  title: string;
+  source: string;
+  datetime: string;
+  ticker?: string;
+  tickerName?: string;
+}
+
+// 해외 뉴스 데이터
+export interface OverseasNewsData {
+  news: OverseasNewsItem[];
+  updatedAt: string;
+}


### PR DESCRIPTION
## Summary
- 해외주식 가격급등락 API 추가 (`/api/market-trend/overseas`)
- 해외주식 거래량급증 API 추가 (`/api/market-trend/overseas`)
- 해외뉴스 API 추가 (`/api/market-trend/overseas/news`)
- React Query 훅 추가 (`useOverseasMarketTrend`, `useOverseasNews`)

## 변경 파일
- `lib/kis/types.ts` - KIS API 응답 타입 추가
- `lib/kis/client.ts` - KIS API 함수 추가
- `types/index.ts` - 프론트엔드 타입 추가
- `app/api/market-trend/overseas/route.ts` - 시장 동향 API (1분 캐싱)
- `app/api/market-trend/overseas/news/route.ts` - 뉴스 API (5분 캐싱)
- `lib/queries/keys.ts` - Query Key 추가
- `hooks/use-market-trend.ts` - Hook 추가

## Test plan
- [ ] 개발 서버에서 `/api/market-trend/overseas` 호출 확인
- [ ] 개발 서버에서 `/api/market-trend/overseas/news` 호출 확인
- [x] UI 작업 시 실제 데이터 연동 테스트

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)