### PR TITLE
#232 [UI] 계좌/결제수단 목록 화면

### DIFF
--- a/app/(main)/assets/accounts/page.tsx
+++ b/app/(main)/assets/accounts/page.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { ChevronDown, Plus } from "lucide-react";
+import { useState } from "react";
+import {
+  AccountFormDialog,
+  AccountList,
+  PaymentMethodFormDialog,
+  PaymentMethodList,
+} from "@/components/accounts";
+import { PageContainer, PageHeader } from "@/components/layout";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+type AddDialogType = "bank" | "investment" | "payment" | null;
+
+export default function AccountsPage() {
+  const [openDialog, setOpenDialog] = useState<AddDialogType>(null);
+
+  return (
+    <PageContainer maxWidth="medium">
+      <PageHeader
+        title="계좌 / 결제수단"
+        backHref="/assets"
+        action={
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button size="sm">
+                <Plus className="w-4 h-4 mr-1" />
+                추가
+                <ChevronDown className="w-3 h-3 ml-1" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={() => setOpenDialog("bank")}>
+                은행 계좌 추가
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => setOpenDialog("investment")}>
+                투자 계좌 추가
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => setOpenDialog("payment")}>
+                결제수단 추가
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        }
+      />
+
+      <div className="space-y-8">
+        <section>
+          <h2 className="text-base font-semibold mb-3">자산 계좌</h2>
+          <AccountList />
+        </section>
+
+        <section>
+          <h2 className="text-base font-semibold mb-3">결제수단</h2>
+          <PaymentMethodList />
+        </section>
+      </div>
+
+      <AccountFormDialog
+        open={openDialog === "bank" || openDialog === "investment"}
+        onOpenChange={(open) => !open && setOpenDialog(null)}
+        category={openDialog === "bank" ? "bank" : "investment"}
+      />
+
+      <PaymentMethodFormDialog
+        open={openDialog === "payment"}
+        onOpenChange={(open) => !open && setOpenDialog(null)}
+      />
+    </PageContainer>
+  );
+}

--- a/app/(main)/assets/stock/accounts/page.tsx
+++ b/app/(main)/assets/stock/accounts/page.tsx
@@ -22,7 +22,7 @@ export default function AccountsPage() {
         }
       />
 
-      <AccountList />
+      <AccountList filter="investment" />
 
       <AccountFormDialog open={isFormOpen} onOpenChange={setIsFormOpen} />
     </PageContainer>

--- a/components/accounts/AccountFormDialog.tsx
+++ b/components/accounts/AccountFormDialog.tsx
@@ -36,37 +36,52 @@ import { Textarea } from "@/components/ui/textarea";
 import { useCreateAccount, useUpdateAccount } from "@/hooks/use-accounts";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import type { AccountWithOwner } from "@/lib/api/account";
-import type { AccountType } from "@/types";
 
-type StockAccountType = Extract<
-  AccountType,
-  "stock" | "isa" | "pension" | "cma"
->;
+const BANK_ACCOUNT_TYPES = ["checking", "savings", "deposit"] as const;
+const INVESTMENT_ACCOUNT_TYPES = ["stock", "isa", "pension", "cma"] as const;
 
-const STOCK_ACCOUNT_TYPE_VALUES: StockAccountType[] = [
-  "stock",
-  "isa",
-  "pension",
-  "cma",
-];
+type BankAccountType = (typeof BANK_ACCOUNT_TYPES)[number];
+type InvestmentAccountType = (typeof INVESTMENT_ACCOUNT_TYPES)[number];
 
