### PR TITLE
feat: 주식 계좌 관리 UI 구현 (#113)

### DIFF
--- a/app/(main)/assets/stock/accounts/page.tsx
+++ b/app/(main)/assets/stock/accounts/page.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { Plus } from "lucide-react";
+import { useState } from "react";
+import { AccountFormDialog, AccountList } from "@/components/accounts";
+import { PageContainer, PageHeader } from "@/components/layout";
+import { Button } from "@/components/ui/button";
+
+export default function AccountsPage() {
+  const [isFormOpen, setIsFormOpen] = useState(false);
+
+  return (
+    <PageContainer maxWidth="medium">
+      <PageHeader
+        title="계좌 관리"
+        backHref="/assets/stock"
+        action={
+          <Button size="sm" onClick={() => setIsFormOpen(true)}>
+            <Plus className="w-4 h-4 mr-1" />
+            계좌 추가
+          </Button>
+        }
+      />
+
+      <AccountList />
+
+      <AccountFormDialog open={isFormOpen} onOpenChange={setIsFormOpen} />
+    </PageContainer>
+  );
+}

--- a/app/(main)/assets/stock/page.tsx
+++ b/app/(main)/assets/stock/page.tsx
@@ -12,13 +12,13 @@ export default function StockMainPage() {
       <PageHeader title="주식" backHref="/assets" />
       <StockSummarySection />
       <div className="mt-6">
+        <MyStockSection />
+      </div>
+      <div className="mt-6">
         <MarketTrendSection />
       </div>
       <div className="mt-6">
         <PortfolioNavSection />
-      </div>
-      <div className="mt-6">
-        <MyStockSection />
       </div>
     </>
   );

--- a/components/accounts/AccountDeleteDialog.tsx
+++ b/components/accounts/AccountDeleteDialog.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { AlertTriangleIcon } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useDeleteAccount } from "@/hooks/use-accounts";
+import type { AccountWithOwner } from "@/lib/api/account";
+
+const ACCOUNT_TYPE_LABELS: Record<string, string> = {
+  stock: "일반",
+  isa: "ISA",
+  pension: "연금저축",
+  cma: "CMA",
+};
+
+interface AccountDeleteDialogProps {
+  account: AccountWithOwner | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function AccountDeleteDialog({
+  account,
+  open,
+  onOpenChange,
+}: AccountDeleteDialogProps) {
+  const deleteMutation = useDeleteAccount();
+
+  const handleDelete = async () => {
+    if (!account) return;
+
+    try {
+      await deleteMutation.mutateAsync(account.id);
+      toast.success(`${account.name} 계좌가 삭제되었습니다.`);
+      onOpenChange(false);
+    } catch (error) {
+      if (error instanceof Error) {
+        toast.error(error.message);
+      } else {
+        toast.error("계좌 삭제에 실패했습니다.");
+      }
+    }
+  };
+
+  if (!account) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <AlertTriangleIcon className="h-5 w-5 text-destructive" />
+            계좌 삭제
+          </DialogTitle>
+          <DialogDescription>
+            다음 계좌를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="rounded-md border p-4 space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="font-medium">{account.name}</span>
+            {account.isDefault && (
+              <span className="text-xs bg-secondary text-secondary-foreground px-2 py-0.5 rounded">
+                기본
+              </span>
+            )}
+          </div>
+          <div className="text-sm text-muted-foreground space-y-1">
+            {account.broker && (
+              <div className="flex justify-between">
+                <span>증권사/은행</span>
+                <span>{account.broker}</span>
+              </div>
+            )}
+            {account.accountType && (
+              <div className="flex justify-between">
+                <span>계좌 유형</span>
+                <span>
+                  {ACCOUNT_TYPE_LABELS[account.accountType] ||
+                    account.accountType}
+                </span>
+              </div>
+            )}
+            {account.accountNumber && (
+              <div className="flex justify-between">
+                <span>계좌번호</span>
+                <span>{account.accountNumber}</span>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <p className="text-sm text-muted-foreground">
+          이 계좌에 연결된 거래 내역은 삭제되지 않고 계좌 정보만 제거됩니다.
+        </p>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={deleteMutation.isPending}
+          >
+            취소
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={handleDelete}
+            disabled={deleteMutation.isPending}
+          >
+            {deleteMutation.isPending ? "삭제 중..." : "삭제"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/accounts/AccountFormDialog.tsx
+++ b/components/accounts/AccountFormDialog.tsx
@@ -1,0 +1,333 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { useCreateAccount, useUpdateAccount } from "@/hooks/use-accounts";
+import type { AccountWithOwner } from "@/lib/api/account";
+import type { AccountType } from "@/types";
+
+type StockAccountType = Extract<
+  AccountType,
+  "stock" | "isa" | "pension" | "cma"
+>;
+
+const STOCK_ACCOUNT_TYPE_VALUES: StockAccountType[] = [
+  "stock",
+  "isa",
+  "pension",
+  "cma",
+];
+
+const accountFormSchema = z.object({
+  name: z
+    .string()
+    .min(1, "계좌명은 필수입니다.")
+    .max(50, "계좌명은 50자 이내여야 합니다."),
+  broker: z.string().max(50, "증권사/은행명은 50자 이내여야 합니다."),
+  accountNumber: z.string().max(50, "계좌번호는 50자 이내여야 합니다."),
+  accountType: z.enum(["stock", "isa", "pension", "cma"], {
+    message: "계좌 유형을 선택해주세요.",
+  }),
+  isDefault: z.boolean(),
+  memo: z.string().max(500, "메모는 500자 이내여야 합니다."),
+});
+
+type AccountFormData = z.infer<typeof accountFormSchema>;
+
+const ACCOUNT_TYPES = [
+  { value: "stock", label: "일반" },
+  { value: "isa", label: "ISA" },
+  { value: "pension", label: "연금저축" },
+  { value: "cma", label: "CMA" },
+] as const;
+
+interface AccountFormDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  account?: AccountWithOwner | null;
+}
+
+export function AccountFormDialog({
+  open,
+  onOpenChange,
+  account,
+}: AccountFormDialogProps) {
+  const isEditing = !!account;
+  const createAccount = useCreateAccount();
+  const updateAccount = useUpdateAccount();
+
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    watch,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<AccountFormData>({
+    resolver: zodResolver(accountFormSchema),
+    defaultValues: {
+      name: "",
+      broker: "",
+      accountNumber: "",
+      accountType: "stock",
+      isDefault: false,
+      memo: "",
+    },
+  });
+
+  const watchIsDefault = watch("isDefault");
+
+  useEffect(() => {
+    if (open) {
+      if (account) {
+        const isStockAccountType = (
+          type: AccountType | null,
+        ): type is StockAccountType =>
+          type !== null &&
+          STOCK_ACCOUNT_TYPE_VALUES.includes(type as StockAccountType);
+
+        const accountType = isStockAccountType(account.accountType)
+          ? account.accountType
+          : "stock";
+
+        reset({
+          name: account.name,
+          broker: account.broker || "",
+          accountNumber: account.accountNumber || "",
+          accountType,
+          isDefault: account.isDefault,
+          memo: account.memo || "",
+        });
+      } else {
+        reset({
+          name: "",
+          broker: "",
+          accountNumber: "",
+          accountType: "stock",
+          isDefault: false,
+          memo: "",
+        });
+      }
+    }
+  }, [open, account, reset]);
+
+  const onSubmit = async (data: AccountFormData, continueAdding = false) => {
+    try {
+      if (isEditing && account) {
+        await updateAccount.mutateAsync({
+          id: account.id,
+          data: {
+            name: data.name,
+            broker: data.broker || null,
+            accountNumber: data.accountNumber || null,
+            accountType: data.accountType,
+            isDefault: data.isDefault,
+            memo: data.memo || null,
+          },
+        });
+        toast.success("계좌가 수정되었습니다.");
+        onOpenChange(false);
+      } else {
+        await createAccount.mutateAsync(data);
+        toast.success(`${data.name} 계좌가 추가되었습니다.`);
+
+        if (continueAdding) {
+          reset({
+            name: "",
+            broker: data.broker,
+            accountNumber: "",
+            accountType: data.accountType,
+            isDefault: false,
+            memo: "",
+          });
+        } else {
+          onOpenChange(false);
+        }
+      }
+    } catch (error) {
+      if (error instanceof Error) {
+        toast.error(error.message);
+      } else {
+        toast.error(
+          isEditing ? "계좌 수정에 실패했습니다." : "계좌 추가에 실패했습니다.",
+        );
+      }
+    }
+  };
+
+  const handleSave = handleSubmit((data) => onSubmit(data, false));
+  const handleSaveAndContinue = handleSubmit((data) => onSubmit(data, true));
+
+  const isPending = createAccount.isPending || updateAccount.isPending;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{isEditing ? "계좌 수정" : "계좌 추가"}</DialogTitle>
+          <DialogDescription>
+            {isEditing
+              ? "계좌 정보를 수정합니다."
+              : "새로운 계좌를 등록합니다."}
+          </DialogDescription>
+        </DialogHeader>
+
+        <form className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="name">
+              계좌명 <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="name"
+              placeholder="예: 삼성증권 주식계좌"
+              {...register("name")}
+              aria-invalid={!!errors.name}
+            />
+            {errors.name && (
+              <p className="text-sm text-destructive">{errors.name.message}</p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="broker">증권사/은행</Label>
+            <Input
+              id="broker"
+              placeholder="예: 삼성증권, 토스증권"
+              {...register("broker")}
+              aria-invalid={!!errors.broker}
+            />
+            {errors.broker && (
+              <p className="text-sm text-destructive">
+                {errors.broker.message}
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="accountType">
+              계좌 유형 <span className="text-destructive">*</span>
+            </Label>
+            <Select
+              value={watch("accountType")}
+              onValueChange={(value: StockAccountType) =>
+                setValue("accountType", value)
+              }
+            >
+              <SelectTrigger id="accountType">
+                <SelectValue placeholder="계좌 유형 선택" />
+              </SelectTrigger>
+              <SelectContent>
+                {ACCOUNT_TYPES.map((type) => (
+                  <SelectItem key={type.value} value={type.value}>
+                    {type.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {errors.accountType && (
+              <p className="text-sm text-destructive">
+                {errors.accountType.message}
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="accountNumber">계좌번호</Label>
+            <Input
+              id="accountNumber"
+              placeholder="예: 123-456-78901234"
+              {...register("accountNumber")}
+              aria-invalid={!!errors.accountNumber}
+            />
+            {errors.accountNumber && (
+              <p className="text-sm text-destructive">
+                {errors.accountNumber.message}
+              </p>
+            )}
+          </div>
+
+          <div className="flex items-center space-x-2">
+            <Checkbox
+              id="isDefault"
+              checked={watchIsDefault}
+              onCheckedChange={(checked) =>
+                setValue("isDefault", checked === true)
+              }
+            />
+            <Label htmlFor="isDefault" className="font-normal cursor-pointer">
+              기본 계좌로 설정
+            </Label>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="memo">메모</Label>
+            <Textarea
+              id="memo"
+              placeholder="계좌에 대한 메모를 입력하세요"
+              rows={2}
+              {...register("memo")}
+              aria-invalid={!!errors.memo}
+            />
+            {errors.memo && (
+              <p className="text-sm text-destructive">{errors.memo.message}</p>
+            )}
+          </div>
+        </form>
+
+        <DialogFooter className="flex-col sm:flex-row gap-2">
+          {!isEditing && (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleSaveAndContinue}
+              disabled={isPending || isSubmitting}
+              className="sm:order-1"
+            >
+              저장하고 추가 계속
+            </Button>
+          )}
+          <div className="flex gap-2 sm:order-2">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => onOpenChange(false)}
+              disabled={isPending || isSubmitting}
+            >
+              취소
+            </Button>
+            <Button
+              type="button"
+              onClick={handleSave}
+              disabled={isPending || isSubmitting}
+            >
+              {isPending || isSubmitting ? "저장 중..." : "저장"}
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/accounts/AccountList.tsx
+++ b/components/accounts/AccountList.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { MoreHorizontal, Pencil, Star, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useAccounts, useUpdateAccount } from "@/hooks/use-accounts";
+import type { AccountWithOwner } from "@/lib/api/account";
+import { AccountDeleteDialog } from "./AccountDeleteDialog";
+import { AccountFormDialog } from "./AccountFormDialog";
+
+const ACCOUNT_TYPE_LABELS: Record<string, string> = {
+  stock: "일반",
+  isa: "ISA",
+  pension: "연금저축",
+  cma: "CMA",
+};
+
+export function AccountList() {
+  const { data: accounts, isLoading, error } = useAccounts();
+  const updateAccount = useUpdateAccount();
+
+  const [editingAccount, setEditingAccount] = useState<AccountWithOwner | null>(
+    null,
+  );
+  const [deletingAccount, setDeletingAccount] =
+    useState<AccountWithOwner | null>(null);
+  const [isFormOpen, setIsFormOpen] = useState(false);
+
+  const handleSetDefault = async (account: AccountWithOwner) => {
+    try {
+      await updateAccount.mutateAsync({
+        id: account.id,
+        data: { isDefault: true },
+      });
+      toast.success(`${account.name}을(를) 기본 계좌로 설정했습니다.`);
+    } catch (error) {
+      if (error instanceof Error) {
+        toast.error(error.message);
+      } else {
+        toast.error("기본 계좌 설정에 실패했습니다.");
+      }
+    }
+  };
+
+  const handleEdit = (account: AccountWithOwner) => {
+    setEditingAccount(account);
+    setIsFormOpen(true);
+  };
+
+  const handleDelete = (account: AccountWithOwner) => {
+    setDeletingAccount(account);
+  };
+
+  const handleFormClose = () => {
+    setIsFormOpen(false);
+    setEditingAccount(null);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="bg-white rounded-2xl shadow-sm p-8">
+        <div className="animate-pulse space-y-4">
+          <div className="h-4 bg-gray-200 rounded w-1/4" />
+          <div className="h-10 bg-gray-100 rounded" />
+          <div className="h-10 bg-gray-100 rounded" />
+          <div className="h-10 bg-gray-100 rounded" />
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-white rounded-2xl shadow-sm p-8 text-center">
+        <p className="text-destructive">계좌 목록을 불러오는데 실패했습니다.</p>
+      </div>
+    );
+  }
+
+  if (!accounts || accounts.length === 0) {
+    return (
+      <div className="bg-white rounded-2xl shadow-sm p-8 text-center">
+        <p className="text-gray-500">등록된 계좌가 없습니다.</p>
+        <p className="text-sm text-gray-400 mt-1">
+          상단의 &quot;계좌 추가&quot; 버튼으로 계좌를 등록해보세요.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="pl-5">계좌명</TableHead>
+              <TableHead>증권사/은행</TableHead>
+              <TableHead>계좌유형</TableHead>
+              <TableHead>계좌번호</TableHead>
+              <TableHead className="w-12 pr-5" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {accounts.map((account) => (
+              <TableRow key={account.id}>
+                <TableCell className="font-medium pl-5">
+                  <div className="flex items-center gap-2">
+                    {account.name}
+                    {account.isDefault && (
+                      <Badge variant="secondary" className="text-xs">
+                        기본
+                      </Badge>
+                    )}
+                  </div>
+                </TableCell>
+                <TableCell className="text-gray-600">
+                  {account.broker || "-"}
+                </TableCell>
+                <TableCell className="text-gray-600">
+                  {account.accountType
+                    ? ACCOUNT_TYPE_LABELS[account.accountType] ||
+                      account.accountType
+                    : "-"}
+                </TableCell>
+                <TableCell className="text-gray-600">
+                  {account.accountNumber || "-"}
+                </TableCell>
+                <TableCell className="pr-5">
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="ghost" size="icon" className="h-8 w-8">
+                        <MoreHorizontal className="h-4 w-4" />
+                        <span className="sr-only">메뉴 열기</span>
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem onClick={() => handleEdit(account)}>
+                        <Pencil className="h-4 w-4 mr-2" />
+                        수정
+                      </DropdownMenuItem>
+                      {!account.isDefault && (
+                        <DropdownMenuItem
+                          onClick={() => handleSetDefault(account)}
+                        >
+                          <Star className="h-4 w-4 mr-2" />
+                          기본 계좌로 설정
+                        </DropdownMenuItem>
+                      )}
+                      <DropdownMenuItem
+                        className="text-destructive focus:text-destructive"
+                        onClick={() => handleDelete(account)}
+                      >
+                        <Trash2 className="h-4 w-4 mr-2" />
+                        삭제
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      <AccountFormDialog
+        open={isFormOpen}
+        onOpenChange={handleFormClose}
+        account={editingAccount}
+      />
+
+      <AccountDeleteDialog
+        account={deletingAccount}
+        open={!!deletingAccount}
+        onOpenChange={(open) => !open && setDeletingAccount(null)}
+      />
+    </>
+  );
+}

--- a/components/accounts/index.ts
+++ b/components/accounts/index.ts
@@ -1,0 +1,3 @@
+export { AccountDeleteDialog } from "./AccountDeleteDialog";
+export { AccountFormDialog } from "./AccountFormDialog";
+export { AccountList } from "./AccountList";

--- a/components/assets/stock/PortfolioNavSection.tsx
+++ b/components/assets/stock/PortfolioNavSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { BarChart3, Receipt, Settings } from "lucide-react";
+import { BarChart3, Receipt, Settings, Wallet } from "lucide-react";
 import { AnalysisCard } from "@/components/dashboard/AnalysisCard";
 
 const navItems = [
@@ -21,6 +21,14 @@ const navItems = [
     bgColor: "bg-green-50",
   },
   {
+    icon: Wallet,
+    label: "계좌 관리",
+    description: "증권 계좌를 등록하고 관리해 보세요",
+    href: "/assets/stock/accounts",
+    color: "text-indigo-600",
+    bgColor: "bg-indigo-50",
+  },
+  {
     icon: Settings,
     label: "종목 설정",
     description: "종목을 내 방식대로 관리해 보세요",
@@ -34,7 +42,7 @@ export function PortfolioNavSection() {
   return (
     <section>
       <h2 className="text-lg font-semibold text-gray-900 mb-4">관리</h2>
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         {navItems.map((item) => (
           <AnalysisCard key={item.href} {...item} />
         ))}

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
+import { CheckIcon } from "lucide-react";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils/cn";
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+}
+
+export { Checkbox };

--- a/hooks/use-accounts.ts
+++ b/hooks/use-accounts.ts
@@ -1,0 +1,152 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { AccountWithOwner } from "@/lib/api/account";
+import { queries } from "@/lib/queries/keys";
+import type { CreateAccountInput, UpdateAccountInput } from "@/schemas/account";
+import type { Account } from "@/types";
+
+interface AccountResponse {
+  data: Account;
+}
+
+interface AccountListResponse {
+  data: AccountWithOwner[];
+}
+
+interface AccountError {
+  error: {
+    code: string;
+    message: string;
+  };
+}
+
+interface DeleteAccountResponse {
+  success: boolean;
+}
+
+// ============================================================================
+// 계좌 목록 조회
+// ============================================================================
+
+async function fetchAccounts(): Promise<AccountWithOwner[]> {
+  const response = await fetch("/api/accounts");
+  const json = await response.json();
+
+  if (!response.ok) {
+    const error = json as AccountError;
+    throw new Error(error.error.message);
+  }
+
+  return (json as AccountListResponse).data;
+}
+
+export function useAccounts() {
+  return useQuery({
+    queryKey: queries.accounts.list.queryKey,
+    queryFn: fetchAccounts,
+    staleTime: 1000 * 60 * 5, // 5분
+  });
+}
+
+// ============================================================================
+// 계좌 생성
+// ============================================================================
+
+async function createAccount(input: CreateAccountInput): Promise<Account> {
+  const response = await fetch("/api/accounts", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  const json = await response.json();
+
+  if (!response.ok) {
+    const error = json as AccountError;
+    throw new Error(error.error.message);
+  }
+
+  return (json as AccountResponse).data;
+}
+
+export function useCreateAccount() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: createAccount,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queries.accounts._def });
+    },
+  });
+}
+
+// ============================================================================
+// 계좌 수정
+// ============================================================================
+
+interface UpdateAccountParams {
+  id: string;
+  data: UpdateAccountInput;
+}
+
+async function updateAccount({
+  id,
+  data,
+}: UpdateAccountParams): Promise<Account> {
+  const response = await fetch(`/api/accounts/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  const json = await response.json();
+
+  if (!response.ok) {
+    const error = json as AccountError;
+    throw new Error(error.error.message);
+  }
+
+  return (json as AccountResponse).data;
+}
+
+export function useUpdateAccount() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updateAccount,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queries.accounts._def });
+    },
+  });
+}
+
+// ============================================================================
+// 계좌 삭제
+// ============================================================================
+
+async function deleteAccount(id: string): Promise<void> {
+  const response = await fetch(`/api/accounts/${id}`, {
+    method: "DELETE",
+  });
+  const json = await response.json();
+
+  if (!response.ok) {
+    const error = json as AccountError;
+    throw new Error(error.error.message);
+  }
+
+  const result = json as DeleteAccountResponse;
+  if (!result.success) {
+    throw new Error("계좌 삭제에 실패했습니다.");
+  }
+}
+
+export function useDeleteAccount() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: deleteAccount,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queries.accounts._def });
+    },
+  });
+}

--- a/lib/queries/keys.ts
+++ b/lib/queries/keys.ts
@@ -5,6 +5,11 @@ export const queries = createQueryKeyStore({
     user: null,
   },
 
+  accounts: {
+    all: null,
+    list: null,
+  },
+
   holdings: {
     all: null,
     list: null,

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
     "@lukemorales/query-key-factory": "^1.3.4",
+    "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@lukemorales/query-key-factory':
         specifier: ^1.3.4
         version: 1.3.4(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))
+      '@radix-ui/react-checkbox':
+        specifier: ^1.3.3
+        version: 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -610,6 +613,19 @@ packages:
 
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-checkbox@1.3.3':
+    resolution: {integrity: sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2265,6 +2281,22 @@ snapshots:
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
+  '@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.7)(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
     optionalDependencies:


### PR DESCRIPTION
## Summary
- 주식 계좌 관리 화면 구현 (`/assets/stock/accounts`)
- 계좌 목록 조회, 추가, 수정, 삭제 기능
- "저장하고 추가 계속" 버튼으로 연속 등록 지원
- 주식 메인 페이지 관리 섹션에 계좌 관리 진입점 추가

## Changes
- `app/(main)/assets/stock/accounts/page.tsx` - 계좌 관리 페이지
- `components/accounts/` - AccountList, AccountFormDialog, AccountDeleteDialog
- `hooks/use-accounts.ts` - React Query 기반 CRUD 훅
- `lib/queries/keys.ts` - accounts 쿼리 키 추가
- `components/assets/stock/PortfolioNavSection.tsx` - 관리 섹션 2x2 그리드, 계좌 관리 추가
- `app/(main)/assets/stock/page.tsx` - 내 종목 섹션 순서 변경

## Test plan
- [x] `/assets/stock` → 관리 섹션 → 계좌 관리 진입 확인
- [x] 계좌 추가 (일반, ISA, 연금, CMA)
- [x] "저장하고 추가 계속"으로 연속 등록
- [x] 계좌 수정
- [x] 기본 계좌 설정
- [x] 계좌 삭제

Closes #113

🤖 Generated with [Claude Code](https://claude.ai/code)