### PR TITLE
#237 [API] 가계부 기록 CRUD API

### DIFF
--- a/app/api/ledger-entries/[id]/route.ts
+++ b/app/api/ledger-entries/[id]/route.ts
@@ -1,0 +1,110 @@
+import { NextResponse } from "next/server";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import { deleteLedgerEntry, updateLedgerEntry } from "@/lib/api/ledger";
+import { createClient } from "@/lib/supabase/server";
+import { updateLedgerEntrySchema } from "@/schemas/ledger-entry";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * PATCH /api/ledger-entries/[id]
+ * 가계부 항목 수정 (본인 항목만)
+ */
+export async function PATCH(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    const body = await request.json();
+    const result = updateLedgerEntrySchema.safeParse(body);
+
+    if (!result.success) {
+      const firstError = result.error.issues[0];
+      throw new APIError(
+        "VALIDATION_ERROR",
+        firstError?.message ?? "유효하지 않은 요청입니다.",
+        400,
+      );
+    }
+
+    const input = result.data;
+
+    const entry = await updateLedgerEntry(supabase, id, user.id, {
+      type: input.type,
+      amount: input.amount,
+      transactedAt: input.transactedAt,
+      categoryId: input.categoryId,
+      fromAccountId: input.fromAccountId,
+      fromPaymentMethodId: input.fromPaymentMethodId,
+      toAccountId: input.toAccountId,
+      toPaymentMethodId: input.toPaymentMethodId,
+      isShared: input.isShared,
+      memo: input.memo,
+    });
+
+    return NextResponse.json({ data: entry });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    console.error("Ledger entry update error:", error);
+    return NextResponse.json(
+      {
+        error: { code: "INTERNAL_ERROR", message: "서버 오류가 발생했습니다." },
+      },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * DELETE /api/ledger-entries/[id]
+ * 가계부 항목 삭제 (본인 항목만)
+ */
+export async function DELETE(_request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    await deleteLedgerEntry(supabase, id, user.id);
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    console.error("Ledger entry delete error:", error);
+    return NextResponse.json(
+      {
+        error: { code: "INTERNAL_ERROR", message: "서버 오류가 발생했습니다." },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/ledger-entries/route.ts
+++ b/app/api/ledger-entries/route.ts
@@ -1,0 +1,144 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import { getUserHouseholdId } from "@/lib/api/invitation";
+import { createLedgerEntry, getLedgerEntries } from "@/lib/api/ledger";
+import { createClient } from "@/lib/supabase/server";
+import { createLedgerEntrySchema } from "@/schemas/ledger-entry";
+
+/**
+ * GET /api/ledger-entries
+ * 가계부 항목 목록 조회
+ *
+ * Query params:
+ *   ?year=2026&month=4   → 월간 목록
+ *   ?date=2026-04-24     → 일별 목록 (캘린더 상세)
+ *   (없음)               → 당월
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    const householdId = await getUserHouseholdId(supabase, user.id);
+
+    if (!householdId) {
+      throw new APIError(
+        "HOUSEHOLD_NOT_FOUND",
+        "가구 정보를 찾을 수 없습니다.",
+        404,
+      );
+    }
+
+    const { searchParams } = request.nextUrl;
+    const yearParam = searchParams.get("year");
+    const monthParam = searchParams.get("month");
+    const dateParam = searchParams.get("date");
+
+    const options = {
+      year: yearParam ? Number(yearParam) : undefined,
+      month: monthParam ? Number(monthParam) : undefined,
+      date: dateParam ?? undefined,
+    };
+
+    const entries = await getLedgerEntries(supabase, householdId, options);
+
+    return NextResponse.json({ data: entries });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    console.error("Ledger entries list error:", error);
+    return NextResponse.json(
+      {
+        error: { code: "INTERNAL_ERROR", message: "서버 오류가 발생했습니다." },
+      },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * POST /api/ledger-entries
+ * 가계부 항목 생성
+ */
+export async function POST(request: Request) {
+  try {
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    const body = await request.json();
+    const result = createLedgerEntrySchema.safeParse(body);
+
+    if (!result.success) {
+      const firstError = result.error.issues[0];
+      throw new APIError(
+        "VALIDATION_ERROR",
+        firstError?.message ?? "유효하지 않은 요청입니다.",
+        400,
+      );
+    }
+
+    const input = result.data;
+
+    const householdId = await getUserHouseholdId(supabase, user.id);
+
+    if (!householdId) {
+      throw new APIError(
+        "HOUSEHOLD_NOT_FOUND",
+        "가구 정보를 찾을 수 없습니다.",
+        404,
+      );
+    }
+
+    const entry = await createLedgerEntry(supabase, {
+      householdId,
+      ownerId: user.id,
+      type: input.type,
+      amount: input.amount,
+      transactedAt: input.transactedAt,
+      categoryId: input.categoryId,
+      fromAccountId: input.fromAccountId,
+      fromPaymentMethodId: input.fromPaymentMethodId,
+      toAccountId: input.toAccountId,
+      toPaymentMethodId: input.toPaymentMethodId,
+      isShared: input.isShared,
+      memo: input.memo,
+    });
+
+    return NextResponse.json({ data: entry }, { status: 201 });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    console.error("Ledger entry creation error:", error);
+    return NextResponse.json(
+      {
+        error: { code: "INTERNAL_ERROR", message: "서버 오류가 발생했습니다." },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/ledger-entries/summary/route.ts
+++ b/app/api/ledger-entries/summary/route.ts
@@ -1,0 +1,70 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import { getUserHouseholdId } from "@/lib/api/invitation";
+import { getLedgerEntrySummary } from "@/lib/api/ledger";
+import { createClient } from "@/lib/supabase/server";
+
+/**
+ * GET /api/ledger-entries/summary
+ * 월간 수입/지출 요약 조회 (홈 화면용)
+ *
+ * Query params:
+ *   ?year=2026&month=4  (없으면 당월)
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    const householdId = await getUserHouseholdId(supabase, user.id);
+
+    if (!householdId) {
+      throw new APIError(
+        "HOUSEHOLD_NOT_FOUND",
+        "가구 정보를 찾을 수 없습니다.",
+        404,
+      );
+    }
+
+    const { searchParams } = request.nextUrl;
+    const now = new Date();
+    const year = searchParams.get("year")
+      ? Number(searchParams.get("year"))
+      : now.getUTCFullYear();
+    const month = searchParams.get("month")
+      ? Number(searchParams.get("month"))
+      : now.getUTCMonth() + 1;
+
+    const summary = await getLedgerEntrySummary(
+      supabase,
+      householdId,
+      year,
+      month,
+    );
+
+    return NextResponse.json({ data: summary });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    console.error("Ledger summary error:", error);
+    return NextResponse.json(
+      {
+        error: { code: "INTERNAL_ERROR", message: "서버 오류가 발생했습니다." },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/lib/api/ledger.test.ts
+++ b/lib/api/ledger.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { calculateLedgerSummary } from "./ledger";
+
+describe("calculateLedgerSummary", () => {
+  it("수입 합계를 정확히 계산한다", () => {
+    const entries = [
+      { type: "income" as const, amount: 3000000 },
+      { type: "income" as const, amount: 500000 },
+    ];
+    const result = calculateLedgerSummary(entries);
+    expect(result.totalIncome).toBe(3500000);
+  });
+
+  it("지출 합계를 정확히 계산한다", () => {
+    const entries = [
+      { type: "expense" as const, amount: 80000 },
+      { type: "expense" as const, amount: 20000 },
+    ];
+    const result = calculateLedgerSummary(entries);
+    expect(result.totalExpense).toBe(100000);
+  });
+
+  it("이체(transfer)는 합산에서 제외한다", () => {
+    const entries = [
+      { type: "income" as const, amount: 1000000 },
+      { type: "transfer" as const, amount: 500000 },
+    ];
+    const result = calculateLedgerSummary(entries);
+    expect(result.totalIncome).toBe(1000000);
+    expect(result.totalExpense).toBe(0);
+  });
+
+  it("잔액 = 수입 - 지출", () => {
+    const entries = [
+      { type: "income" as const, amount: 5000000 },
+      { type: "expense" as const, amount: 3000000 },
+    ];
+    const result = calculateLedgerSummary(entries);
+    expect(result.balance).toBe(2000000);
+  });
+
+  it("항목이 없으면 모두 0을 반환한다", () => {
+    const result = calculateLedgerSummary([]);
+    expect(result.totalIncome).toBe(0);
+    expect(result.totalExpense).toBe(0);
+    expect(result.balance).toBe(0);
+  });
+
+  it("수입과 지출이 섞여 있어도 각각 정확히 계산한다", () => {
+    const entries = [
+      { type: "income" as const, amount: 4500000 },
+      { type: "expense" as const, amount: 85000 },
+      { type: "expense" as const, amount: 750000 },
+      { type: "transfer" as const, amount: 100000 },
+      { type: "income" as const, amount: 500000 },
+    ];
+    const result = calculateLedgerSummary(entries);
+    expect(result.totalIncome).toBe(5000000);
+    expect(result.totalExpense).toBe(835000);
+    expect(result.balance).toBe(4165000);
+  });
+});

--- a/lib/api/ledger.ts
+++ b/lib/api/ledger.ts
@@ -1,0 +1,408 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { APIError } from "@/lib/api/error";
+import type { Database, LedgerEntry, LedgerEntryType } from "@/types";
+
+export interface LedgerEntryWithDetails {
+  id: string;
+  householdId: string;
+  ownerId: string;
+  ownerName: string;
+  type: LedgerEntryType;
+  amount: number;
+  categoryId: string | null;
+  categoryName: string | null;
+  categoryIcon: string | null;
+  fromAccountId: string | null;
+  fromAccountName: string | null;
+  fromPaymentMethodId: string | null;
+  fromPaymentMethodName: string | null;
+  toAccountId: string | null;
+  toAccountName: string | null;
+  toPaymentMethodId: string | null;
+  toPaymentMethodName: string | null;
+  isShared: boolean;
+  memo: string | null;
+  transactedAt: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface LedgerEntrySummary {
+  totalIncome: number;
+  totalExpense: number;
+  balance: number;
+}
+
+export interface GetLedgerEntriesOptions {
+  year?: number;
+  month?: number;
+  date?: string;
+}
+
+export interface CreateLedgerEntryParams {
+  householdId: string;
+  ownerId: string;
+  type: LedgerEntryType;
+  amount: number;
+  transactedAt: string;
+  categoryId?: string;
+  fromAccountId?: string;
+  fromPaymentMethodId?: string;
+  toAccountId?: string;
+  toPaymentMethodId?: string;
+  isShared?: boolean;
+  memo?: string;
+}
+
+export interface UpdateLedgerEntryParams {
+  type?: LedgerEntryType;
+  amount?: number;
+  transactedAt?: string;
+  categoryId?: string | null;
+  fromAccountId?: string | null;
+  fromPaymentMethodId?: string | null;
+  toAccountId?: string | null;
+  toPaymentMethodId?: string | null;
+  isShared?: boolean;
+  memo?: string | null;
+}
+
+export function calculateLedgerSummary(
+  entries: Pick<LedgerEntryWithDetails, "type" | "amount">[],
+): LedgerEntrySummary {
+  let totalIncome = 0;
+  let totalExpense = 0;
+
+  for (const entry of entries) {
+    if (entry.type === "income") {
+      totalIncome += entry.amount;
+    } else if (entry.type === "expense") {
+      totalExpense += entry.amount;
+    }
+    // transfer는 합산 제외
+  }
+
+  return { totalIncome, totalExpense, balance: totalIncome - totalExpense };
+}
+
+function getDateRange(options: GetLedgerEntriesOptions): {
+  from: string;
+  to: string;
+} {
+  if (options.date) {
+    return {
+      from: `${options.date}T00:00:00.000Z`,
+      to: `${options.date}T23:59:59.999Z`,
+    };
+  }
+
+  const now = new Date();
+  const year = options.year ?? now.getUTCFullYear();
+  const month = options.month ?? now.getUTCMonth() + 1;
+
+  const from = new Date(Date.UTC(year, month - 1, 1));
+  const to = new Date(Date.UTC(year, month, 0, 23, 59, 59, 999));
+
+  return { from: from.toISOString(), to: to.toISOString() };
+}
+
+export async function getLedgerEntries(
+  supabase: SupabaseClient<Database>,
+  householdId: string,
+  options?: GetLedgerEntriesOptions,
+): Promise<LedgerEntryWithDetails[]> {
+  const { from, to } = getDateRange(options ?? {});
+
+  const { data, error } = await supabase
+    .from("ledger_entries")
+    .select("*")
+    .eq("household_id", householdId)
+    .gte("transacted_at", from)
+    .lte("transacted_at", to)
+    .order("transacted_at", { ascending: false })
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    console.error("Ledger entries fetch error:", error);
+    throw new APIError(
+      "LEDGER_FETCH_ERROR",
+      "가계부 내역 조회에 실패했습니다.",
+      500,
+    );
+  }
+
+  const rows = data ?? [];
+
+  if (rows.length === 0) {
+    return [];
+  }
+
+  // 관련 ID 수집
+  const ownerIds = [...new Set(rows.map((r) => r.owner_id))];
+  const categoryIds = [
+    ...new Set(rows.map((r) => r.category_id).filter(Boolean) as string[]),
+  ];
+  const accountIds = [
+    ...new Set(
+      [
+        ...rows.map((r) => r.from_account_id),
+        ...rows.map((r) => r.to_account_id),
+      ].filter(Boolean) as string[],
+    ),
+  ];
+  const paymentMethodIds = [
+    ...new Set(
+      [
+        ...rows.map((r) => r.from_payment_method_id),
+        ...rows.map((r) => r.to_payment_method_id),
+      ].filter(Boolean) as string[],
+    ),
+  ];
+
+  const [
+    { data: profiles },
+    { data: categories },
+    { data: accounts },
+    { data: paymentMethods },
+  ] = await Promise.all([
+    ownerIds.length > 0
+      ? supabase.from("profiles").select("id, name").in("id", ownerIds)
+      : Promise.resolve({ data: [] }),
+    categoryIds.length > 0
+      ? supabase
+          .from("categories")
+          .select("id, name, icon")
+          .in("id", categoryIds)
+      : Promise.resolve({ data: [] }),
+    accountIds.length > 0
+      ? supabase.from("accounts").select("id, name").in("id", accountIds)
+      : Promise.resolve({ data: [] }),
+    paymentMethodIds.length > 0
+      ? supabase
+          .from("payment_methods")
+          .select("id, name")
+          .in("id", paymentMethodIds)
+      : Promise.resolve({ data: [] }),
+  ]);
+
+  const ownerMap = new Map((profiles ?? []).map((p) => [p.id, p.name]));
+  const categoryMap = new Map(
+    (categories ?? []).map((c) => [c.id, { name: c.name, icon: c.icon }]),
+  );
+  const accountMap = new Map((accounts ?? []).map((a) => [a.id, a.name]));
+  const paymentMethodMap = new Map(
+    (paymentMethods ?? []).map((pm) => [pm.id, pm.name]),
+  );
+
+  return rows.map((r) => ({
+    id: r.id,
+    householdId: r.household_id,
+    ownerId: r.owner_id,
+    ownerName: ownerMap.get(r.owner_id) ?? "알 수 없음",
+    type: r.type,
+    amount: r.amount,
+    categoryId: r.category_id,
+    categoryName: r.category_id
+      ? (categoryMap.get(r.category_id)?.name ?? null)
+      : null,
+    categoryIcon: r.category_id
+      ? (categoryMap.get(r.category_id)?.icon ?? null)
+      : null,
+    fromAccountId: r.from_account_id,
+    fromAccountName: r.from_account_id
+      ? (accountMap.get(r.from_account_id) ?? null)
+      : null,
+    fromPaymentMethodId: r.from_payment_method_id,
+    fromPaymentMethodName: r.from_payment_method_id
+      ? (paymentMethodMap.get(r.from_payment_method_id) ?? null)
+      : null,
+    toAccountId: r.to_account_id,
+    toAccountName: r.to_account_id
+      ? (accountMap.get(r.to_account_id) ?? null)
+      : null,
+    toPaymentMethodId: r.to_payment_method_id,
+    toPaymentMethodName: r.to_payment_method_id
+      ? (paymentMethodMap.get(r.to_payment_method_id) ?? null)
+      : null,
+    isShared: r.is_shared,
+    memo: r.memo,
+    transactedAt: r.transacted_at,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+  }));
+}
+
+export async function getLedgerEntrySummary(
+  supabase: SupabaseClient<Database>,
+  householdId: string,
+  year: number,
+  month: number,
+): Promise<LedgerEntrySummary> {
+  const { from, to } = getDateRange({ year, month });
+
+  const { data, error } = await supabase
+    .from("ledger_entries")
+    .select("type, amount")
+    .eq("household_id", householdId)
+    .gte("transacted_at", from)
+    .lte("transacted_at", to);
+
+  if (error) {
+    console.error("Ledger summary fetch error:", error);
+    throw new APIError(
+      "LEDGER_FETCH_ERROR",
+      "가계부 요약 조회에 실패했습니다.",
+      500,
+    );
+  }
+
+  return calculateLedgerSummary(data ?? []);
+}
+
+export async function createLedgerEntry(
+  supabase: SupabaseClient<Database>,
+  params: CreateLedgerEntryParams,
+): Promise<LedgerEntry> {
+  const { data, error } = await supabase
+    .from("ledger_entries")
+    .insert({
+      household_id: params.householdId,
+      owner_id: params.ownerId,
+      type: params.type,
+      amount: params.amount,
+      transacted_at: params.transactedAt,
+      category_id: params.categoryId ?? null,
+      from_account_id: params.fromAccountId ?? null,
+      from_payment_method_id: params.fromPaymentMethodId ?? null,
+      to_account_id: params.toAccountId ?? null,
+      to_payment_method_id: params.toPaymentMethodId ?? null,
+      is_shared: params.isShared ?? true,
+      memo: params.memo ?? null,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    console.error("Ledger entry insert error:", error);
+    throw new APIError(
+      "LEDGER_CREATE_ERROR",
+      "가계부 항목 생성에 실패했습니다.",
+      500,
+    );
+  }
+
+  return data;
+}
+
+export async function updateLedgerEntry(
+  supabase: SupabaseClient<Database>,
+  entryId: string,
+  ownerId: string,
+  params: UpdateLedgerEntryParams,
+): Promise<LedgerEntry> {
+  const { data: existing } = await supabase
+    .from("ledger_entries")
+    .select("id, owner_id")
+    .eq("id", entryId)
+    .single();
+
+  if (!existing) {
+    throw new APIError(
+      "LEDGER_NOT_FOUND",
+      "가계부 항목을 찾을 수 없습니다.",
+      404,
+    );
+  }
+
+  if (existing.owner_id !== ownerId) {
+    throw new APIError(
+      "LEDGER_FORBIDDEN",
+      "본인의 가계부 항목만 수정할 수 있습니다.",
+      403,
+    );
+  }
+
+  const { data, error } = await supabase
+    .from("ledger_entries")
+    .update({
+      ...(params.type !== undefined && { type: params.type }),
+      ...(params.amount !== undefined && { amount: params.amount }),
+      ...(params.transactedAt !== undefined && {
+        transacted_at: params.transactedAt,
+      }),
+      ...(params.categoryId !== undefined && {
+        category_id: params.categoryId,
+      }),
+      ...(params.fromAccountId !== undefined && {
+        from_account_id: params.fromAccountId,
+      }),
+      ...(params.fromPaymentMethodId !== undefined && {
+        from_payment_method_id: params.fromPaymentMethodId,
+      }),
+      ...(params.toAccountId !== undefined && {
+        to_account_id: params.toAccountId,
+      }),
+      ...(params.toPaymentMethodId !== undefined && {
+        to_payment_method_id: params.toPaymentMethodId,
+      }),
+      ...(params.isShared !== undefined && { is_shared: params.isShared }),
+      ...(params.memo !== undefined && { memo: params.memo }),
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", entryId)
+    .select()
+    .single();
+
+  if (error) {
+    console.error("Ledger entry update error:", error);
+    throw new APIError(
+      "LEDGER_UPDATE_ERROR",
+      "가계부 항목 수정에 실패했습니다.",
+      500,
+    );
+  }
+
+  return data;
+}
+
+export async function deleteLedgerEntry(
+  supabase: SupabaseClient<Database>,
+  entryId: string,
+  ownerId: string,
+): Promise<void> {
+  const { data: existing } = await supabase
+    .from("ledger_entries")
+    .select("id, owner_id")
+    .eq("id", entryId)
+    .single();
+
+  if (!existing) {
+    throw new APIError(
+      "LEDGER_NOT_FOUND",
+      "가계부 항목을 찾을 수 없습니다.",
+      404,
+    );
+  }
+
+  if (existing.owner_id !== ownerId) {
+    throw new APIError(
+      "LEDGER_FORBIDDEN",
+      "본인의 가계부 항목만 삭제할 수 있습니다.",
+      403,
+    );
+  }
+
+  const { error } = await supabase
+    .from("ledger_entries")
+    .delete()
+    .eq("id", entryId);
+
+  if (error) {
+    console.error("Ledger entry delete error:", error);
+    throw new APIError(
+      "LEDGER_DELETE_ERROR",
+      "가계부 항목 삭제에 실패했습니다.",
+      500,
+    );
+  }
+}

--- a/schemas/ledger-entry.test.ts
+++ b/schemas/ledger-entry.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import {
+  createLedgerEntrySchema,
+  updateLedgerEntrySchema,
+} from "./ledger-entry";
+
+const validDatetime = "2026-04-24T10:00:00.000Z";
+
+describe("createLedgerEntrySchema", () => {
+  it("유효한 최소 입력으로 파싱된다", () => {
+    const result = createLedgerEntrySchema.safeParse({
+      type: "expense",
+      amount: 50000,
+      transactedAt: validDatetime,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("transactedAt이 없으면 실패한다", () => {
+    const result = createLedgerEntrySchema.safeParse({
+      type: "expense",
+      amount: 50000,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("amount가 0이면 실패한다", () => {
+    const result = createLedgerEntrySchema.safeParse({
+      type: "expense",
+      amount: 0,
+      transactedAt: validDatetime,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("amount가 음수이면 실패한다", () => {
+    const result = createLedgerEntrySchema.safeParse({
+      type: "expense",
+      amount: -1000,
+      transactedAt: validDatetime,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("유효하지 않은 type이면 실패한다", () => {
+    const result = createLedgerEntrySchema.safeParse({
+      type: "refund",
+      amount: 50000,
+      transactedAt: validDatetime,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("transactedAt이 ISO datetime 형식이 아니면 실패한다", () => {
+    const result = createLedgerEntrySchema.safeParse({
+      type: "expense",
+      amount: 50000,
+      transactedAt: "2026-04-24",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("memo가 500자를 초과하면 실패한다", () => {
+    const result = createLedgerEntrySchema.safeParse({
+      type: "expense",
+      amount: 50000,
+      transactedAt: validDatetime,
+      memo: "a".repeat(501),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("isShared 기본값은 true다", () => {
+    const result = createLedgerEntrySchema.safeParse({
+      type: "income",
+      amount: 5000000,
+      transactedAt: validDatetime,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.isShared).toBe(true);
+    }
+  });
+
+  it("income, transfer 타입도 허용된다", () => {
+    const incomeResult = createLedgerEntrySchema.safeParse({
+      type: "income",
+      amount: 3000000,
+      transactedAt: validDatetime,
+    });
+    const transferResult = createLedgerEntrySchema.safeParse({
+      type: "transfer",
+      amount: 100000,
+      transactedAt: validDatetime,
+    });
+    expect(incomeResult.success).toBe(true);
+    expect(transferResult.success).toBe(true);
+  });
+});
+
+describe("updateLedgerEntrySchema", () => {
+  it("모든 필드가 optional이라 빈 객체도 성공한다", () => {
+    const result = updateLedgerEntrySchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it("categoryId를 null로 설정할 수 있다", () => {
+    const result = updateLedgerEntrySchema.safeParse({ categoryId: null });
+    expect(result.success).toBe(true);
+  });
+
+  it("fromAccountId를 null로 설정할 수 있다", () => {
+    const result = updateLedgerEntrySchema.safeParse({ fromAccountId: null });
+    expect(result.success).toBe(true);
+  });
+
+  it("memo를 null로 설정할 수 있다", () => {
+    const result = updateLedgerEntrySchema.safeParse({ memo: null });
+    expect(result.success).toBe(true);
+  });
+
+  it("amount가 0이면 실패한다", () => {
+    const result = updateLedgerEntrySchema.safeParse({ amount: 0 });
+    expect(result.success).toBe(false);
+  });
+
+  it("유효하지 않은 type이면 실패한다", () => {
+    const result = updateLedgerEntrySchema.safeParse({ type: "refund" });
+    expect(result.success).toBe(false);
+  });
+
+  it("memo가 500자를 초과하면 실패한다", () => {
+    const result = updateLedgerEntrySchema.safeParse({
+      memo: "a".repeat(501),
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/schemas/ledger-entry.ts
+++ b/schemas/ledger-entry.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+
+const ledgerEntryTypeValues = ["expense", "income", "transfer"] as const;
+
+export const createLedgerEntrySchema = z.object({
+  type: z.enum(ledgerEntryTypeValues, {
+    message: "유효한 항목 유형이 아닙니다.",
+  }),
+  amount: z.number().positive("금액은 0보다 커야 합니다."),
+  transactedAt: z.string().datetime("올바른 날짜 형식이 아닙니다."),
+  categoryId: z.string().uuid().optional(),
+  fromAccountId: z.string().uuid().optional(),
+  fromPaymentMethodId: z.string().uuid().optional(),
+  toAccountId: z.string().uuid().optional(),
+  toPaymentMethodId: z.string().uuid().optional(),
+  isShared: z.boolean().default(true),
+  memo: z.string().max(500, "메모는 500자 이내여야 합니다.").optional(),
+});
+
+export type CreateLedgerEntryInput = z.infer<typeof createLedgerEntrySchema>;
+
+export const updateLedgerEntrySchema = z.object({
+  type: z
+    .enum(ledgerEntryTypeValues, {
+      message: "유효한 항목 유형이 아닙니다.",
+    })
+    .optional(),
+  amount: z.number().positive("금액은 0보다 커야 합니다.").optional(),
+  transactedAt: z.string().datetime("올바른 날짜 형식이 아닙니다.").optional(),
+  categoryId: z.string().uuid().nullable().optional(),
+  fromAccountId: z.string().uuid().nullable().optional(),
+  fromPaymentMethodId: z.string().uuid().nullable().optional(),
+  toAccountId: z.string().uuid().nullable().optional(),
+  toPaymentMethodId: z.string().uuid().nullable().optional(),
+  isShared: z.boolean().optional(),
+  memo: z
+    .string()
+    .max(500, "메모는 500자 이내여야 합니다.")
+    .nullable()
+    .optional(),
+});
+
+export type UpdateLedgerEntryInput = z.infer<typeof updateLedgerEntrySchema>;

--- a/types/index.ts
+++ b/types/index.ts
@@ -24,6 +24,8 @@ export type TransactionType = Enums<"transaction_type">;
 export type HouseholdRole = Enums<"household_role">;
 export type UserRole = Enums<"user_role">;
 export type AllocationCategory = Enums<"allocation_category">;
+export type LedgerEntryType = Enums<"ledger_entry_type">;
+export type CategoryType = Enums<"category_type">;
 
 // 테이블 Row 타입 (편의를 위해)
 export type Account = Tables<"accounts">;
@@ -39,6 +41,12 @@ export type ExchangeRate = Tables<"exchange_rates">;
 export type Tag = Tables<"tags">;
 export type HoldingTag = Tables<"holding_tags">;
 export type TargetAllocation = Tables<"target_allocations">;
+
+// 가계부 테이블 타입
+export type LedgerEntry = Tables<"ledger_entries">;
+export type LedgerEntryInsert = TablesInsert<"ledger_entries">;
+export type LedgerEntryUpdate = TablesUpdate<"ledger_entries">;
+export type Category = Tables<"categories">;
 
 // View 타입
 export type Holding = Tables<"holdings">;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -345,17 +345,16 @@ export type Database = {
       };
       ledger_entries: {
         Row: {
-          account_id: string | null;
           amount: number;
           category_id: string | null;
           created_at: string;
           from_account_id: string | null;
+          from_payment_method_id: string | null;
           household_id: string;
           id: string;
           is_shared: boolean;
           memo: string | null;
           owner_id: string;
-          payment_method_id: string | null;
           to_account_id: string | null;
           to_payment_method_id: string | null;
           transacted_at: string;
@@ -363,17 +362,16 @@ export type Database = {
           updated_at: string;
         };
         Insert: {
-          account_id?: string | null;
           amount: number;
           category_id?: string | null;
           created_at?: string;
           from_account_id?: string | null;
+          from_payment_method_id?: string | null;
           household_id: string;
           id?: string;
           is_shared?: boolean;
           memo?: string | null;
           owner_id: string;
-          payment_method_id?: string | null;
           to_account_id?: string | null;
           to_payment_method_id?: string | null;
           transacted_at: string;
@@ -381,17 +379,16 @@ export type Database = {
           updated_at?: string;
         };
         Update: {
-          account_id?: string | null;
           amount?: number;
           category_id?: string | null;
           created_at?: string;
           from_account_id?: string | null;
+          from_payment_method_id?: string | null;
           household_id?: string;
           id?: string;
           is_shared?: boolean;
           memo?: string | null;
           owner_id?: string;
-          payment_method_id?: string | null;
           to_account_id?: string | null;
           to_payment_method_id?: string | null;
           transacted_at?: string;
@@ -399,13 +396,6 @@ export type Database = {
           updated_at?: string;
         };
         Relationships: [
-          {
-            foreignKeyName: "ledger_entries_account_id_fkey";
-            columns: ["account_id"];
-            isOneToOne: false;
-            referencedRelation: "accounts";
-            referencedColumns: ["id"];
-          },
           {
             foreignKeyName: "ledger_entries_category_id_fkey";
             columns: ["category_id"];
@@ -421,6 +411,13 @@ export type Database = {
             referencedColumns: ["id"];
           },
           {
+            foreignKeyName: "ledger_entries_from_payment_method_id_fkey";
+            columns: ["from_payment_method_id"];
+            isOneToOne: false;
+            referencedRelation: "payment_methods";
+            referencedColumns: ["id"];
+          },
+          {
             foreignKeyName: "ledger_entries_household_id_fkey";
             columns: ["household_id"];
             isOneToOne: false;
@@ -432,13 +429,6 @@ export type Database = {
             columns: ["owner_id"];
             isOneToOne: false;
             referencedRelation: "profiles";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "ledger_entries_payment_method_id_fkey";
-            columns: ["payment_method_id"];
-            isOneToOne: false;
-            referencedRelation: "payment_methods";
             referencedColumns: ["id"];
           },
           {


### PR DESCRIPTION
## Summary

- 가계부 항목(`ledger_entries`) 읽기/생성/수정/삭제 API 구현
- 월간 요약(수입·지출 합계) 전용 엔드포인트 분리
- Supabase 타입 재생성 및 `types/index.ts`에 가계부 관련 타입 추가

## 엔드포인트

| 메서드 | 경로 | 설명 |
|--------|------|------|
| GET | `/api/ledger-entries` | 목록 조회 (`?year=&month=` 또는 `?date=`) |
| POST | `/api/ledger-entries` | 항목 생성 |
| GET | `/api/ledger-entries/summary` | 월간 수입/지출 합계 |
| PATCH | `/api/ledger-entries/[id]` | 항목 수정 (본인만) |
| DELETE | `/api/ledger-entries/[id]` | 항목 삭제 (본인만) |

## 주요 설계

- `transactedAt` POST에서 필수값 (가계부 핵심 필드)
- GET 쿼리 유연성: 월간 리스트·일별 상세·캘린더 뷰 모두 동일 엔드포인트 지원
- summary 엔드포인트 분리: 홈 화면 수입/지출 요약을 별도 호출로 처리
- RLS가 `is_shared` 프라이버시 처리 (공용/개인 구분 자동 적용)
- `calculateLedgerSummary` 순수 함수 분리로 재사용성 확보

## Test plan

- [ ] `pnpm type-check` 통과
- [ ] `pnpm vitest run` — 22개 유닛 테스트 통과 (스키마 검증 + 요약 계산)
- [ ] GET `/api/ledger-entries?year=2026&month=4` 월간 목록 반환 확인
- [ ] GET `/api/ledger-entries?date=2026-04-24` 일별 목록 반환 확인
- [ ] GET `/api/ledger-entries/summary?year=2026&month=4` 요약 반환 확인
- [ ] POST `/api/ledger-entries` 항목 생성 (201 반환)
- [ ] PATCH/DELETE 본인 항목만 수정·삭제되는지 확인

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)