### PR TITLE
#229 하단/사이드 네비게이션 4탭 개편

### DIFF
--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -11,7 +11,7 @@ export default function MainLayout({
       <div className="flex flex-1 overflow-hidden">
         <Sidebar />
         <div className="size-full overflow-y-scroll">
-          <main className="flex-1 p-4 pb-[calc(4rem+env(safe-area-inset-bottom))] lg:pb-4">
+          <main className="flex-1 p-4 pb-[calc(6rem+env(safe-area-inset-bottom))] lg:pb-4">
             <div className="max-w-4xl mx-auto space-y-6">{children}</div>
           </main>
         </div>

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -11,7 +11,7 @@ export default function MainLayout({
       <div className="flex flex-1 overflow-hidden">
         <Sidebar />
         <div className="size-full overflow-y-scroll">
-          <main className="flex-1 p-4 pb-20 lg:pb-4 ">
+          <main className="flex-1 p-4 pb-[calc(4rem+env(safe-area-inset-bottom))] lg:pb-4">
             <div className="max-w-4xl mx-auto space-y-6">{children}</div>
           </main>
         </div>

--- a/app/(main)/ledger/page.tsx
+++ b/app/(main)/ledger/page.tsx
@@ -1,0 +1,13 @@
+import { PageHeader } from "@/components/layout";
+
+export default function LedgerPage() {
+  return (
+    <>
+      <PageHeader title="가계부" />
+      <div className="flex flex-col items-center justify-center py-20 text-gray-500">
+        <p className="text-lg font-medium">준비 중입니다</p>
+        <p className="mt-2 text-sm">가계부 기능이 곧 추가됩니다.</p>
+      </div>
+    </>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -50,6 +50,7 @@
 }
 
 :root {
+  --safe-area-inset-bottom: env(safe-area-inset-bottom, 0px);
   --radius: 0.625rem;
   --positive: #f04452;
   --negative: #3182f6;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,6 +18,7 @@ const geistMono = Geist_Mono({
 
 export const viewport: Viewport = {
   themeColor: "#4F46E5",
+  viewportFit: "cover",
 };
 
 export const metadata: Metadata = {

--- a/components/layout/BottomNav.test.tsx
+++ b/components/layout/BottomNav.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { BottomNav } from "./BottomNav";
+
+// next/navigation mock
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(() => "/home"),
+}));
+
+// next/link mock
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+import { usePathname } from "next/navigation";
+
+describe("BottomNav", () => {
+  it("4개의 네비게이션 항목을 렌더링한다", () => {
+    render(<BottomNav />);
+
+    expect(screen.getByText("홈")).toBeInTheDocument();
+    expect(screen.getByText("가계부")).toBeInTheDocument();
+    expect(screen.getByText("자산")).toBeInTheDocument();
+    expect(screen.getByText("설정")).toBeInTheDocument();
+  });
+
+  it("분석, 가구 탭이 없다", () => {
+    render(<BottomNav />);
+
+    expect(screen.queryByText("분석")).not.toBeInTheDocument();
+    expect(screen.queryByText("가구")).not.toBeInTheDocument();
+  });
+
+  it("4열 그리드로 렌더링된다", () => {
+    const { container } = render(<BottomNav />);
+    const grid = container.querySelector(".grid-cols-4");
+    expect(grid).toBeInTheDocument();
+  });
+
+  it("현재 경로에 해당하는 탭이 활성 상태이다", () => {
+    vi.mocked(usePathname).mockReturnValue("/home");
+    render(<BottomNav />);
+
+    const homeLink = screen.getByText("홈").closest("a");
+    expect(homeLink?.className).toContain("text-primary");
+  });
+
+  it("하위 경로에서도 부모 탭이 활성 상태이다", () => {
+    vi.mocked(usePathname).mockReturnValue("/assets/stock/holdings");
+    render(<BottomNav />);
+
+    const assetsLink = screen.getByText("자산").closest("a");
+    expect(assetsLink?.className).toContain("text-primary");
+  });
+
+  it("safe-area-inset-bottom 패딩이 적용된다", () => {
+    const { container } = render(<BottomNav />);
+    const nav = container.querySelector("nav");
+    expect(nav?.className).toContain("pb-[env(safe-area-inset-bottom)]");
+  });
+});

--- a/components/layout/BottomNav.test.tsx
+++ b/components/layout/BottomNav.test.tsx
@@ -69,4 +69,28 @@ describe("BottomNav", () => {
     const nav = container.querySelector("nav");
     expect(nav?.className).toContain("pb-[env(safe-area-inset-bottom)]");
   });
+
+  it("/dashboard 경로에서 자산 탭이 활성 상태이다", () => {
+    vi.mocked(usePathname).mockReturnValue("/dashboard");
+    render(<BottomNav />);
+
+    const assetsLink = screen.getByText("자산").closest("a");
+    expect(assetsLink?.className).toContain("text-primary");
+  });
+
+  it("/dashboard/stocks 하위 경로에서도 자산 탭이 활성 상태이다", () => {
+    vi.mocked(usePathname).mockReturnValue("/dashboard/stocks");
+    render(<BottomNav />);
+
+    const assetsLink = screen.getByText("자산").closest("a");
+    expect(assetsLink?.className).toContain("text-primary");
+  });
+
+  it("/household 경로에서 설정 탭이 활성 상태이다", () => {
+    vi.mocked(usePathname).mockReturnValue("/household");
+    render(<BottomNav />);
+
+    const settingsLink = screen.getByText("설정").closest("a");
+    expect(settingsLink?.className).toContain("text-primary");
+  });
 });

--- a/components/layout/BottomNav.tsx
+++ b/components/layout/BottomNav.tsx
@@ -2,25 +2,18 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { NAV_ITEMS } from "@/constants/nav-items";
+import { isNavItemActive, NAV_ITEMS } from "@/constants/nav-items";
 import { cn } from "@/lib/utils/cn";
 
 export function BottomNav() {
   const pathname = usePathname();
-
-  const isActive = (href: string) => {
-    if (href === "/home") {
-      return pathname === "/home";
-    }
-    return pathname === href || pathname.startsWith(`${href}/`);
-  };
 
   return (
     <nav className="fixed bottom-0 left-0 right-0 z-40 bg-white border-t border-gray-200 pb-[env(safe-area-inset-bottom)] lg:hidden">
       <div className="h-16 grid grid-cols-4">
         {NAV_ITEMS.map((item) => {
           const Icon = item.icon;
-          const active = isActive(item.href);
+          const active = isNavItemActive(item, pathname);
 
           return (
             <Link

--- a/components/layout/BottomNav.tsx
+++ b/components/layout/BottomNav.tsx
@@ -1,17 +1,9 @@
 "use client";
 
-import { BarChart3, Briefcase, Home, Settings, Users } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { NAV_ITEMS } from "@/constants/nav-items";
 import { cn } from "@/lib/utils/cn";
-
-const navItems = [
-  { href: "/home", label: "홈", icon: Home },
-  { href: "/dashboard", label: "분석", icon: BarChart3 },
-  { href: "/assets", label: "자산", icon: Briefcase },
-  { href: "/household", label: "가구", icon: Users },
-  { href: "/settings", label: "설정", icon: Settings },
-];
 
 export function BottomNav() {
   const pathname = usePathname();
@@ -24,9 +16,9 @@ export function BottomNav() {
   };
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 z-40 h-16 bg-white border-t border-gray-200 lg:hidden">
-      <div className="h-full grid grid-cols-5">
-        {navItems.map((item) => {
+    <nav className="fixed bottom-0 left-0 right-0 z-40 bg-white border-t border-gray-200 pb-[env(safe-area-inset-bottom)] lg:hidden">
+      <div className="h-16 grid grid-cols-4">
+        {NAV_ITEMS.map((item) => {
           const Icon = item.icon;
           const active = isActive(item.href);
 

--- a/components/layout/Sidebar.test.tsx
+++ b/components/layout/Sidebar.test.tsx
@@ -56,4 +56,20 @@ describe("Sidebar", () => {
     const ledgerLink = screen.getByText("가계부").closest("a");
     expect(ledgerLink?.className).toContain("bg-primary/10");
   });
+
+  it("/dashboard 경로에서 자산 항목이 활성 상태이다", () => {
+    vi.mocked(usePathname).mockReturnValue("/dashboard/stocks");
+    render(<Sidebar />);
+
+    const assetsLink = screen.getByText("자산").closest("a");
+    expect(assetsLink?.className).toContain("bg-primary/10");
+  });
+
+  it("/household 경로에서 설정 항목이 활성 상태이다", () => {
+    vi.mocked(usePathname).mockReturnValue("/household");
+    render(<Sidebar />);
+
+    const settingsLink = screen.getByText("설정").closest("a");
+    expect(settingsLink?.className).toContain("bg-primary/10");
+  });
 });

--- a/components/layout/Sidebar.test.tsx
+++ b/components/layout/Sidebar.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Sidebar } from "./Sidebar";
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(() => "/home"),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+import { usePathname } from "next/navigation";
+
+describe("Sidebar", () => {
+  it("4개의 네비게이션 항목을 렌더링한다", () => {
+    render(<Sidebar />);
+
+    expect(screen.getByText("홈")).toBeInTheDocument();
+    expect(screen.getByText("가계부")).toBeInTheDocument();
+    expect(screen.getByText("자산")).toBeInTheDocument();
+    expect(screen.getByText("설정")).toBeInTheDocument();
+  });
+
+  it("분석, 가구 탭이 없다", () => {
+    render(<Sidebar />);
+
+    expect(screen.queryByText("분석")).not.toBeInTheDocument();
+    expect(screen.queryByText("가구")).not.toBeInTheDocument();
+  });
+
+  it("현재 경로에 해당하는 항목이 활성 상태이다", () => {
+    vi.mocked(usePathname).mockReturnValue("/assets");
+    render(<Sidebar />);
+
+    const assetsLink = screen.getByText("자산").closest("a");
+    expect(assetsLink?.className).toContain("bg-primary/10");
+    expect(assetsLink?.className).toContain("text-primary");
+  });
+
+  it("하위 경로에서도 부모 항목이 활성 상태이다", () => {
+    vi.mocked(usePathname).mockReturnValue("/ledger/detail");
+    render(<Sidebar />);
+
+    const ledgerLink = screen.getByText("가계부").closest("a");
+    expect(ledgerLink?.className).toContain("bg-primary/10");
+  });
+});

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -2,25 +2,18 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { NAV_ITEMS } from "@/constants/nav-items";
+import { isNavItemActive, NAV_ITEMS } from "@/constants/nav-items";
 import { cn } from "@/lib/utils/cn";
 
 export function Sidebar() {
   const pathname = usePathname();
-
-  const isActive = (href: string) => {
-    if (href === "/home") {
-      return pathname === "/home";
-    }
-    return pathname === href || pathname.startsWith(`${href}/`);
-  };
 
   return (
     <aside className="hidden lg:block w-56 shrink-0 bg-white border-r border-gray-200 overflow-y-auto">
       <nav className="p-4 space-y-1">
         {NAV_ITEMS.map((item) => {
           const Icon = item.icon;
-          const active = isActive(item.href);
+          const active = isNavItemActive(item, pathname);
 
           return (
             <Link

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -1,17 +1,9 @@
 "use client";
 
-import { BarChart3, Briefcase, Home, Settings, Users } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { NAV_ITEMS } from "@/constants/nav-items";
 import { cn } from "@/lib/utils/cn";
-
-const navItems = [
-  { href: "/home", label: "홈", icon: Home },
-  { href: "/dashboard", label: "분석", icon: BarChart3 },
-  { href: "/assets", label: "자산", icon: Briefcase },
-  { href: "/household", label: "가구", icon: Users },
-  { href: "/settings", label: "설정", icon: Settings },
-];
 
 export function Sidebar() {
   const pathname = usePathname();
@@ -26,7 +18,7 @@ export function Sidebar() {
   return (
     <aside className="hidden lg:block w-56 shrink-0 bg-white border-r border-gray-200 overflow-y-auto">
       <nav className="p-4 space-y-1">
-        {navItems.map((item) => {
+        {NAV_ITEMS.map((item) => {
           const Icon = item.icon;
           const active = isActive(item.href);
 

--- a/constants/nav-items.test.ts
+++ b/constants/nav-items.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { NAV_ITEMS } from "./nav-items";
+
+describe("NAV_ITEMS", () => {
+  it("4개의 네비게이션 항목을 가진다", () => {
+    expect(NAV_ITEMS).toHaveLength(4);
+  });
+
+  it("홈, 가계부, 자산, 설정 순서로 정의된다", () => {
+    const labels = NAV_ITEMS.map((item) => item.label);
+    expect(labels).toEqual(["홈", "가계부", "자산", "설정"]);
+  });
+
+  it("각 항목이 올바른 경로를 가진다", () => {
+    const hrefs = NAV_ITEMS.map((item) => item.href);
+    expect(hrefs).toEqual(["/home", "/ledger", "/assets", "/settings"]);
+  });
+
+  it("각 항목이 icon 컴포넌트를 가진다", () => {
+    for (const item of NAV_ITEMS) {
+      expect(item.icon).toBeDefined();
+      expect(item.icon.$$typeof).toBeDefined();
+    }
+  });
+});

--- a/constants/nav-items.test.ts
+++ b/constants/nav-items.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { NAV_ITEMS } from "./nav-items";
+import { isNavItemActive, NAV_ITEMS } from "./nav-items";
 
 describe("NAV_ITEMS", () => {
   it("4개의 네비게이션 항목을 가진다", () => {
@@ -21,5 +21,38 @@ describe("NAV_ITEMS", () => {
       expect(item.icon).toBeDefined();
       expect(item.icon.$$typeof).toBeDefined();
     }
+  });
+});
+
+describe("isNavItemActive", () => {
+  const assetsItem = NAV_ITEMS.find((item) => item.href === "/assets")!;
+  const settingsItem = NAV_ITEMS.find((item) => item.href === "/settings")!;
+  const homeItem = NAV_ITEMS.find((item) => item.href === "/home")!;
+
+  it("정확한 경로에서 활성 상태이다", () => {
+    expect(isNavItemActive(assetsItem, "/assets")).toBe(true);
+  });
+
+  it("하위 경로에서 활성 상태이다", () => {
+    expect(isNavItemActive(assetsItem, "/assets/stock/holdings")).toBe(true);
+  });
+
+  it("/home은 정확히 일치할 때만 활성이다", () => {
+    expect(isNavItemActive(homeItem, "/home")).toBe(true);
+    expect(isNavItemActive(homeItem, "/home/sub")).toBe(false);
+  });
+
+  it("/dashboard 경로에서 자산 항목이 활성이다", () => {
+    expect(isNavItemActive(assetsItem, "/dashboard")).toBe(true);
+    expect(isNavItemActive(assetsItem, "/dashboard/stocks")).toBe(true);
+  });
+
+  it("/household 경로에서 설정 항목이 활성이다", () => {
+    expect(isNavItemActive(settingsItem, "/household")).toBe(true);
+  });
+
+  it("관련 없는 경로에서 비활성이다", () => {
+    expect(isNavItemActive(assetsItem, "/home")).toBe(false);
+    expect(isNavItemActive(settingsItem, "/ledger")).toBe(false);
   });
 });

--- a/constants/nav-items.ts
+++ b/constants/nav-items.ts
@@ -5,11 +5,38 @@ export interface NavItem {
   href: string;
   label: string;
   icon: LucideIcon;
+  /** 이 탭을 활성화하는 추가 경로 접두사 (예: /dashboard -> 자산 탭) */
+  aliasPatterns?: string[];
+}
+
+export function isNavItemActive(item: NavItem, pathname: string): boolean {
+  if (item.href === "/home") {
+    return pathname === "/home";
+  }
+  if (pathname === item.href || pathname.startsWith(`${item.href}/`)) {
+    return true;
+  }
+  if (item.aliasPatterns) {
+    return item.aliasPatterns.some(
+      (alias) => pathname === alias || pathname.startsWith(`${alias}/`),
+    );
+  }
+  return false;
 }
 
 export const NAV_ITEMS: NavItem[] = [
   { href: "/home", label: "홈", icon: Home },
   { href: "/ledger", label: "가계부", icon: BookText },
-  { href: "/assets", label: "자산", icon: Wallet },
-  { href: "/settings", label: "설정", icon: Settings },
+  {
+    href: "/assets",
+    label: "자산",
+    icon: Wallet,
+    aliasPatterns: ["/dashboard"],
+  },
+  {
+    href: "/settings",
+    label: "설정",
+    icon: Settings,
+    aliasPatterns: ["/household"],
+  },
 ];

--- a/constants/nav-items.ts
+++ b/constants/nav-items.ts
@@ -1,0 +1,15 @@
+import type { LucideIcon } from "lucide-react";
+import { BookText, Home, Settings, Wallet } from "lucide-react";
+
+export interface NavItem {
+  href: string;
+  label: string;
+  icon: LucideIcon;
+}
+
+export const NAV_ITEMS: NavItem[] = [
+  { href: "/home", label: "홈", icon: Home },
+  { href: "/ledger", label: "가계부", icon: BookText },
+  { href: "/assets", label: "자산", icon: Wallet },
+  { href: "/settings", label: "설정", icon: Settings },
+];

--- a/constants/nav-items.ts
+++ b/constants/nav-items.ts
@@ -1,5 +1,5 @@
 import type { LucideIcon } from "lucide-react";
-import { BookText, Home, Settings, Wallet } from "lucide-react";
+import { BookOpen, Briefcase, Home, Settings } from "lucide-react";
 
 export interface NavItem {
   href: string;
@@ -26,11 +26,11 @@ export function isNavItemActive(item: NavItem, pathname: string): boolean {
 
 export const NAV_ITEMS: NavItem[] = [
   { href: "/home", label: "홈", icon: Home },
-  { href: "/ledger", label: "가계부", icon: BookText },
+  { href: "/ledger", label: "가계부", icon: BookOpen },
   {
     href: "/assets",
     label: "자산",
-    icon: Wallet,
+    icon: Briefcase,
     aliasPatterns: ["/dashboard"],
   },
   {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,8 @@
 packages:
   - .
+
 ignoredBuiltDependencies:
+  - esbuild
   - sharp
   - supabase
   - unrs-resolver


### PR DESCRIPTION
## Summary
- 5탭(홈/분석/자산/가구/설정) → 4탭(홈/가계부/자산/설정)으로 네비게이션 개편
- navItems를 `constants/nav-items.ts`로 공통화 (BottomNav, Sidebar 공유)
- aliasPatterns으로 `/dashboard/*` → 자산탭, `/household` → 설정탭 활성 매핑
- safe-area-inset-bottom 대응 (viewport-fit=cover + CSS 변수 + layout padding)
- `/ledger` placeholder 페이지 생성 (404 방지)

## Test plan
- [x] navItems 상수 테스트 (4개 탭, 올바른 아이콘/경로)
- [x] isNavItemActive 함수 테스트 (정확 매칭 + alias 패턴)
- [x] BottomNav 컴포넌트 테스트 (렌더링, 활성 상태, safe-area)
- [x] Sidebar 컴포넌트 테스트 (렌더링, 활성 상태)
- [x] 25 tests passed (vitest), type-check 통과, biome check 통과

Closes #229

🤖 Generated by auto-develop

Co-Authored-By: Claude <noreply@anthropic.com>