### PR TITLE
#112 거래 API 수정 - account_id 지원

### DIFF
--- a/app/api/transactions/[id]/route.ts
+++ b/app/api/transactions/[id]/route.ts
@@ -125,6 +125,7 @@ export async function PATCH(request: Request, { params }: RouteParams) {
         price: input.price,
         transactedAt: input.transactedAt,
         memo: input.memo,
+        accountId: input.accountId,
       },
     );
 

--- a/app/api/transactions/route.ts
+++ b/app/api/transactions/route.ts
@@ -133,6 +133,7 @@ export async function POST(request: Request) {
       price: input.price,
       transactedAt: input.transactedAt,
       memo: input.memo,
+      accountId: input.accountId,
       stock: {
         name: input.stock.name,
         market: input.stock.market,

--- a/lib/api/transaction.ts
+++ b/lib/api/transaction.ts
@@ -25,6 +25,7 @@ export interface CreateTransactionParams {
   price: number;
   transactedAt: string;
   memo?: string;
+  accountId?: string;
   stock: {
     name: string;
     market: MarketType;
@@ -52,6 +53,7 @@ export async function createTransaction(
     price,
     transactedAt,
     memo,
+    accountId,
     stock,
   } = params;
 
@@ -110,6 +112,7 @@ export async function createTransaction(
       price,
       transacted_at: transactedAt,
       memo: memo || null,
+      account_id: accountId || null,
     })
     .select()
     .single();
@@ -295,6 +298,7 @@ export interface UpdateTransactionParams {
   price?: number;
   transactedAt?: string;
   memo?: string | null;
+  accountId?: string | null;
 }
 
 /**
@@ -377,6 +381,7 @@ export async function updateTransaction(
   if (params.transactedAt !== undefined)
     updateData.transacted_at = params.transactedAt;
   if (params.memo !== undefined) updateData.memo = params.memo;
+  if (params.accountId !== undefined) updateData.account_id = params.accountId;
 
   const { data, error } = await supabase
     .from("transactions")

--- a/schemas/transaction.ts
+++ b/schemas/transaction.ts
@@ -20,6 +20,7 @@ export const createTransactionSchema = z.object({
     .string()
     .datetime({ message: "유효한 날짜 형식이 아닙니다." }),
   memo: z.string().max(500, "메모는 500자 이내여야 합니다.").optional(),
+  accountId: z.string().uuid("유효한 계좌 ID가 아닙니다.").optional(),
 
   // 종목 정보 (첫 거래 시 household_stock_settings 생성용)
   stock: z.object({
@@ -58,6 +59,11 @@ export const updateTransactionSchema = z.object({
   memo: z
     .string()
     .max(500, "메모는 500자 이내여야 합니다.")
+    .nullable()
+    .optional(),
+  accountId: z
+    .string()
+    .uuid("유효한 계좌 ID가 아닙니다.")
     .nullable()
     .optional(),
 });


### PR DESCRIPTION
## Summary
- 거래 생성/수정 API에 `accountId` 파라미터 추가
- 거래와 계좌 연결 기능 지원

## Changes
- `schemas/transaction.ts`: createTransactionSchema, updateTransactionSchema에 accountId 필드 추가
- `lib/api/transaction.ts`: CreateTransactionParams, UpdateTransactionParams에 accountId 추가
- `app/api/transactions/route.ts`: POST 핸들러에서 accountId 전달
- `app/api/transactions/[id]/route.ts`: PATCH 핸들러에서 accountId 전달

## Test plan
- [ ] POST /api/transactions - accountId 포함하여 거래 생성 테스트
- [ ] PATCH /api/transactions/[id] - accountId 수정 테스트
- [ ] accountId 없이 기존 방식으로 거래 생성 가능 확인

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)