### PR TITLE
[UI] 주식 대시보드 계좌별 분석 기능 추가

### DIFF
--- a/app/(main)/dashboard/stocks/page.tsx
+++ b/app/(main)/dashboard/stocks/page.tsx
@@ -1,5 +1,7 @@
 import {
+  AccountBreakdownSection,
   MarketBreakdownSection,
+  StockAccountDistributionSection,
   StockAllocationSection,
   StockSummarySection,
   TopPerformersSection,
@@ -17,6 +19,8 @@ export default function StocksAnalysisPage() {
       <StockSummarySection />
       <StockAllocationSection />
       <MarketBreakdownSection />
+      <AccountBreakdownSection />
+      <StockAccountDistributionSection />
       <TopPerformersSection />
     </>
   );

--- a/app/api/dashboard/by-owner/route.ts
+++ b/app/api/dashboard/by-owner/route.ts
@@ -128,6 +128,11 @@ export async function GET() {
         returnAmount,
         returnRate,
         allocationPercent: 0, // 나중에 계산
+        account: {
+          id: h.account.id,
+          name: h.account.name,
+          broker: h.account.broker,
+        },
       };
 
       const ownerId = h.owner.id;

--- a/components/dashboard/stocks/AccountBreakdownSection.tsx
+++ b/components/dashboard/stocks/AccountBreakdownSection.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useMemo } from "react";
+import { Cell, Pie, PieChart } from "recharts";
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import { useStockAnalysis } from "@/hooks/use-stock-analysis";
+import { formatCurrency, formatPercent } from "@/lib/utils/format";
+
+const CHART_COLORS = [
+  "#4F46E5", // 인디고
+  "#03B26C", // 초록
+  "#FF9F00", // 주황
+  "#F04452", // 빨강
+  "#6366F1", // 보라
+  "#8B95A1", // 회색 (미배정용)
+];
+
+export function AccountBreakdownSection() {
+  const { data, isLoading } = useStockAnalysis();
+
+  const chartData = useMemo(() => {
+    if (!data || data.byAccount.length === 0) return [];
+
+    return data.byAccount.map((account, index) => ({
+      id: account.accountId ?? "unassigned",
+      name: account.accountName ?? "미배정",
+      value: account.totalValue,
+      percentage: account.percentage,
+      returnRate: account.returnRate,
+      holdingCount: account.holdingCount,
+      fill: account.accountId
+        ? CHART_COLORS[index % (CHART_COLORS.length - 1)]
+        : CHART_COLORS[CHART_COLORS.length - 1], // 미배정은 회색
+    }));
+  }, [data]);
+
+  const chartConfig = useMemo(() => {
+    const config: ChartConfig = {};
+    for (const item of chartData) {
+      config[item.id] = {
+        label: item.name,
+        color: item.fill,
+      };
+    }
+    return config;
+  }, [chartData]);
+
+  if (isLoading) {
+    return (
+      <div className="bg-white rounded-2xl p-5 shadow-sm">
+        <div className="animate-pulse">
+          <div className="h-4 w-24 bg-gray-200 rounded mb-4" />
+          <div className="flex gap-6">
+            <div className="size-48 bg-gray-200 rounded-full" />
+            <div className="flex-1 space-y-3">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="h-6 bg-gray-200 rounded" />
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data || data.byAccount.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="bg-white rounded-2xl p-5 shadow-sm">
+      <h3 className="text-sm font-medium text-gray-900 mb-4">계좌별 비중</h3>
+      <div className="flex flex-col md:flex-row gap-6">
+        {/* 도넛 차트 */}
+        <div className="flex-shrink-0">
+          <ChartContainer config={chartConfig} className="size-48">
+            <PieChart>
+              <ChartTooltip
+                content={
+                  <ChartTooltipContent
+                    formatter={(_value, _name, item) => (
+                      <div className="flex items-center justify-between gap-4">
+                        <span>{item.payload.name}</span>
+                        <span className="font-mono font-medium">
+                          {item.payload.percentage.toFixed(1)}%
+                        </span>
+                      </div>
+                    )}
+                  />
+                }
+              />
+              <Pie
+                data={chartData}
+                dataKey="value"
+                nameKey="name"
+                cx="50%"
+                cy="50%"
+                innerRadius={50}
+                outerRadius={80}
+                strokeWidth={2}
+                stroke="#fff"
+              >
+                {chartData.map((entry) => (
+                  <Cell key={entry.id} fill={entry.fill} />
+                ))}
+              </Pie>
+            </PieChart>
+          </ChartContainer>
+        </div>
+
+        {/* 범례 리스트 */}
+        <div className="flex-1 space-y-3">
+          {chartData.map((item) => (
+            <div key={item.id} className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <div
+                  className="size-3 rounded-full"
+                  style={{ backgroundColor: item.fill }}
+                />
+                <div className="flex flex-col">
+                  <span className="text-sm text-gray-700">{item.name}</span>
+                  <span className="text-xs text-gray-500">
+                    {item.holdingCount}종목
+                  </span>
+                </div>
+              </div>
+              <div className="text-right">
+                <span className="text-sm font-medium text-gray-900">
+                  {formatCurrency(item.value, "KRW")}
+                </span>
+                <div className="flex items-center justify-end gap-1">
+                  <span
+                    className={`text-xs ${
+                      item.returnRate >= 0 ? "text-positive" : "text-negative"
+                    }`}
+                  >
+                    {formatPercent(item.returnRate)}
+                  </span>
+                  <span className="text-xs text-gray-500">
+                    ({item.percentage.toFixed(1)}%)
+                  </span>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/stocks/StockAccountDistributionSection.tsx
+++ b/components/dashboard/stocks/StockAccountDistributionSection.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Cell, Pie, PieChart } from "recharts";
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useStockAnalysis } from "@/hooks/use-stock-analysis";
+import { formatCurrency } from "@/lib/utils/format";
+
+const CHART_COLORS = [
+  "#4F46E5", // 인디고
+  "#03B26C", // 초록
+  "#FF9F00", // 주황
+  "#F04452", // 빨강
+  "#6366F1", // 보라
+  "#8B95A1", // 회색 (미배정용)
+];
+
+export function StockAccountDistributionSection() {
+  const { data, isLoading } = useStockAnalysis();
+  const [selectedTicker, setSelectedTicker] = useState<string>("");
+
+  // 종목 목록 (중복 제거, 종목명 기준 정렬)
+  const stockOptions = useMemo(() => {
+    if (!data) return [];
+
+    const tickerMap = new Map<string, string>();
+    for (const holding of data.holdings) {
+      if (!tickerMap.has(holding.ticker)) {
+        tickerMap.set(holding.ticker, holding.name);
+      }
+    }
+
+    return Array.from(tickerMap.entries())
+      .map(([ticker, name]) => ({ ticker, name }))
+      .sort((a, b) => a.name.localeCompare(b.name, "ko"));
+  }, [data]);
+
+  // 선택된 종목의 계좌별 분포
+  const distributionData = useMemo(() => {
+    if (!data || !selectedTicker) return [];
+
+    // 선택된 종목의 holdings 필터링
+    const selectedHoldings = data.holdings.filter(
+      (h) => h.ticker === selectedTicker,
+    );
+
+    if (selectedHoldings.length === 0) return [];
+
+    // 계좌별로 그룹핑
+    const accountMap = new Map<
+      string | null,
+      { name: string | null; quantity: number; value: number }
+    >();
+
+    for (const holding of selectedHoldings) {
+      const accountId = holding.account.id;
+      const existing = accountMap.get(accountId);
+
+      if (existing) {
+        existing.quantity += holding.quantity;
+        existing.value += holding.currentValue;
+      } else {
+        accountMap.set(accountId, {
+          name: holding.account.name,
+          quantity: holding.quantity,
+          value: holding.currentValue,
+        });
+      }
+    }
+
+    // 총 가치 계산
+    const totalValue = Array.from(accountMap.values()).reduce(
+      (sum, item) => sum + item.value,
+      0,
+    );
+
+    // 차트 데이터 생성
+    return Array.from(accountMap.entries())
+      .map(([accountId, data], index) => ({
+        id: accountId ?? "unassigned",
+        name: data.name ?? "미배정",
+        quantity: data.quantity,
+        value: data.value,
+        percentage: totalValue > 0 ? (data.value / totalValue) * 100 : 0,
+        fill: accountId
+          ? CHART_COLORS[index % (CHART_COLORS.length - 1)]
+          : CHART_COLORS[CHART_COLORS.length - 1],
+      }))
+      .sort((a, b) => b.value - a.value);
+  }, [data, selectedTicker]);
+
+  const chartConfig = useMemo(() => {
+    const config: ChartConfig = {};
+    for (const item of distributionData) {
+      config[item.id] = {
+        label: item.name,
+        color: item.fill,
+      };
+    }
+    return config;
+  }, [distributionData]);
+
+  // 선택된 종목 정보
+  const selectedStock = useMemo(() => {
+    if (!data || !selectedTicker) return null;
+    return stockOptions.find((s) => s.ticker === selectedTicker);
+  }, [data, selectedTicker, stockOptions]);
+
+  if (isLoading) {
+    return (
+      <div className="bg-white rounded-2xl p-5 shadow-sm">
+        <div className="animate-pulse">
+          <div className="h-4 w-32 bg-gray-200 rounded mb-4" />
+          <div className="h-9 w-48 bg-gray-200 rounded" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!data || stockOptions.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="bg-white rounded-2xl p-5 shadow-sm">
+      <h3 className="text-sm font-medium text-gray-900 mb-4">
+        종목별 계좌 분포
+      </h3>
+
+      {/* 종목 선택 */}
+      <div className="mb-6">
+        <Select value={selectedTicker} onValueChange={setSelectedTicker}>
+          <SelectTrigger className="w-full md:w-64">
+            <SelectValue placeholder="종목을 선택하세요" />
+          </SelectTrigger>
+          <SelectContent>
+            {stockOptions.map((stock) => (
+              <SelectItem key={stock.ticker} value={stock.ticker}>
+                {stock.name} ({stock.ticker})
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* 선택된 종목의 계좌별 분포 */}
+      {selectedTicker && distributionData.length > 0 ? (
+        <div className="flex flex-col md:flex-row gap-6">
+          {/* 도넛 차트 */}
+          <div className="flex-shrink-0">
+            <ChartContainer config={chartConfig} className="size-48">
+              <PieChart>
+                <ChartTooltip
+                  content={
+                    <ChartTooltipContent
+                      formatter={(_value, _name, item) => (
+                        <div className="flex items-center justify-between gap-4">
+                          <span>{item.payload.name}</span>
+                          <span className="font-mono font-medium">
+                            {item.payload.percentage.toFixed(1)}%
+                          </span>
+                        </div>
+                      )}
+                    />
+                  }
+                />
+                <Pie
+                  data={distributionData}
+                  dataKey="value"
+                  nameKey="name"
+                  cx="50%"
+                  cy="50%"
+                  innerRadius={50}
+                  outerRadius={80}
+                  strokeWidth={2}
+                  stroke="#fff"
+                >
+                  {distributionData.map((entry) => (
+                    <Cell key={entry.id} fill={entry.fill} />
+                  ))}
+                </Pie>
+              </PieChart>
+            </ChartContainer>
+          </div>
+
+          {/* 범례 리스트 */}
+          <div className="flex-1 space-y-3">
+            {distributionData.map((item) => (
+              <div key={item.id} className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <div
+                    className="size-3 rounded-full"
+                    style={{ backgroundColor: item.fill }}
+                  />
+                  <span className="text-sm text-gray-700">{item.name}</span>
+                </div>
+                <div className="text-right">
+                  <div className="text-sm font-medium text-gray-900">
+                    {item.quantity.toLocaleString()}주
+                  </div>
+                  <div className="flex items-center justify-end gap-1">
+                    <span className="text-xs text-gray-600">
+                      {formatCurrency(item.value, "KRW")}
+                    </span>
+                    <span className="text-xs text-gray-500">
+                      ({item.percentage.toFixed(1)}%)
+                    </span>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : selectedTicker ? (
+        <p className="text-sm text-gray-500 text-center py-8">
+          선택한 종목의 계좌 분포 데이터가 없습니다.
+        </p>
+      ) : (
+        <p className="text-sm text-gray-500 text-center py-8">
+          종목을 선택하면 계좌별 분포를 확인할 수 있습니다.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/components/dashboard/stocks/index.ts
+++ b/components/dashboard/stocks/index.ts
@@ -1,4 +1,6 @@
+export { AccountBreakdownSection } from "./AccountBreakdownSection";
 export { MarketBreakdownSection } from "./MarketBreakdownSection";
+export { StockAccountDistributionSection } from "./StockAccountDistributionSection";
 export { StockAllocationSection } from "./StockAllocationSection";
 export { StockSummarySection } from "./StockSummarySection";
 export { TopPerformersSection } from "./TopPerformersSection";

--- a/lib/api/holdings.ts
+++ b/lib/api/holdings.ts
@@ -56,6 +56,7 @@ export interface HoldingWithDetails {
   account: {
     id: string | null;
     name: string | null;
+    broker: string | null;
   };
 }
 
@@ -167,6 +168,7 @@ export async function getHoldings(
     account: {
       id: h.account_id,
       name: h.account_name,
+      broker: h.account_broker,
     },
   }));
 

--- a/supabase/migrations/20260111100000_add_broker_to_holdings_view.sql
+++ b/supabase/migrations/20260111100000_add_broker_to_holdings_view.sql
@@ -1,0 +1,54 @@
+-- holdings View 수정 - broker 정보 추가
+-- 이슈: #189
+
+-- 기존 View 삭제
+drop view if exists public.holdings;
+
+-- broker 정보가 포함된 새 View 생성
+create view public.holdings
+with (security_invoker = on) as
+select
+  t.household_id,
+  t.owner_id,
+  t.account_id,
+  a.name as account_name,
+  a.broker as account_broker,
+  t.ticker,
+  s.name,
+  s.asset_type,
+  s.market,
+  s.currency,
+  s.risk_level,
+  -- 현재 보유 수량
+  sum(case when t.type = 'buy' then t.quantity else -t.quantity end) as quantity,
+  -- 평균 매수가 (매수 거래만 계산)
+  case
+    when sum(case when t.type = 'buy' then t.quantity else 0 end) > 0
+    then sum(case when t.type = 'buy' then t.quantity * t.price else 0 end) /
+         sum(case when t.type = 'buy' then t.quantity else 0 end)
+    else 0
+  end as avg_price,
+  -- 총 매수 금액
+  sum(case when t.type = 'buy' then t.quantity * t.price else 0 end) as total_invested,
+  -- 최초 거래일
+  min(t.transacted_at) as first_transaction_at,
+  -- 최근 거래일
+  max(t.transacted_at) as last_transaction_at
+from public.transactions t
+join public.household_stock_settings s
+  on t.household_id = s.household_id and t.ticker = s.ticker
+left join public.accounts a
+  on t.account_id = a.id
+group by
+  t.household_id,
+  t.owner_id,
+  t.account_id,
+  a.name,
+  a.broker,
+  t.ticker,
+  s.name,
+  s.asset_type,
+  s.market,
+  s.currency,
+  s.risk_level
+having sum(case when t.type = 'buy' then t.quantity else -t.quantity end) > 0;

--- a/types/index.ts
+++ b/types/index.ts
@@ -89,6 +89,7 @@ export interface StockAnalysisData {
   holdings: StockHoldingWithReturn[];
   byMarket: MarketBreakdown[];
   byCurrency: CurrencyBreakdown[];
+  byAccount: AccountBreakdown[];
   exchangeRate: number;
 }
 
@@ -114,6 +115,11 @@ export interface StockHoldingWithReturn {
   returnAmount: number;
   returnRate: number;
   allocationPercent: number;
+  account: {
+    id: string | null;
+    name: string | null;
+    broker: string | null;
+  };
 }
 
 export interface MarketBreakdown {
@@ -126,6 +132,18 @@ export interface CurrencyBreakdown {
   currency: CurrencyType;
   totalValue: number;
   percentage: number;
+}
+
+export interface AccountBreakdown {
+  accountId: string | null;
+  accountName: string | null;
+  broker: string | null;
+  totalValue: number;
+  totalInvested: number;
+  returnAmount: number;
+  returnRate: number;
+  percentage: number;
+  holdingCount: number;
 }
 
 // 소유자별 분석 페이지용 타입

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -550,6 +550,7 @@ export type Database = {
         Row: {
           account_id: string | null;
           account_name: string | null;
+          account_broker: string | null;
           asset_type: Database["public"]["Enums"]["asset_type"] | null;
           avg_price: number | null;
           currency: Database["public"]["Enums"]["currency_type"] | null;


### PR DESCRIPTION
## Summary
- 주식 대시보드에 계좌별 비중 섹션 추가 (도넛 차트 + 목록)
- 종목별 계좌 분포 섹션 추가 (종목 선택 → 해당 종목의 계좌별 분포)
- holdings View에 broker 정보 추가

## Test plan
- [x] `/dashboard/stocks` 페이지에서 계좌별 비중 섹션 확인
- [x] 계좌별 평가금액, 수익률, 비중이 도넛 차트로 표시되는지 확인
- [x] 종목 Select에서 보유 종목 선택 가능한지 확인
- [x] 종목 선택 시 계좌별 분포 차트가 표시되는지 확인
- [x] 계좌가 없는 자산이 "미배정"으로 표시되는지 확인
- [ ] Supabase 마이그레이션 적용 후 broker 정보가 정상 조회되는지 확인

Closes #189

🤖 Generated with [Claude Code](https://claude.ai/code)