-const accountFormSchema = z.object({
+const bankAccountFormSchema = z.object({
   name: z
     .string()
     .min(1, "계좌명은 필수입니다.")
     .max(50, "계좌명은 50자 이내여야 합니다."),
   broker: z.string().max(50, "증권사/은행명은 50자 이내여야 합니다."),
   accountNumber: z.string().max(50, "계좌번호는 50자 이내여야 합니다."),
-  accountType: z.enum(["stock", "isa", "pension", "cma"], {
+  accountType: z.enum(BANK_ACCOUNT_TYPES, {
     message: "계좌 유형을 선택해주세요.",
   }),
   isDefault: z.boolean(),
   memo: z.string().max(500, "메모는 500자 이내여야 합니다."),
 });
 
-type AccountFormData = z.infer<typeof accountFormSchema>;
+const investmentAccountFormSchema = z.object({
+  name: z
+    .string()
+    .min(1, "계좌명은 필수입니다.")
+    .max(50, "계좌명은 50자 이내여야 합니다."),
+  broker: z.string().max(50, "증권사/은행명은 50자 이내여야 합니다."),
+  accountNumber: z.string().max(50, "계좌번호는 50자 이내여야 합니다."),
+  accountType: z.enum(INVESTMENT_ACCOUNT_TYPES, {
+    message: "계좌 유형을 선택해주세요.",
+  }),
+  isDefault: z.boolean(),
+  memo: z.string().max(500, "메모는 500자 이내여야 합니다."),
+});
 
-const ACCOUNT_TYPES = [
+type BankAccountFormData = z.infer<typeof bankAccountFormSchema>;
+type InvestmentAccountFormData = z.infer<typeof investmentAccountFormSchema>;
+type AccountFormData = BankAccountFormData | InvestmentAccountFormData;
+
+const BANK_ACCOUNT_TYPE_OPTIONS = [
+  { value: "checking", label: "입출금" },
+  { value: "savings", label: "적금" },
+  { value: "deposit", label: "예금" },
+] as const;
+
+const INVESTMENT_ACCOUNT_TYPE_OPTIONS = [
   { value: "stock", label: "일반" },
   { value: "isa", label: "ISA" },
   { value: "pension", label: "연금저축" },
@@ -77,16 +92,31 @@ interface AccountFormDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   account?: AccountWithOwner | null;
+  category?: "bank" | "investment";
 }
 
 export function AccountFormDialog({
   open,
   onOpenChange,
   account,
+  category = "investment",
 }: AccountFormDialogProps) {
   const isEditing = !!account;
   const createAccount = useCreateAccount();
   const updateAccount = useUpdateAccount();
+
+  const effectiveCategory =
+    account?.category ??
+    (BANK_ACCOUNT_TYPES.includes(account?.accountType as BankAccountType)
+      ? "bank"
+      : category);
+
+  const isBank = effectiveCategory === "bank";
+  const schema = isBank ? bankAccountFormSchema : investmentAccountFormSchema;
+  const defaultAccountType = isBank ? "checking" : "stock";
+  const accountTypeOptions = isBank
+    ? BANK_ACCOUNT_TYPE_OPTIONS
+    : INVESTMENT_ACCOUNT_TYPE_OPTIONS;
 
   const {
     register,
@@ -96,12 +126,13 @@ export function AccountFormDialog({
     reset,
     formState: { errors, isSubmitting },
   } = useForm<AccountFormData>({
-    resolver: zodResolver(accountFormSchema),
+    resolver: zodResolver(schema),
     defaultValues: {
       name: "",
       broker: "",
       accountNumber: "",
-      accountType: "stock",
+      accountType: defaultAccountType as BankAccountType &
+        InvestmentAccountType,
       isDefault: false,
       memo: "",
     },
@@ -112,21 +143,18 @@ export function AccountFormDialog({
   useEffect(() => {
     if (open) {
       if (account) {
-        const isStockAccountType = (
-          type: AccountType | null,
-        ): type is StockAccountType =>
-          type !== null &&
-          STOCK_ACCOUNT_TYPE_VALUES.includes(type as StockAccountType);
-
-        const accountType = isStockAccountType(account.accountType)
+        const validTypes = isBank
+          ? (BANK_ACCOUNT_TYPES as readonly string[])
+          : (INVESTMENT_ACCOUNT_TYPES as readonly string[]);
+        const resolvedType = validTypes.includes(account.accountType ?? "")
           ? account.accountType
-          : "stock";
+          : defaultAccountType;
 
         reset({
           name: account.name,
           broker: account.broker || "",
           accountNumber: account.accountNumber || "",
-          accountType,
+          accountType: resolvedType as BankAccountType & InvestmentAccountType,
           isDefault: account.isDefault,
           memo: account.memo || "",
         });
@@ -135,13 +163,14 @@ export function AccountFormDialog({
           name: "",
           broker: "",
           accountNumber: "",
-          accountType: "stock",
+          accountType: defaultAccountType as BankAccountType &
+            InvestmentAccountType,
           isDefault: false,
           memo: "",
         });
       }
     }
-  }, [open, account, reset]);
+  }, [open, account, reset, isBank, defaultAccountType]);
 
   const onSubmit = async (data: AccountFormData, continueAdding = false) => {
     try {
@@ -153,6 +182,7 @@ export function AccountFormDialog({
             broker: data.broker || null,
             accountNumber: data.accountNumber || null,
             accountType: data.accountType,
+            category: isBank ? "bank" : "investment",
             isDefault: data.isDefault,
             memo: data.memo || null,
           },
@@ -160,7 +190,10 @@ export function AccountFormDialog({
         toast.success("계좌가 수정되었습니다.");
         onOpenChange(false);
       } else {
-        await createAccount.mutateAsync(data);
+        await createAccount.mutateAsync({
+          ...data,
+          category: isBank ? "bank" : "investment",
+        });
         toast.success(`${data.name} 계좌가 추가되었습니다.`);
 
         if (continueAdding) {
@@ -201,7 +234,9 @@ export function AccountFormDialog({
         </Label>
         <Input
           id="name"
-          placeholder="예: 삼성증권 주식계좌"
+          placeholder={
+            isBank ? "예: 국민은행 입출금통장" : "예: 삼성증권 주식계좌"
+          }
           {...register("name")}
           aria-invalid={!!errors.name}
         />
@@ -211,10 +246,12 @@ export function AccountFormDialog({
       </div>
 
       <div className="space-y-2">
-        <Label htmlFor="broker">증권사/은행</Label>
+        <Label htmlFor="broker">{isBank ? "은행" : "증권사/은행"}</Label>
         <Input
           id="broker"
-          placeholder="예: 삼성증권, 토스증권"
+          placeholder={
+            isBank ? "예: 국민은행, 신한은행" : "예: 삼성증권, 토스증권"
+          }
           {...register("broker")}
           aria-invalid={!!errors.broker}
         />
@@ -229,15 +266,18 @@ export function AccountFormDialog({
         </Label>
         <Select
           value={watch("accountType")}
-          onValueChange={(value: StockAccountType) =>
-            setValue("accountType", value)
+          onValueChange={(value) =>
+            setValue(
+              "accountType",
+              value as BankAccountType & InvestmentAccountType,
+            )
           }
         >
           <SelectTrigger id="accountType">
             <SelectValue placeholder="계좌 유형 선택" />
           </SelectTrigger>
           <SelectContent>
-            {ACCOUNT_TYPES.map((type) => (
+            {accountTypeOptions.map((type) => (
               <SelectItem key={type.value} value={type.value}>
                 {type.label}
               </SelectItem>
@@ -293,17 +333,24 @@ export function AccountFormDialog({
     </>
   );
 
+  const title = isEditing
+    ? "계좌 수정"
+    : isBank
+      ? "은행 계좌 추가"
+      : "투자 계좌 추가";
+  const description = isEditing
+    ? "계좌 정보를 수정합니다."
+    : isBank
+      ? "새로운 은행 계좌를 등록합니다."
+      : "새로운 투자 계좌를 등록합니다.";
+
   if (isDesktop) {
     return (
       <Dialog open={open} onOpenChange={onOpenChange}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
-            <DialogTitle>{isEditing ? "계좌 수정" : "계좌 추가"}</DialogTitle>
-            <DialogDescription>
-              {isEditing
-                ? "계좌 정보를 수정합니다."
-                : "새로운 계좌를 등록합니다."}
-            </DialogDescription>
+            <DialogTitle>{title}</DialogTitle>
+            <DialogDescription>{description}</DialogDescription>
           </DialogHeader>
 
           <form className="space-y-4">{formFields}</form>
@@ -343,17 +390,12 @@ export function AccountFormDialog({
     );
   }
 
-  // 모바일: Drawer (Bottom Sheet)
   return (
     <Drawer open={open} onOpenChange={onOpenChange}>
       <DrawerContent>
         <DrawerHeader>
-          <DrawerTitle>{isEditing ? "계좌 수정" : "계좌 추가"}</DrawerTitle>
-          <DrawerDescription>
-            {isEditing
-              ? "계좌 정보를 수정합니다."
-              : "새로운 계좌를 등록합니다."}
-          </DrawerDescription>
+          <DrawerTitle>{title}</DrawerTitle>
+          <DrawerDescription>{description}</DrawerDescription>
         </DrawerHeader>
 
         <div className="overflow-y-auto flex-1 px-4">

--- a/components/accounts/AccountList.tsx
+++ b/components/accounts/AccountList.tsx
@@ -26,13 +26,136 @@ import { AccountDeleteDialog } from "./AccountDeleteDialog";
 import { AccountFormDialog } from "./AccountFormDialog";
 
 const ACCOUNT_TYPE_LABELS: Record<string, string> = {
+  checking: "입출금",
+  savings: "적금",
+  deposit: "예금",
   stock: "일반",
   isa: "ISA",
   pension: "연금저축",
   cma: "CMA",
 };
 
-export function AccountList() {
+const BANK_ACCOUNT_TYPES = ["checking", "savings", "deposit"] as const;
+const INVESTMENT_ACCOUNT_TYPES = ["stock", "isa", "pension", "cma"] as const;
+
+type BankAccountType = (typeof BANK_ACCOUNT_TYPES)[number];
+type InvestmentAccountType = (typeof INVESTMENT_ACCOUNT_TYPES)[number];
+
+function isBankAccountType(type: string | null): type is BankAccountType {
+  return BANK_ACCOUNT_TYPES.includes(type as BankAccountType);
+}
+
+function isInvestmentAccountType(
+  type: string | null,
+): type is InvestmentAccountType {
+  return INVESTMENT_ACCOUNT_TYPES.includes(type as InvestmentAccountType);
+}
+
+interface AccountListProps {
+  filter?: "bank" | "investment";
+}
+
+interface AccountTableProps {
+  accounts: AccountWithOwner[];
+  currentUserId: string | null;
+  category?: "bank" | "investment";
+  onEdit: (account: AccountWithOwner, category?: "bank" | "investment") => void;
+  onDelete: (account: AccountWithOwner) => void;
+  onSetDefault: (account: AccountWithOwner) => void;
+}
+
+function AccountTable({
+  accounts,
+  currentUserId,
+  category,
+  onEdit,
+  onDelete,
+  onSetDefault,
+}: AccountTableProps) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="pl-5">계좌명</TableHead>
+          <TableHead>소유자</TableHead>
+          <TableHead>증권사/은행</TableHead>
+          <TableHead>계좌유형</TableHead>
+          <TableHead>계좌번호</TableHead>
+          <TableHead className="w-12 pr-5" />
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {accounts.map((account) => {
+          const isOwner = currentUserId === account.ownerId;
+          return (
+            <TableRow key={account.id}>
+              <TableCell className="font-medium pl-5">
+                <div className="flex items-center gap-2">
+                  {account.name}
+                  {account.isDefault && (
+                    <Badge variant="secondary" className="text-xs">
+                      기본
+                    </Badge>
+                  )}
+                </div>
+              </TableCell>
+              <TableCell className="text-gray-600">
+                {account.ownerName}
+              </TableCell>
+              <TableCell className="text-gray-600">
+                {account.broker || "-"}
+              </TableCell>
+              <TableCell className="text-gray-600">
+                {account.accountType
+                  ? ACCOUNT_TYPE_LABELS[account.accountType] ||
+                    account.accountType
+                  : "-"}
+              </TableCell>
+              <TableCell className="text-gray-600">
+                {account.accountNumber || "-"}
+              </TableCell>
+              <TableCell className="pr-5">
+                {isOwner && (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="ghost" size="icon" className="h-8 w-8">
+                        <MoreHorizontal className="h-4 w-4" />
+                        <span className="sr-only">메뉴 열기</span>
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem
+                        onClick={() => onEdit(account, category)}
+                      >
+                        <Pencil className="h-4 w-4 mr-2" />
+                        수정
+                      </DropdownMenuItem>
+                      {!account.isDefault && (
+                        <DropdownMenuItem onClick={() => onSetDefault(account)}>
+                          <Star className="h-4 w-4 mr-2" />
+                          기본 계좌로 설정
+                        </DropdownMenuItem>
+                      )}
+                      <DropdownMenuItem
+                        className="text-destructive focus:text-destructive"
+                        onClick={() => onDelete(account)}
+                      >
+                        <Trash2 className="h-4 w-4 mr-2" />
+                        삭제
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                )}
+              </TableCell>
+            </TableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
+  );
+}
+
+export function AccountList({ filter }: AccountListProps) {
   const { data: accounts, isLoading, error } = useAccounts();
   const { userId: currentUserId } = useCurrentUserId();
   const updateAccount = useUpdateAccount();
@@ -40,6 +163,9 @@ export function AccountList() {
   const [editingAccount, setEditingAccount] = useState<AccountWithOwner | null>(
     null,
   );
+  const [editingCategory, setEditingCategory] = useState<
+    "bank" | "investment" | undefined
+  >();
   const [deletingAccount, setDeletingAccount] =
     useState<AccountWithOwner | null>(null);
   const [isFormOpen, setIsFormOpen] = useState(false);
@@ -60,8 +186,12 @@ export function AccountList() {
     }
   };
 
-  const handleEdit = (account: AccountWithOwner) => {
+  const handleEdit = (
+    account: AccountWithOwner,
+    category?: "bank" | "investment",
+  ) => {
     setEditingAccount(account);
+    setEditingCategory(category);
     setIsFormOpen(true);
   };
 
@@ -72,6 +202,7 @@ export function AccountList() {
   const handleFormClose = () => {
     setIsFormOpen(false);
     setEditingAccount(null);
+    setEditingCategory(undefined);
   };
 
   if (isLoading) {
@@ -95,7 +226,66 @@ export function AccountList() {
     );
   }
 
-  if (!accounts || accounts.length === 0) {
+  const allAccounts = accounts ?? [];
+
+  // filter prop이 있으면 필터링만 (서브그룹핑 없음)
+  if (filter) {
+    const filtered = allAccounts.filter((account) => {
+      if (filter === "bank") return isBankAccountType(account.accountType);
+      if (filter === "investment")
+        return isInvestmentAccountType(account.accountType);
+      return true;
+    });
+
+    if (filtered.length === 0) {
+      return (
+        <div className="bg-white rounded-2xl shadow-sm p-8 text-center">
+          <p className="text-gray-500">등록된 계좌가 없습니다.</p>
+          <p className="text-sm text-gray-400 mt-1">
+            상단의 &quot;계좌 추가&quot; 버튼으로 계좌를 등록해보세요.
+          </p>
+        </div>
+      );
+    }
+
+    return (
+      <>
+        <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
+          <AccountTable
+            accounts={filtered}
+            currentUserId={currentUserId}
+            onEdit={handleEdit}
+            onDelete={handleDelete}
+            onSetDefault={handleSetDefault}
+          />
+        </div>
+
+        <AccountFormDialog
+          open={isFormOpen}
+          onOpenChange={handleFormClose}
+          account={editingAccount}
+          category={filter}
+        />
+
+        <AccountDeleteDialog
+          account={deletingAccount}
+          open={!!deletingAccount}
+          onOpenChange={(open) => !open && setDeletingAccount(null)}
+        />
+      </>
+    );
+  }
+
+  // filter 없으면 bank/investment 서브그룹핑
+  const bankAccounts = allAccounts.filter((a) =>
+    isBankAccountType(a.accountType),
+  );
+  const investmentAccounts = allAccounts.filter((a) =>
+    isInvestmentAccountType(a.accountType),
+  );
+  const hasAnyAccount = allAccounts.length > 0;
+
+  if (!hasAnyAccount) {
     return (
       <div className="bg-white rounded-2xl shadow-sm p-8 text-center">
         <p className="text-gray-500">등록된 계좌가 없습니다.</p>
@@ -108,96 +298,49 @@ export function AccountList() {
 
   return (
     <>
-      <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead className="pl-5">계좌명</TableHead>
-              <TableHead>소유자</TableHead>
-              <TableHead>증권사/은행</TableHead>
-              <TableHead>계좌유형</TableHead>
-              <TableHead>계좌번호</TableHead>
-              <TableHead className="w-12 pr-5" />
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {accounts.map((account) => {
-              const isOwner = currentUserId === account.ownerId;
-              return (
-                <TableRow key={account.id}>
-                  <TableCell className="font-medium pl-5">
-                    <div className="flex items-center gap-2">
-                      {account.name}
-                      {account.isDefault && (
-                        <Badge variant="secondary" className="text-xs">
-                          기본
-                        </Badge>
-                      )}
-                    </div>
-                  </TableCell>
-                  <TableCell className="text-gray-600">
-                    {account.ownerName}
-                  </TableCell>
-                  <TableCell className="text-gray-600">
-                    {account.broker || "-"}
-                  </TableCell>
-                  <TableCell className="text-gray-600">
-                    {account.accountType
-                      ? ACCOUNT_TYPE_LABELS[account.accountType] ||
-                        account.accountType
-                      : "-"}
-                  </TableCell>
-                  <TableCell className="text-gray-600">
-                    {account.accountNumber || "-"}
-                  </TableCell>
-                  <TableCell className="pr-5">
-                    {isOwner && (
-                      <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="h-8 w-8"
-                          >
-                            <MoreHorizontal className="h-4 w-4" />
-                            <span className="sr-only">메뉴 열기</span>
-                          </Button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end">
-                          <DropdownMenuItem onClick={() => handleEdit(account)}>
-                            <Pencil className="h-4 w-4 mr-2" />
-                            수정
-                          </DropdownMenuItem>
-                          {!account.isDefault && (
-                            <DropdownMenuItem
-                              onClick={() => handleSetDefault(account)}
-                            >
-                              <Star className="h-4 w-4 mr-2" />
-                              기본 계좌로 설정
-                            </DropdownMenuItem>
-                          )}
-                          <DropdownMenuItem
-                            className="text-destructive focus:text-destructive"
-                            onClick={() => handleDelete(account)}
-                          >
-                            <Trash2 className="h-4 w-4 mr-2" />
-                            삭제
-                          </DropdownMenuItem>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-                    )}
-                  </TableCell>
-                </TableRow>
-              );
-            })}
-          </TableBody>
-        </Table>
+      <div className="space-y-4">
+        {bankAccounts.length > 0 && (
+          <div>
+            <h3 className="text-sm font-medium text-gray-500 mb-2 px-1">
+              은행 계좌
+            </h3>
+            <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
+              <AccountTable
+                accounts={bankAccounts}
+                currentUserId={currentUserId}
+                category="bank"
+                onEdit={handleEdit}
+                onDelete={handleDelete}
+                onSetDefault={handleSetDefault}
+              />
+            </div>
+          </div>
+        )}
+
+        {investmentAccounts.length > 0 && (
+          <div>
+            <h3 className="text-sm font-medium text-gray-500 mb-2 px-1">
+              투자 계좌
+            </h3>
+            <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
+              <AccountTable
+                accounts={investmentAccounts}
+                currentUserId={currentUserId}
+                category="investment"
+                onEdit={handleEdit}
+                onDelete={handleDelete}
+                onSetDefault={handleSetDefault}
+              />
+            </div>
+          </div>
+        )}
       </div>
 
       <AccountFormDialog
         open={isFormOpen}
         onOpenChange={handleFormClose}
         account={editingAccount}
+        category={editingCategory}
       />
 
       <AccountDeleteDialog

--- a/components/accounts/PaymentMethodDeleteDialog.tsx
+++ b/components/accounts/PaymentMethodDeleteDialog.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { AlertTriangleIcon } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useDeletePaymentMethod } from "@/hooks/use-payment-methods";
+import type { PaymentMethodWithDetails } from "@/lib/api/payment-method";
+
+const PAYMENT_METHOD_TYPE_LABELS: Record<string, string> = {
+  credit_card: "신용카드",
+  debit_card: "체크카드",
+  prepaid: "선불페이",
+  gift_card: "상품권",
+  cash: "현금",
+};
+
+interface PaymentMethodDeleteDialogProps {
+  paymentMethod: PaymentMethodWithDetails | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function PaymentMethodDeleteDialog({
+  paymentMethod,
+  open,
+  onOpenChange,
+}: PaymentMethodDeleteDialogProps) {
+  const deleteMutation = useDeletePaymentMethod();
+
+  const handleDelete = async () => {
+    if (!paymentMethod) return;
+
+    try {
+      await deleteMutation.mutateAsync(paymentMethod.id);
+      toast.success(`${paymentMethod.name}이(가) 삭제되었습니다.`);
+      onOpenChange(false);
+    } catch (error) {
+      if (error instanceof Error) {
+        toast.error(error.message);
+      } else {
+        toast.error("결제수단 삭제에 실패했습니다.");
+      }
+    }
+  };
+
+  if (!paymentMethod) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <AlertTriangleIcon className="h-5 w-5 text-destructive" />
+            결제수단 삭제
+          </DialogTitle>
+          <DialogDescription>
+            다음 결제수단을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="rounded-md border p-4 space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="font-medium">{paymentMethod.name}</span>
+            {paymentMethod.isDefault && (
+              <span className="text-xs bg-secondary text-secondary-foreground px-2 py-0.5 rounded">
+                기본
+              </span>
+            )}
+          </div>
+          <div className="text-sm text-muted-foreground space-y-1">
+            <div className="flex justify-between">
+              <span>유형</span>
+              <span>
+                {PAYMENT_METHOD_TYPE_LABELS[paymentMethod.type] ||
+                  paymentMethod.type}
+              </span>
+            </div>
+            {paymentMethod.issuer && (
+              <div className="flex justify-between">
+                <span>카드사/서비스</span>
+                <span>{paymentMethod.issuer}</span>
+              </div>
+            )}
+            {paymentMethod.lastFour && (
+              <div className="flex justify-between">
+                <span>카드번호 끝 4자리</span>
+                <span>···· {paymentMethod.lastFour}</span>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={deleteMutation.isPending}
+          >
+            취소
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={handleDelete}
+            disabled={deleteMutation.isPending}
+          >
+            {deleteMutation.isPending ? "삭제 중..." : "삭제"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/accounts/PaymentMethodFormDialog.tsx
+++ b/components/accounts/PaymentMethodFormDialog.tsx
@@ -1,0 +1,430 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { useAccounts } from "@/hooks/use-accounts";
+import { useMediaQuery } from "@/hooks/use-media-query";
+import {
+  useCreatePaymentMethod,
+  useUpdatePaymentMethod,
+} from "@/hooks/use-payment-methods";
+import type { PaymentMethodWithDetails } from "@/lib/api/payment-method";
+
+const PAYMENT_METHOD_TYPE_VALUES = [
+  "credit_card",
+  "debit_card",
+  "prepaid",
+  "gift_card",
+  "cash",
+] as const;
+
+const PAYMENT_METHOD_TYPE_OPTIONS = [
+  { value: "credit_card", label: "신용카드" },
+  { value: "debit_card", label: "체크카드" },
+  { value: "prepaid", label: "선불페이" },
+  { value: "gift_card", label: "상품권" },
+  { value: "cash", label: "현금" },
+] as const;
+
+type PaymentMethodTypeValue = (typeof PAYMENT_METHOD_TYPE_VALUES)[number];
+
+const paymentMethodFormSchema = z.object({
+  name: z
+    .string()
+    .min(1, "결제수단명은 필수입니다.")
+    .max(50, "결제수단명은 50자 이내여야 합니다."),
+  type: z.enum(PAYMENT_METHOD_TYPE_VALUES, {
+    message: "결제수단 유형을 선택해주세요.",
+  }),
+  linkedAccountId: z.string().optional(),
+  issuer: z
+    .string()
+    .max(50, "카드사/서비스명은 50자 이내여야 합니다.")
+    .optional(),
+  lastFour: z
+    .string()
+    .length(4, "카드 번호 끝 4자리를 입력해주세요.")
+    .regex(/^\d{4}$/, "숫자 4자리만 입력해주세요.")
+    .optional()
+    .or(z.literal("")),
+  paymentDay: z
+    .number()
+    .int()
+    .min(1, "결제일은 1일 이상이어야 합니다.")
+    .max(31, "결제일은 31일 이하여야 합니다.")
+    .optional()
+    .or(z.nan()),
+  isDefault: z.boolean(),
+  memo: z.string().max(500, "메모는 500자 이내여야 합니다.").optional(),
+});
+
+type PaymentMethodFormData = z.infer<typeof paymentMethodFormSchema>;
+
+interface PaymentMethodFormDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  paymentMethod?: PaymentMethodWithDetails | null;
+}
+
+export function PaymentMethodFormDialog({
+  open,
+  onOpenChange,
+  paymentMethod,
+}: PaymentMethodFormDialogProps) {
+  const isEditing = !!paymentMethod;
+  const createPaymentMethod = useCreatePaymentMethod();
+  const updatePaymentMethod = useUpdatePaymentMethod();
+  const { data: accounts } = useAccounts();
+
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    watch,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<PaymentMethodFormData>({
+    resolver: zodResolver(paymentMethodFormSchema),
+    defaultValues: {
+      name: "",
+      type: "credit_card",
+      linkedAccountId: undefined,
+      issuer: "",
+      lastFour: "",
+      paymentDay: undefined,
+      isDefault: false,
+      memo: "",
+    },
+  });
+
+  const watchIsDefault = watch("isDefault");
+  const watchType = watch("type");
+
+  const showCardFields =
+    watchType === "credit_card" || watchType === "debit_card";
+  const showPaymentDay = watchType === "credit_card";
+
+  useEffect(() => {
+    if (open) {
+      if (paymentMethod) {
+        reset({
+          name: paymentMethod.name,
+          type: paymentMethod.type as PaymentMethodTypeValue,
+          linkedAccountId: paymentMethod.linkedAccountId ?? undefined,
+          issuer: paymentMethod.issuer ?? "",
+          lastFour: paymentMethod.lastFour ?? "",
+          paymentDay: paymentMethod.paymentDay ?? undefined,
+          isDefault: paymentMethod.isDefault,
+          memo: paymentMethod.memo ?? "",
+        });
+      } else {
+        reset({
+          name: "",
+          type: "credit_card",
+          linkedAccountId: undefined,
+          issuer: "",
+          lastFour: "",
+          paymentDay: undefined,
+          isDefault: false,
+          memo: "",
+        });
+      }
+    }
+  }, [open, paymentMethod, reset]);
+
+  const onSubmit = async (data: PaymentMethodFormData) => {
+    const payload = {
+      name: data.name,
+      type: data.type,
+      linkedAccountId: data.linkedAccountId || undefined,
+      issuer: data.issuer || undefined,
+      lastFour: data.lastFour || undefined,
+      paymentDay: Number.isNaN(data.paymentDay)
+        ? undefined
+        : (data.paymentDay as number | undefined),
+      isDefault: data.isDefault,
+      memo: data.memo || undefined,
+    };
+
+    try {
+      if (isEditing && paymentMethod) {
+        await updatePaymentMethod.mutateAsync({
+          id: paymentMethod.id,
+          data: payload,
+        });
+        toast.success("결제수단이 수정되었습니다.");
+      } else {
+        await createPaymentMethod.mutateAsync(payload);
+        toast.success(`${data.name}이(가) 추가되었습니다.`);
+      }
+      onOpenChange(false);
+    } catch (error) {
+      if (error instanceof Error) {
+        toast.error(error.message);
+      } else {
+        toast.error(
+          isEditing
+            ? "결제수단 수정에 실패했습니다."
+            : "결제수단 추가에 실패했습니다.",
+        );
+      }
+    }
+  };
+
+  const handleSave = handleSubmit(onSubmit);
+  const isPending =
+    createPaymentMethod.isPending || updatePaymentMethod.isPending;
+  const isDesktop = useMediaQuery("(min-width: 768px)");
+
+  const formFields = (
+    <>
+      <div className="space-y-2">
+        <Label htmlFor="pm-name">
+          결제수단명 <span className="text-destructive">*</span>
+        </Label>
+        <Input
+          id="pm-name"
+          placeholder="예: 신한카드 체크"
+          {...register("name")}
+          aria-invalid={!!errors.name}
+        />
+        {errors.name && (
+          <p className="text-sm text-destructive">{errors.name.message}</p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="pm-type">
+          유형 <span className="text-destructive">*</span>
+        </Label>
+        <Select
+          value={watchType}
+          onValueChange={(value: PaymentMethodTypeValue) =>
+            setValue("type", value)
+          }
+        >
+          <SelectTrigger id="pm-type">
+            <SelectValue placeholder="결제수단 유형 선택" />
+          </SelectTrigger>
+          <SelectContent>
+            {PAYMENT_METHOD_TYPE_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {errors.type && (
+          <p className="text-sm text-destructive">{errors.type.message}</p>
+        )}
+      </div>
+
+      {showCardFields && (
+        <div className="space-y-2">
+          <Label htmlFor="pm-issuer">카드사</Label>
+          <Input
+            id="pm-issuer"
+            placeholder="예: 신한카드, 삼성카드"
+            {...register("issuer")}
+            aria-invalid={!!errors.issuer}
+          />
+          {errors.issuer && (
+            <p className="text-sm text-destructive">{errors.issuer.message}</p>
+          )}
+        </div>
+      )}
+
+      {showCardFields && (
+        <div className="space-y-2">
+          <Label htmlFor="pm-last-four">카드번호 끝 4자리</Label>
+          <Input
+            id="pm-last-four"
+            placeholder="예: 1234"
+            maxLength={4}
+            {...register("lastFour")}
+            aria-invalid={!!errors.lastFour}
+          />
+          {errors.lastFour && (
+            <p className="text-sm text-destructive">
+              {errors.lastFour.message}
+            </p>
+          )}
+        </div>
+      )}
+
+      {showPaymentDay && (
+        <div className="space-y-2">
+          <Label htmlFor="pm-payment-day">결제일</Label>
+          <Input
+            id="pm-payment-day"
+            type="number"
+            min={1}
+            max={31}
+            placeholder="예: 15"
+            {...register("paymentDay", { valueAsNumber: true })}
+            aria-invalid={!!errors.paymentDay}
+          />
+          {errors.paymentDay && (
+            <p className="text-sm text-destructive">
+              {errors.paymentDay.message}
+            </p>
+          )}
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <Label htmlFor="pm-linked-account">연결 계좌</Label>
+        <Select
+          value={watch("linkedAccountId") ?? "none"}
+          onValueChange={(value) =>
+            setValue("linkedAccountId", value === "none" ? undefined : value)
+          }
+        >
+          <SelectTrigger id="pm-linked-account">
+            <SelectValue placeholder="연결할 계좌 선택 (선택사항)" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="none">없음</SelectItem>
+            {(accounts ?? []).map((account) => (
+              <SelectItem key={account.id} value={account.id}>
+                {account.name}
+                {account.broker ? ` (${account.broker})` : ""}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex items-center space-x-2">
+        <Checkbox
+          id="pm-is-default"
+          checked={watchIsDefault}
+          onCheckedChange={(checked) => setValue("isDefault", checked === true)}
+        />
+        <Label htmlFor="pm-is-default" className="font-normal cursor-pointer">
+          기본 결제수단으로 설정
+        </Label>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="pm-memo">메모</Label>
+        <Textarea
+          id="pm-memo"
+          placeholder="결제수단에 대한 메모를 입력하세요"
+          rows={2}
+          {...register("memo")}
+          aria-invalid={!!errors.memo}
+        />
+        {errors.memo && (
+          <p className="text-sm text-destructive">{errors.memo.message}</p>
+        )}
+      </div>
+    </>
+  );
+
+  const title = isEditing ? "결제수단 수정" : "결제수단 추가";
+  const description = isEditing
+    ? "결제수단 정보를 수정합니다."
+    : "새로운 결제수단을 등록합니다.";
+
+  if (isDesktop) {
+    return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>{title}</DialogTitle>
+            <DialogDescription>{description}</DialogDescription>
+          </DialogHeader>
+
+          <form className="space-y-4">{formFields}</form>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => onOpenChange(false)}
+              disabled={isPending || isSubmitting}
+            >
+              취소
+            </Button>
+            <Button
+              type="button"
+              onClick={handleSave}
+              disabled={isPending || isSubmitting}
+            >
+              {isPending || isSubmitting ? "저장 중..." : "저장"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent>
+        <DrawerHeader>
+          <DrawerTitle>{title}</DrawerTitle>
+          <DrawerDescription>{description}</DrawerDescription>
+        </DrawerHeader>
+
+        <div className="overflow-y-auto flex-1 px-4">
+          <form className="space-y-4 pb-2">{formFields}</form>
+        </div>
+
+        <DrawerFooter>
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => onOpenChange(false)}
+              disabled={isPending || isSubmitting}
+              className="flex-1"
+            >
+              취소
+            </Button>
+            <Button
+              type="button"
+              onClick={handleSave}
+              disabled={isPending || isSubmitting}
+              className="flex-1"
+            >
+              {isPending || isSubmitting ? "저장 중..." : "저장"}
+            </Button>
+          </div>
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/components/accounts/PaymentMethodList.tsx
+++ b/components/accounts/PaymentMethodList.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useCurrentUserId } from "@/hooks/use-current-user";
+import { usePaymentMethods } from "@/hooks/use-payment-methods";
+import type { PaymentMethodWithDetails } from "@/lib/api/payment-method";
+import { PaymentMethodDeleteDialog } from "./PaymentMethodDeleteDialog";
+import { PaymentMethodFormDialog } from "./PaymentMethodFormDialog";
+
+const PAYMENT_METHOD_TYPE_LABELS: Record<string, string> = {
+  credit_card: "신용카드",
+  debit_card: "체크카드",
+  prepaid: "선불페이",
+  gift_card: "상품권",
+  cash: "현금",
+};
+
+export function PaymentMethodList() {
+  const { data: paymentMethods, isLoading, error } = usePaymentMethods();
+  const { userId: currentUserId } = useCurrentUserId();
+
+  const [editingMethod, setEditingMethod] =
+    useState<PaymentMethodWithDetails | null>(null);
+  const [deletingMethod, setDeletingMethod] =
+    useState<PaymentMethodWithDetails | null>(null);
+  const [isFormOpen, setIsFormOpen] = useState(false);
+
+  const handleEdit = (method: PaymentMethodWithDetails) => {
+    setEditingMethod(method);
+    setIsFormOpen(true);
+  };
+
+  const handleDelete = (method: PaymentMethodWithDetails) => {
+    setDeletingMethod(method);
+  };
+
+  const handleFormClose = () => {
+    setIsFormOpen(false);
+    setEditingMethod(null);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="bg-white rounded-2xl shadow-sm p-8">
+        <div className="animate-pulse space-y-4">
+          <div className="h-4 bg-gray-200 rounded w-1/4" />
+          <div className="h-10 bg-gray-100 rounded" />
+          <div className="h-10 bg-gray-100 rounded" />
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-white rounded-2xl shadow-sm p-8 text-center">
+        <p className="text-destructive">
+          결제수단 목록을 불러오는데 실패했습니다.
+        </p>
+      </div>
+    );
+  }
+
+  if (!paymentMethods || paymentMethods.length === 0) {
+    return (
+      <div className="bg-white rounded-2xl shadow-sm p-8 text-center">
+        <p className="text-gray-500">등록된 결제수단이 없습니다.</p>
+        <p className="text-sm text-gray-400 mt-1">
+          상단의 &quot;추가&quot; 버튼으로 결제수단을 등록해보세요.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="pl-5">결제수단명</TableHead>
+              <TableHead>소유자</TableHead>
+              <TableHead>유형</TableHead>
+              <TableHead>카드사/서비스</TableHead>
+              <TableHead>연결 계좌</TableHead>
+              <TableHead className="w-12 pr-5" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {paymentMethods.map((method) => {
+              const isOwner = currentUserId === method.ownerId;
+              return (
+                <TableRow key={method.id}>
+                  <TableCell className="font-medium pl-5">
+                    <div className="flex items-center gap-2">
+                      {method.name}
+                      {method.isDefault && (
+                        <Badge variant="secondary" className="text-xs">
+                          기본
+                        </Badge>
+                      )}
+                      {method.lastFour && (
+                        <span className="text-xs text-gray-400">
+                          ···· {method.lastFour}
+                        </span>
+                      )}
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-gray-600">
+                    {method.ownerName}
+                  </TableCell>
+                  <TableCell className="text-gray-600">
+                    {PAYMENT_METHOD_TYPE_LABELS[method.type] || method.type}
+                  </TableCell>
+                  <TableCell className="text-gray-600">
+                    {method.issuer || "-"}
+                  </TableCell>
+                  <TableCell className="text-gray-600">
+                    {method.linkedAccountName || "-"}
+                  </TableCell>
+                  <TableCell className="pr-5">
+                    {isOwner && (
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8"
+                          >
+                            <MoreHorizontal className="h-4 w-4" />
+                            <span className="sr-only">메뉴 열기</span>
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem onClick={() => handleEdit(method)}>
+                            <Pencil className="h-4 w-4 mr-2" />
+                            수정
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            className="text-destructive focus:text-destructive"
+                            onClick={() => handleDelete(method)}
+                          >
+                            <Trash2 className="h-4 w-4 mr-2" />
+                            삭제
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    )}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </div>
+
+      <PaymentMethodFormDialog
+        open={isFormOpen}
+        onOpenChange={handleFormClose}
+        paymentMethod={editingMethod}
+      />
+
+      <PaymentMethodDeleteDialog
+        paymentMethod={deletingMethod}
+        open={!!deletingMethod}
+        onOpenChange={(open) => !open && setDeletingMethod(null)}
+      />
+    </>
+  );
+}

--- a/components/accounts/index.ts
+++ b/components/accounts/index.ts
@@ -1,3 +1,6 @@
 export { AccountDeleteDialog } from "./AccountDeleteDialog";
 export { AccountFormDialog } from "./AccountFormDialog";
 export { AccountList } from "./AccountList";
+export { PaymentMethodDeleteDialog } from "./PaymentMethodDeleteDialog";
+export { PaymentMethodFormDialog } from "./PaymentMethodFormDialog";
+export { PaymentMethodList } from "./PaymentMethodList";

--- a/hooks/use-payment-methods.test.ts
+++ b/hooks/use-payment-methods.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { queries } from "@/lib/queries/keys";
+
+describe("paymentMethods 쿼리 키", () => {
+  it("paymentMethods list 쿼리 키가 정의되어 있다", () => {
+    expect(queries.paymentMethods.list.queryKey).toBeDefined();
+    expect(Array.isArray(queries.paymentMethods.list.queryKey)).toBe(true);
+  });
+
+  it("paymentMethods _def 키가 정의되어 있다", () => {
+    expect(queries.paymentMethods._def).toBeDefined();
+    expect(Array.isArray(queries.paymentMethods._def)).toBe(true);
+  });
+
+  it("paymentMethods list 쿼리 키가 _def 키를 prefix로 포함한다", () => {
+    const defKey = queries.paymentMethods._def;
+    const listKey = queries.paymentMethods.list.queryKey;
+    expect(listKey.length).toBeGreaterThanOrEqual(defKey.length);
+    defKey.forEach((part, i) => {
+      expect(listKey[i]).toEqual(part);
+    });
+  });
+});

--- a/hooks/use-payment-methods.ts
+++ b/hooks/use-payment-methods.ts
@@ -1,0 +1,148 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { PaymentMethodWithDetails } from "@/lib/api/payment-method";
+import { queries } from "@/lib/queries/keys";
+import type {
+  CreatePaymentMethodInput,
+  UpdatePaymentMethodInput,
+} from "@/schemas/payment-method";
+import type { PaymentMethod } from "@/types";
+
+interface PaymentMethodResponse {
+  data: PaymentMethod;
+}
+
+interface PaymentMethodListResponse {
+  data: PaymentMethodWithDetails[];
+}
+
+interface PaymentMethodError {
+  error: {
+    code: string;
+    message: string;
+  };
+}
+
+// ============================================================================
+// 결제수단 목록 조회
+// ============================================================================
+
+async function fetchPaymentMethods(): Promise<PaymentMethodWithDetails[]> {
+  const response = await fetch("/api/payment-methods");
+  const json = await response.json();
+
+  if (!response.ok) {
+    const error = json as PaymentMethodError;
+    throw new Error(error.error.message);
+  }
+
+  return (json as PaymentMethodListResponse).data;
+}
+
+export function usePaymentMethods() {
+  return useQuery({
+    queryKey: queries.paymentMethods.list.queryKey,
+    queryFn: fetchPaymentMethods,
+    staleTime: 1000 * 60 * 5,
+  });
+}
+
+// ============================================================================
+// 결제수단 생성
+// ============================================================================
+
+async function createPaymentMethod(
+  input: CreatePaymentMethodInput,
+): Promise<PaymentMethod> {
+  const response = await fetch("/api/payment-methods", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  const json = await response.json();
+
+  if (!response.ok) {
+    const error = json as PaymentMethodError;
+    throw new Error(error.error.message);
+  }
+
+  return (json as PaymentMethodResponse).data;
+}
+
+export function useCreatePaymentMethod() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: createPaymentMethod,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queries.paymentMethods._def });
+    },
+  });
+}
+
+// ============================================================================
+// 결제수단 수정
+// ============================================================================
+
+interface UpdatePaymentMethodParams {
+  id: string;
+  data: UpdatePaymentMethodInput;
+}
+
+async function updatePaymentMethod({
+  id,
+  data,
+}: UpdatePaymentMethodParams): Promise<PaymentMethod> {
+  const response = await fetch(`/api/payment-methods/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  const json = await response.json();
+
+  if (!response.ok) {
+    const error = json as PaymentMethodError;
+    throw new Error(error.error.message);
+  }
+
+  return (json as PaymentMethodResponse).data;
+}
+
+export function useUpdatePaymentMethod() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updatePaymentMethod,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queries.paymentMethods._def });
+    },
+  });
+}
+
+// ============================================================================
+// 결제수단 삭제
+// ============================================================================
+
+async function deletePaymentMethod(id: string): Promise<void> {
+  const response = await fetch(`/api/payment-methods/${id}`, {
+    method: "DELETE",
+  });
+  const json = await response.json();
+
+  if (!response.ok) {
+    const error = json as PaymentMethodError;
+    throw new Error(error.error.message);
+  }
+}
+
+export function useDeletePaymentMethod() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: deletePaymentMethod,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queries.paymentMethods._def });
+    },
+  });
+}

--- a/lib/queries/keys.ts
+++ b/lib/queries/keys.ts
@@ -10,6 +10,11 @@ export const queries = createQueryKeyStore({
     list: null,
   },
 
+  paymentMethods: {
+    all: null,
+    list: null,
+  },
+
   holdings: {
     all: null,
     list: null,


### PR DESCRIPTION
## Summary

- `/assets/accounts` 페이지 신규 생성 — 계좌(자산)와 결제수단을 섹션별로 통합 표시
- `AccountList`에 `filter` prop 추가 및 bank/investment 서브그룹핑 구현
- `AccountFormDialog`에 `category` prop 추가 및 bank/investment 스키마 분리 (기존 stock 페이지 회귀 없음)
- `PaymentMethodList`, `PaymentMethodFormDialog`, `PaymentMethodDeleteDialog` 신규 생성
- `use-payment-methods` 훅 및 queryKey 추가
- `/assets/stock/accounts` 페이지에 `filter="investment"` 명시하여 은행 계좌 노출 회귀 방지

## Test plan

- [ ] vitest 48개 테스트 통과 확인
- [ ] `/assets/accounts` 페이지에서 은행/투자 계좌 서브그룹핑 렌더 확인
- [ ] `/assets/accounts` 페이지에서 결제수단 목록 렌더 확인
- [ ] 계좌 추가 버튼 드롭다운 ("은행 계좌 추가" / "투자 계좌 추가" / "결제수단 추가") 동작 확인
- [ ] 은행 계좌 수정 시 은행 유형(입출금/적금/예금) 폼이 열리는지 확인
- [ ] `/assets/stock/accounts` 페이지에서 bank 계좌 미노출 확인 (회귀 없음)
- [ ] 타인 계좌/결제수단에 수정/삭제 메뉴 미노출 확인

Closes #232

🤖 Generated by auto-develop

Co-Authored-By: Claude <noreply@anthropic.com>