### PR TITLE
[#234] 자산 관리 및 가계부 진입점 통합 및 개선

### DIFF
--- a/app/(main)/assets/page.tsx
+++ b/app/(main)/assets/page.tsx
@@ -56,8 +56,8 @@ export default async function AssetsPage() {
           returnRate={portfolio.returnRate}
         />
 
-        {/* 현금/예적금 - 준비 중 */}
-        <AssetTypeCard type="cash" disabled />
+        {/* 현금/예적금 - 계좌 관리로 연결됨 */}
+        <AssetTypeCard type="cash" />
 
         {/* 부동산 - 준비 중 */}
         <AssetTypeCard type="real-estate" disabled />

--- a/app/(main)/ledger/page.tsx
+++ b/app/(main)/ledger/page.tsx
@@ -1,13 +1,30 @@
+import { ChevronRight, CreditCard } from "lucide-react";
+import Link from "next/link";
 import { PageHeader } from "@/components/layout";
 
 export default function LedgerPage() {
   return (
     <>
       <PageHeader title="가계부" />
-      <div className="flex flex-col items-center justify-center py-20 text-gray-500">
+      <div className="flex flex-col items-center justify-center py-20 text-gray-500 bg-white rounded-2xl shadow-sm mb-4">
         <p className="text-lg font-medium">준비 중입니다</p>
         <p className="mt-2 text-sm">가계부 기능이 곧 추가됩니다.</p>
       </div>
+
+      <Link
+        href="/ledger/payment-methods"
+        className="flex items-center justify-between p-4 bg-white rounded-2xl shadow-sm hover:bg-gray-50 transition-colors"
+      >
+        <div className="flex items-center gap-3">
+          <div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
+            <CreditCard className="w-5 h-5 text-primary" />
+          </div>
+          <span className="font-semibold text-gray-900 truncate">
+            결제수단 관리
+          </span>
+        </div>
+        <ChevronRight className="w-5 h-5 text-gray-400 shrink-0" />
+      </Link>
     </>
   );
 }

--- a/app/(main)/ledger/payment-methods/new/page.tsx
+++ b/app/(main)/ledger/payment-methods/new/page.tsx
@@ -1,0 +1,11 @@
+import { PaymentMethodNewForm } from "@/components/accounts/PaymentMethodNewForm";
+import { PageContainer, PageHeader } from "@/components/layout";
+
+export default function NewPaymentMethodPage() {
+  return (
+    <PageContainer maxWidth="narrow">
+      <PageHeader title="결제수단 추가" backHref="/ledger/payment-methods" />
+      <PaymentMethodNewForm />
+    </PageContainer>
+  );
+}

--- a/app/(main)/ledger/payment-methods/page.tsx
+++ b/app/(main)/ledger/payment-methods/page.tsx
@@ -1,20 +1,20 @@
 import { Plus } from "lucide-react";
 import Link from "next/link";
-import { AccountList } from "@/components/accounts";
+import { PaymentMethodList } from "@/components/accounts";
 import { PageContainer, PageHeader } from "@/components/layout";
 import { Button } from "@/components/ui/button";
 
-export default function AccountsPage() {
+export default function PaymentMethodsPage() {
   return (
     <PageContainer maxWidth="medium">
       <PageHeader
-        title="계좌 관리"
+        title="결제수단 관리"
         backHref="/assets"
         action={
-          <Link href="/assets/accounts/new">
+          <Link href="/ledger/payment-methods/new?returnUrl=/ledger/payment-methods">
             <Button size="sm">
               <Plus className="w-4 h-4 mr-1" />
-              계좌 추가
+              결제수단 추가
             </Button>
           </Link>
         }
@@ -22,8 +22,7 @@ export default function AccountsPage() {
 
       <div className="space-y-8">
         <section>
-          <h2 className="text-base font-semibold mb-3">자산 계좌</h2>
-          <AccountList />
+          <PaymentMethodList />
         </section>
       </div>
     </PageContainer>

--- a/components/accounts/AccountNewForm.tsx
+++ b/components/accounts/AccountNewForm.tsx
@@ -2,8 +2,8 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Building2, TrendingUp } from "lucide-react";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
@@ -99,6 +99,8 @@ interface DetailFormProps {
 
 function DetailForm({ category, onBack }: DetailFormProps) {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const returnUrl = searchParams.get("returnUrl") || "/assets/accounts";
   const createAccount = useCreateAccount();
   const isBank = category === "bank";
   const defaultAccountType: AllAccountType = isBank ? "checking" : "stock";
@@ -145,7 +147,7 @@ function DetailForm({ category, onBack }: DetailFormProps) {
         memo: data.memo || undefined,
       });
       toast.success(`${data.name} 계좌가 추가되었습니다.`);
-      router.push("/assets/accounts");
+      router.push(returnUrl);
     } catch (error) {
       if (error instanceof Error) {
         toast.error(error.message);
@@ -298,7 +300,7 @@ function DetailForm({ category, onBack }: DetailFormProps) {
   );
 }
 
-export function AccountNewForm() {
+export function AccountNewFormInner() {
   const [category, setCategory] = useState<AccountCategory | null>(null);
 
   if (category) {
@@ -323,5 +325,13 @@ export function AccountNewForm() {
         />
       </div>
     </div>
+  );
+}
+
+export function AccountNewForm() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <AccountNewFormInner />
+    </Suspense>
   );
 }

--- a/components/accounts/PaymentMethodNewForm.tsx
+++ b/components/accounts/PaymentMethodNewForm.tsx
@@ -1,0 +1,365 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Banknote, CreditCard, Gift, Landmark, Wallet } from "lucide-react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { useAccounts } from "@/hooks/use-accounts";
+import { useCreatePaymentMethod } from "@/hooks/use-payment-methods";
+
+const PAYMENT_METHOD_TYPE_VALUES = [
+  "credit_card",
+  "debit_card",
+  "prepaid",
+  "gift_card",
+  "cash",
+] as const;
+
+type PaymentMethodTypeValue = (typeof PAYMENT_METHOD_TYPE_VALUES)[number];
+
+const paymentMethodFormSchema = z.object({
+  name: z
+    .string()
+    .min(1, "결제수단명은 필수입니다.")
+    .max(50, "결제수단명은 50자 이내여야 합니다."),
+  type: z.enum(PAYMENT_METHOD_TYPE_VALUES, {
+    message: "결제수단 유형을 선택해주세요.",
+  }),
+  linkedAccountId: z.string().optional(),
+  issuer: z
+    .string()
+    .max(50, "카드사/서비스명은 50자 이내여야 합니다.")
+    .optional(),
+  lastFour: z
+    .string()
+    .length(4, "카드 번호 끝 4자리를 입력해주세요.")
+    .regex(/^\d{4}$/, "숫자 4자리만 입력해주세요.")
+    .optional()
+    .or(z.literal("")),
+  paymentDay: z
+    .number()
+    .int()
+    .min(1, "결제일은 1일 이상이어야 합니다.")
+    .max(31, "결제일은 31일 이하여야 합니다.")
+    .optional()
+    .or(z.nan()),
+  isDefault: z.boolean(),
+  memo: z.string().max(500, "메모는 500자 이내여야 합니다.").optional(),
+});
+
+type PaymentMethodFormData = z.infer<typeof paymentMethodFormSchema>;
+
+interface CategoryCardProps {
+  onClick: () => void;
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+}
+
+function CategoryCard({
+  onClick,
+  icon,
+  title,
+  description,
+}: CategoryCardProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="w-full flex items-center gap-4 p-4 rounded-2xl border-2 border-gray-100 bg-white hover:border-primary/30 hover:bg-primary/5 transition-colors text-left"
+    >
+      <div className="w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
+        {icon}
+      </div>
+      <div>
+        <p className="text-lg font-semibold text-gray-900">{title}</p>
+        <p className="text-sm text-gray-500">{description}</p>
+      </div>
+    </button>
+  );
+}
+
+interface DetailFormProps {
+  type: PaymentMethodTypeValue;
+  onBack: () => void;
+}
+
+function DetailForm({ type, onBack }: DetailFormProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const returnUrl = searchParams.get("returnUrl") || "/ledger/payment-methods";
+
+  const createPaymentMethod = useCreatePaymentMethod();
+  const { data: accounts } = useAccounts();
+
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    watch,
+    formState: { errors, isSubmitting },
+  } = useForm<PaymentMethodFormData>({
+    resolver: zodResolver(paymentMethodFormSchema),
+    defaultValues: {
+      name: "",
+      type,
+      linkedAccountId: undefined,
+      issuer: "",
+      lastFour: "",
+      paymentDay: undefined,
+      isDefault: false,
+      memo: "",
+    },
+  });
+
+  const watchIsDefault = watch("isDefault");
+  const watchType = watch("type");
+
+  const showCardFields =
+    watchType === "credit_card" || watchType === "debit_card";
+  const showPaymentDay = watchType === "credit_card";
+
+  const onSubmit = async (data: PaymentMethodFormData) => {
+    const payload = {
+      name: data.name,
+      type: data.type,
+      linkedAccountId: data.linkedAccountId || undefined,
+      issuer: data.issuer || undefined,
+      lastFour: data.lastFour || undefined,
+      paymentDay: Number.isNaN(data.paymentDay)
+        ? undefined
+        : (data.paymentDay as number | undefined),
+      isDefault: data.isDefault,
+      memo: data.memo || undefined,
+    };
+
+    try {
+      await createPaymentMethod.mutateAsync(payload);
+      toast.success(`${data.name}이(가) 추가되었습니다.`);
+      router.push(returnUrl);
+    } catch (error) {
+      if (error instanceof Error) {
+        toast.error(error.message);
+      } else {
+        toast.error("결제수단 추가에 실패했습니다.");
+      }
+    }
+  };
+
+  const isPending = createPaymentMethod.isPending;
+
+  const handleCancel = () => {
+    router.push(returnUrl);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="pm-name">
+          결제수단명 <span className="text-destructive">*</span>
+        </Label>
+        <Input
+          id="pm-name"
+          placeholder="예: 신한카드 체크"
+          {...register("name")}
+          aria-invalid={!!errors.name}
+        />
+        {errors.name && (
+          <p className="text-sm text-destructive">{errors.name.message}</p>
+        )}
+      </div>
+
+      {/* 유형은 Funnel에서 선택했으므로 숨김 (필요시 Select 유지) */}
+      <input type="hidden" {...register("type")} />
+
+      {showCardFields && (
+        <div className="space-y-2">
+          <Label htmlFor="pm-issuer">카드사</Label>
+          <Input
+            id="pm-issuer"
+            placeholder="예: 신한카드, 삼성카드"
+            {...register("issuer")}
+            aria-invalid={!!errors.issuer}
+          />
+          {errors.issuer && (
+            <p className="text-sm text-destructive">{errors.issuer.message}</p>
+          )}
+        </div>
+      )}
+
+      {showCardFields && (
+        <div className="space-y-2">
+          <Label htmlFor="pm-last-four">카드번호 끝 4자리</Label>
+          <Input
+            id="pm-last-four"
+            placeholder="예: 1234"
+            maxLength={4}
+            {...register("lastFour")}
+            aria-invalid={!!errors.lastFour}
+          />
+          {errors.lastFour && (
+            <p className="text-sm text-destructive">
+              {errors.lastFour.message}
+            </p>
+          )}
+        </div>
+      )}
+
+      {showPaymentDay && (
+        <div className="space-y-2">
+          <Label htmlFor="pm-payment-day">결제일</Label>
+          <Input
+            id="pm-payment-day"
+            type="number"
+            min={1}
+            max={31}
+            placeholder="예: 15"
+            {...register("paymentDay", { valueAsNumber: true })}
+            aria-invalid={!!errors.paymentDay}
+          />
+          {errors.paymentDay && (
+            <p className="text-sm text-destructive">
+              {errors.paymentDay.message}
+            </p>
+          )}
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <Label htmlFor="pm-linked-account">연결 계좌</Label>
+        <Select
+          value={watch("linkedAccountId") ?? "none"}
+          onValueChange={(value) =>
+            setValue("linkedAccountId", value === "none" ? undefined : value)
+          }
+        >
+          <SelectTrigger id="pm-linked-account">
+            <SelectValue placeholder="연결할 계좌 선택 (선택사항)" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="none">없음</SelectItem>
+            {(accounts ?? []).map((account) => (
+              <SelectItem key={account.id} value={account.id}>
+                {account.name}
+                {account.broker ? ` (${account.broker})` : ""}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex items-center space-x-2">
+        <Checkbox
+          id="pm-is-default"
+          checked={watchIsDefault}
+          onCheckedChange={(checked) => setValue("isDefault", checked === true)}
+        />
+        <Label htmlFor="pm-is-default" className="font-normal cursor-pointer">
+          기본 결제수단으로 설정
+        </Label>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="pm-memo">메모</Label>
+        <Textarea
+          id="pm-memo"
+          placeholder="결제수단에 대한 메모를 입력하세요"
+          rows={2}
+          {...register("memo")}
+          aria-invalid={!!errors.memo}
+        />
+        {errors.memo && (
+          <p className="text-sm text-destructive">{errors.memo.message}</p>
+        )}
+      </div>
+
+      <div className="flex gap-2 pt-2">
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={onBack}
+          disabled={isPending || isSubmitting}
+          className="flex-1"
+        >
+          이전
+        </Button>
+        <Button
+          type="submit"
+          disabled={isPending || isSubmitting}
+          className="flex-1"
+        >
+          {isPending || isSubmitting ? "저장 중..." : "저장"}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+function PaymentMethodNewFormInner() {
+  const [type, setType] = useState<PaymentMethodTypeValue | null>(null);
+
+  if (type) {
+    return <DetailForm type={type} onBack={() => setType(null)} />;
+  }
+
+  return (
+    <div className="space-y-6">
+      <p className="text-gray-500">어떤 결제수단을 추가하시겠어요?</p>
+      <div className="space-y-3">
+        <CategoryCard
+          onClick={() => setType("credit_card")}
+          icon={<CreditCard className="w-6 h-6 text-primary" />}
+          title="신용카드"
+          description="결제일에 연결 계좌에서 출금"
+        />
+        <CategoryCard
+          onClick={() => setType("debit_card")}
+          icon={<Landmark className="w-6 h-6 text-primary" />}
+          title="체크카드"
+          description="연결 계좌에서 즉시 출금"
+        />
+        <CategoryCard
+          onClick={() => setType("prepaid")}
+          icon={<Wallet className="w-6 h-6 text-primary" />}
+          title="선불페이"
+          description="네이버페이, 카카오페이 등 충전식 페이"
+        />
+        <CategoryCard
+          onClick={() => setType("gift_card")}
+          icon={<Gift className="w-6 h-6 text-primary" />}
+          title="상품권"
+          description="백화점, 마트, 문화상품권 등"
+        />
+        <CategoryCard
+          onClick={() => setType("cash")}
+          icon={<Banknote className="w-6 h-6 text-primary" />}
+          title="현금"
+          description="실물 현금 결제"
+        />
+      </div>
+    </div>
+  );
+}
+
+export function PaymentMethodNewForm() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <PaymentMethodNewFormInner />
+    </Suspense>
+  );
+}

--- a/components/accounts/index.ts
+++ b/components/accounts/index.ts
@@ -5,3 +5,4 @@ export { AccountNewForm } from "./AccountNewForm";
 export { PaymentMethodDeleteDialog } from "./PaymentMethodDeleteDialog";
 export { PaymentMethodFormDialog } from "./PaymentMethodFormDialog";
 export { PaymentMethodList } from "./PaymentMethodList";
+export { PaymentMethodNewForm } from "./PaymentMethodNewForm";

--- a/components/assets/common/AssetTypeCard.tsx
+++ b/components/assets/common/AssetTypeCard.tsx
@@ -10,46 +10,25 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { toast } from "sonner";
+import { type AssetType, BASE_ASSET_TYPE_CONFIG } from "@/lib/constants/assets";
 import { cn } from "@/lib/utils/cn";
 import { formatCurrency, formatPercent } from "@/lib/utils/format";
 
-export type AssetType = "stock" | "cash" | "real-estate" | "other";
-
 interface AssetTypeConfig {
-  icon: LucideIcon;
-  label: string;
-  color: string;
-  bgColor: string;
   href: string;
 }
 
-const ASSET_TYPE_CONFIG: Record<AssetType, AssetTypeConfig> = {
+const ASSET_TYPE_EXTRAS: Record<AssetType, AssetTypeConfig> = {
   stock: {
-    icon: TrendingUp,
-    label: "주식/ETF",
-    color: "text-indigo-600",
-    bgColor: "bg-indigo-50",
     href: "/assets/stock",
   },
   cash: {
-    icon: Wallet,
-    label: "현금/예적금",
-    color: "text-emerald-600",
-    bgColor: "bg-emerald-50",
-    href: "/assets/cash",
+    href: "/assets/accounts",
   },
   "real-estate": {
-    icon: Home,
-    label: "부동산",
-    color: "text-rose-600",
-    bgColor: "bg-rose-50",
     href: "/assets/real-estate",
   },
   other: {
-    icon: Package,
-    label: "기타",
-    color: "text-amber-600",
-    bgColor: "bg-amber-50",
     href: "/assets/other",
   },
 };
@@ -71,8 +50,9 @@ export function AssetTypeListItem({
   disabled = false,
   isLoading = false,
 }: AssetTypeListItemProps) {
-  const config = ASSET_TYPE_CONFIG[type];
-  const Icon = config.icon;
+  const baseConfig = BASE_ASSET_TYPE_CONFIG[type];
+  const extraConfig = ASSET_TYPE_EXTRAS[type];
+  const Icon = baseConfig.icon;
 
   // 로딩 상태
   if (isLoading) {
@@ -95,7 +75,7 @@ export function AssetTypeListItem({
   // 비활성 상태 (준비 중)
   if (disabled) {
     const handleDisabledClick = () => {
-      toast.info(`${config.label} 기능은 준비 중이에요`, {
+      toast.info(`${baseConfig.label} 기능은 준비 중이에요`, {
         description: "조금만 기다려주세요!",
       });
     };
@@ -107,13 +87,13 @@ export function AssetTypeListItem({
         className="w-full flex items-center gap-4 px-4 py-4 hover:bg-gray-50 transition-colors"
       >
         {/* 아이콘 */}
-        <div className={cn("p-2.5 rounded-xl", config.bgColor)}>
-          <Icon className={cn("w-5 h-5", config.color)} />
+        <div className={cn("p-2.5 rounded-xl", baseConfig.bgColor)}>
+          <Icon className={cn("w-5 h-5", baseConfig.color)} />
         </div>
 
         {/* 라벨 */}
         <div className="flex-1 text-left">
-          <p className="font-medium text-gray-900">{config.label}</p>
+          <p className="font-medium text-gray-900">{baseConfig.label}</p>
         </div>
 
         {/* 준비 중 */}
@@ -129,17 +109,17 @@ export function AssetTypeListItem({
 
   return (
     <Link
-      href={config.href}
+      href={extraConfig.href}
       className="flex items-center gap-4 px-4 py-4 hover:bg-gray-50 transition-colors"
     >
       {/* 아이콘 */}
-      <div className={cn("p-2.5 rounded-xl", config.bgColor)}>
-        <Icon className={cn("w-5 h-5", config.color)} />
+      <div className={cn("p-2.5 rounded-xl", baseConfig.bgColor)}>
+        <Icon className={cn("w-5 h-5", baseConfig.color)} />
       </div>
 
       {/* 라벨 + 부가정보 */}
       <div className="flex-1">
-        <p className="font-medium text-gray-900">{config.label}</p>
+        <p className="font-medium text-gray-900">{baseConfig.label}</p>
         {isEmpty ? (
           <p className="text-sm text-gray-400">아직 등록된 자산이 없어요</p>
         ) : (

--- a/components/assets/common/index.ts
+++ b/components/assets/common/index.ts
@@ -1,1 +1,2 @@
-export { type AssetType, AssetTypeCard } from "./AssetTypeCard";
+export type { AssetType } from "@/lib/constants/assets";
+export { AssetTypeCard } from "./AssetTypeCard";

--- a/components/dashboard/AnalysisTypeSection.tsx
+++ b/components/dashboard/AnalysisTypeSection.tsx
@@ -1,68 +1,60 @@
 "use client";
 
-import { Home, Package, TrendingUp, Wallet } from "lucide-react";
+import { type AssetType, BASE_ASSET_TYPE_CONFIG } from "@/lib/constants/assets";
 import { AnalysisCard } from "./AnalysisCard";
 
-const ANALYSIS_TYPES = [
+const ANALYSIS_TYPES: Array<{
+  type: AssetType;
+  description: string;
+  href: string;
+  disabled: boolean;
+}> = [
   {
-    type: "stocks",
-    icon: TrendingUp,
-    label: "주식/ETF",
+    type: "stock",
     description: "종목별 비중과 수익률을 분석하세요",
     href: "/dashboard/stocks",
-    color: "text-indigo-600",
-    bgColor: "bg-indigo-50",
     disabled: false,
   },
   {
     type: "cash",
-    icon: Wallet,
-    label: "현금/예적금",
     description: "예금, 적금, CMA 등 분석",
     href: "/dashboard/cash",
-    color: "text-emerald-600",
-    bgColor: "bg-emerald-50",
     disabled: true,
   },
   {
     type: "real-estate",
-    icon: Home,
-    label: "부동산",
     description: "부동산 자산 분석",
     href: "/dashboard/real-estate",
-    color: "text-rose-600",
-    bgColor: "bg-rose-50",
     disabled: true,
   },
   {
     type: "other",
-    icon: Package,
-    label: "기타",
     description: "금, 코인 등 기타 자산 분석",
     href: "/dashboard/other",
-    color: "text-amber-600",
-    bgColor: "bg-amber-50",
     disabled: true,
   },
-] as const;
+];
 
 export function AnalysisTypeSection() {
   return (
     <div className="space-y-3">
       <h2 className="text-lg font-semibold text-gray-900">자산 유형별 분석</h2>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-        {ANALYSIS_TYPES.map((item) => (
-          <AnalysisCard
-            key={item.type}
-            icon={item.icon}
-            label={item.label}
-            description={item.description}
-            href={item.href}
-            color={item.color}
-            bgColor={item.bgColor}
-            disabled={item.disabled}
-          />
-        ))}
+        {ANALYSIS_TYPES.map((item) => {
+          const baseConfig = BASE_ASSET_TYPE_CONFIG[item.type];
+          return (
+            <AnalysisCard
+              key={item.type}
+              icon={baseConfig.icon}
+              label={baseConfig.label}
+              description={item.description}
+              href={item.href}
+              color={baseConfig.color}
+              bgColor={baseConfig.bgColor}
+              disabled={item.disabled}
+            />
+          );
+        })}
       </div>
     </div>
   );

--- a/components/home/AssetTypeSummary.tsx
+++ b/components/home/AssetTypeSummary.tsx
@@ -1,57 +1,29 @@
 "use client";
 
-import {
-  Home,
-  type LucideIcon,
-  Package,
-  TrendingUp,
-  Wallet,
-} from "lucide-react";
 import Link from "next/link";
 import { toast } from "sonner";
+import { type AssetType, BASE_ASSET_TYPE_CONFIG } from "@/lib/constants/assets";
 import { cn } from "@/lib/utils/cn";
 
-type AssetType = "stock" | "cash" | "real-estate" | "other";
-
 interface AssetTypeConfig {
-  icon: LucideIcon;
-  label: string;
-  color: string;
-  bgColor: string;
   href: string;
   description: string;
 }
 
-const ASSET_TYPE_CONFIG: Record<AssetType, AssetTypeConfig> = {
+const ASSET_TYPE_EXTRAS: Record<AssetType, AssetTypeConfig> = {
   stock: {
-    icon: TrendingUp,
-    label: "주식/ETF",
-    color: "text-indigo-600",
-    bgColor: "bg-indigo-50",
     href: "/assets/stock",
     description: "국내외 주식 보유 현황과 수익률을 한눈에 확인하세요",
   },
   cash: {
-    icon: Wallet,
-    label: "현금/예적금",
-    color: "text-emerald-600",
-    bgColor: "bg-emerald-50",
-    href: "/assets/cash",
-    description: "예금, 적금, CMA 등 현금성 자산을 관리하세요",
+    href: "/assets/accounts",
+    description: "은행 입출금, 예적금, 투자 계좌 등을 관리하세요",
   },
   "real-estate": {
-    icon: Home,
-    label: "부동산",
-    color: "text-rose-600",
-    bgColor: "bg-rose-50",
     href: "/assets/real-estate",
     description: "아파트, 토지 등 부동산 자산을 기록하세요",
   },
   other: {
-    icon: Package,
-    label: "기타",
-    color: "text-amber-600",
-    bgColor: "bg-amber-50",
     href: "/assets/other",
     description: "금, 코인, 자동차 등 기타 자산을 추가하세요",
   },
@@ -63,13 +35,14 @@ interface AssetSummaryCardProps {
 }
 
 function AssetSummaryCard({ type, disabled = false }: AssetSummaryCardProps) {
-  const config = ASSET_TYPE_CONFIG[type];
-  const Icon = config.icon;
+  const baseConfig = BASE_ASSET_TYPE_CONFIG[type];
+  const extraConfig = ASSET_TYPE_EXTRAS[type];
+  const Icon = baseConfig.icon;
 
   // 비활성 상태 (준비 중)
   if (disabled) {
     const handleClick = () => {
-      toast.info(`${config.label} 기능은 준비 중이에요`, {
+      toast.info(`${baseConfig.label} 기능은 준비 중이에요`, {
         description: "조금만 기다려주세요!",
       });
     };
@@ -80,12 +53,12 @@ function AssetSummaryCard({ type, disabled = false }: AssetSummaryCardProps) {
         onClick={handleClick}
         className="w-full text-left bg-white rounded-2xl p-5 shadow-sm hover:shadow-md transition-shadow opacity-80 hover:opacity-100"
       >
-        <div className={cn("p-2.5 rounded-xl w-fit mb-3", config.bgColor)}>
-          <Icon className={cn("w-5 h-5", config.color)} />
+        <div className={cn("p-2.5 rounded-xl w-fit mb-3", baseConfig.bgColor)}>
+          <Icon className={cn("w-5 h-5", baseConfig.color)} />
         </div>
-        <p className="font-medium text-gray-900 mb-1">{config.label}</p>
+        <p className="font-medium text-gray-900 mb-1">{baseConfig.label}</p>
         <p className="text-sm text-gray-500 leading-relaxed">
-          {config.description}
+          {extraConfig.description}
         </p>
       </button>
     );
@@ -94,15 +67,15 @@ function AssetSummaryCard({ type, disabled = false }: AssetSummaryCardProps) {
   // 활성 상태
   return (
     <Link
-      href={config.href}
+      href={extraConfig.href}
       className="block bg-white rounded-2xl p-5 shadow-sm hover:shadow-md transition-shadow"
     >
-      <div className={cn("p-2.5 rounded-xl w-fit mb-3", config.bgColor)}>
-        <Icon className={cn("w-5 h-5", config.color)} />
+      <div className={cn("p-2.5 rounded-xl w-fit mb-3", baseConfig.bgColor)}>
+        <Icon className={cn("w-5 h-5", baseConfig.color)} />
       </div>
-      <p className="font-medium text-gray-900 mb-1">{config.label}</p>
+      <p className="font-medium text-gray-900 mb-1">{baseConfig.label}</p>
       <p className="text-sm text-gray-500 leading-relaxed">
-        {config.description}
+        {extraConfig.description}
       </p>
     </Link>
   );
@@ -122,7 +95,7 @@ export function AssetTypeSummary() {
       </div>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <AssetSummaryCard type="stock" />
-        <AssetSummaryCard type="cash" disabled />
+        <AssetSummaryCard type="cash" />
         <AssetSummaryCard type="real-estate" disabled />
         <AssetSummaryCard type="other" disabled />
       </div>

--- a/lib/constants/assets.ts
+++ b/lib/constants/assets.ts
@@ -1,0 +1,48 @@
+import {
+  Home,
+  type LucideIcon,
+  Package,
+  TrendingUp,
+  Wallet,
+} from "lucide-react";
+
+export type AssetType = "stock" | "cash" | "real-estate" | "other";
+
+export interface BaseAssetTypeConfig {
+  type: AssetType;
+  icon: LucideIcon;
+  label: string;
+  color: string;
+  bgColor: string;
+}
+
+export const BASE_ASSET_TYPE_CONFIG: Record<AssetType, BaseAssetTypeConfig> = {
+  stock: {
+    type: "stock",
+    icon: TrendingUp,
+    label: "주식/ETF",
+    color: "text-indigo-600",
+    bgColor: "bg-indigo-50",
+  },
+  cash: {
+    type: "cash",
+    icon: Wallet,
+    label: "금융 계좌",
+    color: "text-emerald-600",
+    bgColor: "bg-emerald-50",
+  },
+  "real-estate": {
+    type: "real-estate",
+    icon: Home,
+    label: "부동산",
+    color: "text-rose-600",
+    bgColor: "bg-rose-50",
+  },
+  other: {
+    type: "other",
+    icon: Package,
+    label: "기타",
+    color: "text-amber-600",
+    bgColor: "bg-amber-50",
+  },
+};


### PR DESCRIPTION
## 변경 내용
- 계좌 추가 및 결제수단 관리 진입점을 자산/가계부 화면 특성에 맞게 통합 및 재배치
- 결제수단 추가(PaymentMethodNewForm)를 모달에서 Funnel 형태의 페이지 폼으로 개편
- 계좌 및 결제수단 등록 시 이전 화면으로 되돌아갈 수 있도록 returnUrl 기능 추가
- 자산 메인, 대시보드 분석, 홈 화면의 자산 유형 요약에서 사용하는 공통 UI 속성(아이콘, 테마 색상 등)을 BASE_ASSET_TYPE_CONFIG로 분리 및 재사용