### PR TITLE
fix: seed.sql 트리거 중복 생성 수정 및 테스트 가구 카테고리 시드 추가

### DIFF
--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -129,6 +129,11 @@ VALUES (
 );
 
 -- 4. 가구 생성 및 멤버십 설정
+-- handle_new_user 트리거가 auth.users INSERT 시 자동으로 가구/멤버십을 생성하므로
+-- 테스트 가구로 교체하기 위해 트리거 생성 데이터를 먼저 정리한다.
+-- households CASCADE → household_members, categories 함께 삭제
+DELETE FROM public.households;
+
 INSERT INTO public.households (id, name)
 VALUES ('00000000-0000-0000-0000-000000000010', '테스트 가구');
 
@@ -136,6 +141,9 @@ INSERT INTO public.household_members (household_id, user_id, role)
 VALUES
   ('00000000-0000-0000-0000-000000000010', '00000000-0000-0000-0000-000000000001', 'owner'),
   ('00000000-0000-0000-0000-000000000010', '00000000-0000-0000-0000-000000000002', 'member');
+
+-- 테스트 가구 기본 카테고리 생성 (#236)
+SELECT public.seed_household_categories('00000000-0000-0000-0000-000000000010');
 
 -- ============================================================================
 -- 환율 초기 데이터


### PR DESCRIPTION
## Summary

- `handle_new_user` 트리거가 `auth.users` INSERT 시 가구를 자동 생성하면서 `seed.sql`과 충돌, 각 유저에 `household_members`가 2개씩 생성되는 문제 수정 (#263)
- 테스트 가구(`000000000010`)에 `seed_household_categories` 호출 추가로 기본 카테고리 시드 처리 (#236)
- #264 NOTICE 경고는 production에 이미 적용된 migration 파일에서 발생하여 수정 불가 — 각 이슈에 사유 코멘트 후 Close 처리

## 변경 파일

- `supabase/seed.sql`
  - 가구 데이터 INSERT 전 `DELETE FROM public.households` 추가 (CASCADE로 household_members, categories 포함 삭제)
  - `SELECT public.seed_household_categories(...)` 추가

## Test plan

- [ ] `supabase db reset` 실행 후 오류 없이 완료되는지 확인
- [ ] `admin@example.com` 로그인 → `/assets/accounts` 접근 시 HOUSEHOLD_NOT_FOUND 에러 없이 정상 표시
- [ ] `GET /api/accounts` → 200 응답 확인

## 관련 이슈

Closes #263, #264, #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)