### PR TITLE
feat: 가계부 카테고리 관리 API 구현 (#238)

### DIFF
--- a/app/api/categories/[id]/route.ts
+++ b/app/api/categories/[id]/route.ts
@@ -1,0 +1,124 @@
+import { NextResponse } from "next/server";
+import { deleteCategory, updateCategory } from "@/lib/api/category";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import { getUserHouseholdId } from "@/lib/api/invitation";
+import { createClient } from "@/lib/supabase/server";
+import { updateCategorySchema } from "@/schemas/category";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * PATCH /api/categories/[id]
+ * 커스텀 카테고리 수정 (is_system = true이면 403)
+ */
+export async function PATCH(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    const body = await request.json();
+    const result = updateCategorySchema.safeParse(body);
+
+    if (!result.success) {
+      const firstError = result.error.issues[0];
+      throw new APIError(
+        "VALIDATION_ERROR",
+        firstError?.message ?? "유효하지 않은 요청입니다.",
+        400,
+      );
+    }
+
+    const householdId = await getUserHouseholdId(supabase, user.id);
+
+    if (!householdId) {
+      throw new APIError(
+        "HOUSEHOLD_NOT_FOUND",
+        "가구 정보를 찾을 수 없습니다.",
+        404,
+      );
+    }
+
+    const category = await updateCategory(
+      supabase,
+      id,
+      householdId,
+      result.data,
+    );
+
+    return NextResponse.json({ data: category });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    console.error("Category update error:", error);
+    return NextResponse.json(
+      {
+        error: { code: "INTERNAL_ERROR", message: "서버 오류가 발생했습니다." },
+      },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * DELETE /api/categories/[id]
+ * 커스텀 카테고리 삭제 (is_system = true이면 403)
+ * 연결된 ledger_entries.category_id는 DB ON DELETE SET NULL로 자동 처리됨
+ */
+export async function DELETE(_request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    const householdId = await getUserHouseholdId(supabase, user.id);
+
+    if (!householdId) {
+      throw new APIError(
+        "HOUSEHOLD_NOT_FOUND",
+        "가구 정보를 찾을 수 없습니다.",
+        404,
+      );
+    }
+
+    await deleteCategory(supabase, id, householdId);
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    console.error("Category delete error:", error);
+    return NextResponse.json(
+      {
+        error: { code: "INTERNAL_ERROR", message: "서버 오류가 발생했습니다." },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/categories/reorder/route.ts
+++ b/app/api/categories/reorder/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from "next/server";
+import { reorderCategories } from "@/lib/api/category";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import { getUserHouseholdId } from "@/lib/api/invitation";
+import { createClient } from "@/lib/supabase/server";
+import { reorderCategoriesSchema } from "@/schemas/category";
+
+/**
+ * PATCH /api/categories/reorder
+ * 카테고리 순서 변경 (display_order 배치 업데이트)
+ *
+ * Body: { orders: [{ id: string, displayOrder: number }] }
+ */
+export async function PATCH(request: Request) {
+  try {
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    const body = await request.json();
+    const result = reorderCategoriesSchema.safeParse(body);
+
+    if (!result.success) {
+      const firstError = result.error.issues[0];
+      throw new APIError(
+        "VALIDATION_ERROR",
+        firstError?.message ?? "유효하지 않은 요청입니다.",
+        400,
+      );
+    }
+
+    const householdId = await getUserHouseholdId(supabase, user.id);
+
+    if (!householdId) {
+      throw new APIError(
+        "HOUSEHOLD_NOT_FOUND",
+        "가구 정보를 찾을 수 없습니다.",
+        404,
+      );
+    }
+
+    await reorderCategories(
+      supabase,
+      householdId,
+      result.data.orders.map((o) => ({
+        id: o.id,
+        displayOrder: o.displayOrder,
+      })),
+    );
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    console.error("Category reorder error:", error);
+    return NextResponse.json(
+      {
+        error: { code: "INTERNAL_ERROR", message: "서버 오류가 발생했습니다." },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/categories/route.ts
+++ b/app/api/categories/route.ts
@@ -1,0 +1,130 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { createCategory, getCategories } from "@/lib/api/category";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import { getUserHouseholdId } from "@/lib/api/invitation";
+import { createClient } from "@/lib/supabase/server";
+import { createCategorySchema } from "@/schemas/category";
+import type { CategoryType } from "@/types";
+
+/**
+ * GET /api/categories
+ * 카테고리 목록 조회
+ *
+ * Query params:
+ *   ?type=expense   → 지출 카테고리만
+ *   ?type=income    → 수입 카테고리만
+ *   (없음)          → 전체
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    const householdId = await getUserHouseholdId(supabase, user.id);
+
+    if (!householdId) {
+      throw new APIError(
+        "HOUSEHOLD_NOT_FOUND",
+        "가구 정보를 찾을 수 없습니다.",
+        404,
+      );
+    }
+
+    const typeParam = request.nextUrl.searchParams.get("type");
+    const type =
+      typeParam === "expense" || typeParam === "income"
+        ? (typeParam as CategoryType)
+        : undefined;
+
+    const categories = await getCategories(supabase, householdId, type);
+
+    return NextResponse.json({ data: categories });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    console.error("Categories list error:", error);
+    return NextResponse.json(
+      {
+        error: { code: "INTERNAL_ERROR", message: "서버 오류가 발생했습니다." },
+      },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * POST /api/categories
+ * 커스텀 카테고리 생성
+ */
+export async function POST(request: Request) {
+  try {
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    const body = await request.json();
+    const result = createCategorySchema.safeParse(body);
+
+    if (!result.success) {
+      const firstError = result.error.issues[0];
+      throw new APIError(
+        "VALIDATION_ERROR",
+        firstError?.message ?? "유효하지 않은 요청입니다.",
+        400,
+      );
+    }
+
+    const householdId = await getUserHouseholdId(supabase, user.id);
+
+    if (!householdId) {
+      throw new APIError(
+        "HOUSEHOLD_NOT_FOUND",
+        "가구 정보를 찾을 수 없습니다.",
+        404,
+      );
+    }
+
+    const category = await createCategory(supabase, {
+      householdId,
+      type: result.data.type,
+      name: result.data.name,
+      icon: result.data.icon,
+    });
+
+    return NextResponse.json({ data: category }, { status: 201 });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    console.error("Category create error:", error);
+    return NextResponse.json(
+      {
+        error: { code: "INTERNAL_ERROR", message: "서버 오류가 발생했습니다." },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/lib/api/category.test.ts
+++ b/lib/api/category.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { nextDisplayOrder, validateReorderIds } from "./category";
+
+describe("nextDisplayOrder", () => {
+  it("기존 순서가 없으면 0을 반환한다", () => {
+    expect(nextDisplayOrder([])).toBe(0);
+  });
+
+  it("기존 최댓값 + 1을 반환한다", () => {
+    expect(nextDisplayOrder([0, 1, 2])).toBe(3);
+  });
+
+  it("순서가 연속적이지 않아도 최댓값 + 1을 반환한다", () => {
+    expect(nextDisplayOrder([0, 5, 3])).toBe(6);
+  });
+
+  it("하나의 항목만 있을 때 1을 반환한다", () => {
+    expect(nextDisplayOrder([0])).toBe(1);
+  });
+
+  it("큰 순서 값도 올바르게 처리한다", () => {
+    expect(nextDisplayOrder([10, 20, 15])).toBe(21);
+  });
+});
+
+describe("validateReorderIds", () => {
+  it("모든 ID가 가구 카테고리에 속하면 true를 반환한다", () => {
+    const ids = new Set(["id-1", "id-2", "id-3"]);
+    expect(validateReorderIds(["id-1", "id-2"], ids)).toBe(true);
+  });
+
+  it("하나라도 가구 카테고리에 없으면 false를 반환한다", () => {
+    const ids = new Set(["id-1", "id-2"]);
+    expect(validateReorderIds(["id-1", "id-999"], ids)).toBe(false);
+  });
+
+  it("빈 요청 배열이면 true를 반환한다", () => {
+    const ids = new Set(["id-1"]);
+    expect(validateReorderIds([], ids)).toBe(true);
+  });
+
+  it("가구 카테고리가 없을 때 빈 요청도 true를 반환한다", () => {
+    expect(validateReorderIds([], new Set())).toBe(true);
+  });
+
+  it("가구 카테고리가 없을 때 요청이 있으면 false를 반환한다", () => {
+    expect(validateReorderIds(["id-1"], new Set())).toBe(false);
+  });
+
+  it("모든 가구 카테고리를 포함한 전체 재정렬도 통과한다", () => {
+    const ids = new Set(["id-1", "id-2", "id-3"]);
+    expect(validateReorderIds(["id-3", "id-1", "id-2"], ids)).toBe(true);
+  });
+});

--- a/lib/api/category.ts
+++ b/lib/api/category.ts
@@ -1,0 +1,276 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { APIError } from "@/lib/api/error";
+import type { Category, CategoryType, Database } from "@/types";
+
+export interface CreateCategoryParams {
+  householdId: string;
+  type: CategoryType;
+  name: string;
+  icon?: string | null;
+}
+
+export interface UpdateCategoryParams {
+  name?: string;
+  icon?: string | null;
+}
+
+export interface ReorderItem {
+  id: string;
+  displayOrder: number;
+}
+
+/**
+ * 다음 display_order 값을 계산한다 (현재 최댓값 + 1).
+ * 기존 순서가 없으면 0을 반환한다.
+ */
+export function nextDisplayOrder(existingOrders: number[]): number {
+  if (existingOrders.length === 0) return 0;
+  return Math.max(...existingOrders) + 1;
+}
+
+/**
+ * reorder 요청의 ID가 모두 해당 가구 카테고리에 속하는지 검증한다.
+ */
+export function validateReorderIds(
+  requestedIds: string[],
+  householdCategoryIds: Set<string>,
+): boolean {
+  return requestedIds.every((id) => householdCategoryIds.has(id));
+}
+
+export async function getCategories(
+  supabase: SupabaseClient<Database>,
+  householdId: string,
+  type?: CategoryType,
+): Promise<Category[]> {
+  let query = supabase
+    .from("categories")
+    .select("*")
+    .eq("household_id", householdId)
+    .order("display_order", { ascending: true });
+
+  if (type) {
+    query = query.eq("type", type);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    console.error("Categories fetch error:", error);
+    throw new APIError("INTERNAL_ERROR", "카테고리 조회에 실패했습니다.", 500);
+  }
+
+  return data ?? [];
+}
+
+export async function createCategory(
+  supabase: SupabaseClient<Database>,
+  params: CreateCategoryParams,
+): Promise<Category> {
+  const { householdId, type, name, icon } = params;
+
+  const { data: duplicate } = await supabase
+    .from("categories")
+    .select("id")
+    .eq("household_id", householdId)
+    .eq("type", type)
+    .eq("name", name)
+    .maybeSingle();
+
+  if (duplicate) {
+    throw new APIError(
+      "CATEGORY_DUPLICATE_NAME",
+      "이미 같은 이름의 카테고리가 있습니다.",
+      400,
+    );
+  }
+
+  const { data: existing } = await supabase
+    .from("categories")
+    .select("display_order")
+    .eq("household_id", householdId)
+    .eq("type", type);
+
+  const orders = (existing ?? []).map((row) => row.display_order);
+  const displayOrder = nextDisplayOrder(orders);
+
+  const { data, error } = await supabase
+    .from("categories")
+    .insert({
+      household_id: householdId,
+      type,
+      name,
+      icon: icon ?? null,
+      display_order: displayOrder,
+      is_system: false,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    console.error("Category create error:", error);
+    throw new APIError("INTERNAL_ERROR", "카테고리 생성에 실패했습니다.", 500);
+  }
+
+  return data;
+}
+
+export async function updateCategory(
+  supabase: SupabaseClient<Database>,
+  id: string,
+  householdId: string,
+  params: UpdateCategoryParams,
+): Promise<Category> {
+  const { data: existing, error: fetchError } = await supabase
+    .from("categories")
+    .select("*")
+    .eq("id", id)
+    .eq("household_id", householdId)
+    .maybeSingle();
+
+  if (fetchError) {
+    console.error("Category fetch error:", fetchError);
+    throw new APIError("INTERNAL_ERROR", "카테고리 조회에 실패했습니다.", 500);
+  }
+
+  if (!existing) {
+    throw new APIError(
+      "CATEGORY_NOT_FOUND",
+      "카테고리를 찾을 수 없습니다.",
+      404,
+    );
+  }
+
+  if (existing.is_system) {
+    throw new APIError(
+      "CATEGORY_SYSTEM_READONLY",
+      "기본 제공 카테고리는 수정할 수 없습니다.",
+      403,
+    );
+  }
+
+  if (params.name && params.name !== existing.name) {
+    const { data: duplicate } = await supabase
+      .from("categories")
+      .select("id")
+      .eq("household_id", householdId)
+      .eq("type", existing.type)
+      .eq("name", params.name)
+      .maybeSingle();
+
+    if (duplicate) {
+      throw new APIError(
+        "CATEGORY_DUPLICATE_NAME",
+        "이미 같은 이름의 카테고리가 있습니다.",
+        400,
+      );
+    }
+  }
+
+  const { data, error } = await supabase
+    .from("categories")
+    .update({
+      ...(params.name !== undefined && { name: params.name }),
+      ...(params.icon !== undefined && { icon: params.icon }),
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", id)
+    .select()
+    .single();
+
+  if (error) {
+    console.error("Category update error:", error);
+    throw new APIError("INTERNAL_ERROR", "카테고리 수정에 실패했습니다.", 500);
+  }
+
+  return data;
+}
+
+export async function deleteCategory(
+  supabase: SupabaseClient<Database>,
+  id: string,
+  householdId: string,
+): Promise<void> {
+  const { data: existing, error: fetchError } = await supabase
+    .from("categories")
+    .select("id, is_system")
+    .eq("id", id)
+    .eq("household_id", householdId)
+    .maybeSingle();
+
+  if (fetchError) {
+    console.error("Category fetch error:", fetchError);
+    throw new APIError("INTERNAL_ERROR", "카테고리 조회에 실패했습니다.", 500);
+  }
+
+  if (!existing) {
+    throw new APIError(
+      "CATEGORY_NOT_FOUND",
+      "카테고리를 찾을 수 없습니다.",
+      404,
+    );
+  }
+
+  if (existing.is_system) {
+    throw new APIError(
+      "CATEGORY_SYSTEM_READONLY",
+      "기본 제공 카테고리는 삭제할 수 없습니다.",
+      403,
+    );
+  }
+
+  const { error } = await supabase.from("categories").delete().eq("id", id);
+
+  if (error) {
+    console.error("Category delete error:", error);
+    throw new APIError("INTERNAL_ERROR", "카테고리 삭제에 실패했습니다.", 500);
+  }
+}
+
+export async function reorderCategories(
+  supabase: SupabaseClient<Database>,
+  householdId: string,
+  orders: ReorderItem[],
+): Promise<void> {
+  const requestedIds = orders.map((o) => o.id);
+
+  const { data: existing, error: fetchError } = await supabase
+    .from("categories")
+    .select("id")
+    .eq("household_id", householdId)
+    .in("id", requestedIds);
+
+  if (fetchError) {
+    console.error("Category fetch error:", fetchError);
+    throw new APIError("INTERNAL_ERROR", "카테고리 조회에 실패했습니다.", 500);
+  }
+
+  const householdCategoryIds = new Set((existing ?? []).map((row) => row.id));
+
+  if (!validateReorderIds(requestedIds, householdCategoryIds)) {
+    throw new APIError(
+      "CATEGORY_NOT_FOUND",
+      "일부 카테고리를 찾을 수 없습니다.",
+      404,
+    );
+  }
+
+  for (const { id, displayOrder } of orders) {
+    const { error } = await supabase
+      .from("categories")
+      .update({
+        display_order: displayOrder,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", id);
+
+    if (error) {
+      console.error("Category reorder error:", error);
+      throw new APIError(
+        "INTERNAL_ERROR",
+        "카테고리 순서 변경에 실패했습니다.",
+        500,
+      );
+    }
+  }
+}

--- a/schemas/category.test.ts
+++ b/schemas/category.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import {
+  createCategorySchema,
+  reorderCategoriesSchema,
+  updateCategorySchema,
+} from "./category";
+
+describe("createCategorySchema", () => {
+  it("유효한 최소 입력으로 파싱된다", () => {
+    const result = createCategorySchema.safeParse({
+      type: "expense",
+      name: "반려동물",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("icon이 없어도 파싱된다", () => {
+    const result = createCategorySchema.safeParse({
+      type: "income",
+      name: "부업",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("icon이 null이어도 파싱된다", () => {
+    const result = createCategorySchema.safeParse({
+      type: "expense",
+      name: "기타",
+      icon: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("유효하지 않은 type이면 실패한다", () => {
+    const result = createCategorySchema.safeParse({
+      type: "transfer",
+      name: "이체",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("name이 빈 문자열이면 실패한다", () => {
+    const result = createCategorySchema.safeParse({
+      type: "expense",
+      name: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("name이 20자를 초과하면 실패한다", () => {
+    const result = createCategorySchema.safeParse({
+      type: "expense",
+      name: "a".repeat(21),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("name이 정확히 20자이면 파싱된다", () => {
+    const result = createCategorySchema.safeParse({
+      type: "expense",
+      name: "a".repeat(20),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("icon이 50자를 초과하면 실패한다", () => {
+    const result = createCategorySchema.safeParse({
+      type: "expense",
+      name: "식비",
+      icon: "a".repeat(51),
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("updateCategorySchema", () => {
+  it("모든 필드가 optional이라 빈 객체도 성공한다", () => {
+    const result = updateCategorySchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it("name만 변경할 수 있다", () => {
+    const result = updateCategorySchema.safeParse({ name: "새이름" });
+    expect(result.success).toBe(true);
+  });
+
+  it("icon을 null로 설정할 수 있다", () => {
+    const result = updateCategorySchema.safeParse({ icon: null });
+    expect(result.success).toBe(true);
+  });
+
+  it("name이 빈 문자열이면 실패한다", () => {
+    const result = updateCategorySchema.safeParse({ name: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("name이 20자를 초과하면 실패한다", () => {
+    const result = updateCategorySchema.safeParse({ name: "a".repeat(21) });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("reorderCategoriesSchema", () => {
+  const validUuid = "550e8400-e29b-41d4-a716-446655440000";
+
+  it("유효한 입력으로 파싱된다", () => {
+    const result = reorderCategoriesSchema.safeParse({
+      orders: [{ id: validUuid, displayOrder: 0 }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("orders가 빈 배열이면 실패한다", () => {
+    const result = reorderCategoriesSchema.safeParse({ orders: [] });
+    expect(result.success).toBe(false);
+  });
+
+  it("id가 UUID 형식이 아니면 실패한다", () => {
+    const result = reorderCategoriesSchema.safeParse({
+      orders: [{ id: "not-a-uuid", displayOrder: 0 }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("displayOrder가 음수이면 실패한다", () => {
+    const result = reorderCategoriesSchema.safeParse({
+      orders: [{ id: validUuid, displayOrder: -1 }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("displayOrder가 0이면 파싱된다", () => {
+    const result = reorderCategoriesSchema.safeParse({
+      orders: [{ id: validUuid, displayOrder: 0 }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("displayOrder가 소수이면 실패한다", () => {
+    const result = reorderCategoriesSchema.safeParse({
+      orders: [{ id: validUuid, displayOrder: 1.5 }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("여러 항목을 한 번에 처리할 수 있다", () => {
+    const result = reorderCategoriesSchema.safeParse({
+      orders: [
+        { id: "550e8400-e29b-41d4-a716-446655440001", displayOrder: 0 },
+        { id: "550e8400-e29b-41d4-a716-446655440002", displayOrder: 1 },
+        { id: "550e8400-e29b-41d4-a716-446655440003", displayOrder: 2 },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/schemas/category.ts
+++ b/schemas/category.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+
+const categoryTypeValues = ["expense", "income"] as const;
+
+export const createCategorySchema = z.object({
+  type: z.enum(categoryTypeValues, {
+    message: "유효한 카테고리 유형이 아닙니다.",
+  }),
+  name: z
+    .string()
+    .min(1, "카테고리명을 입력해주세요.")
+    .max(20, "카테고리명은 20자 이내여야 합니다."),
+  icon: z
+    .string()
+    .max(50, "아이콘명은 50자 이내여야 합니다.")
+    .nullable()
+    .optional(),
+});
+
+export type CreateCategoryInput = z.infer<typeof createCategorySchema>;
+
+export const updateCategorySchema = z.object({
+  name: z
+    .string()
+    .min(1, "카테고리명을 입력해주세요.")
+    .max(20, "카테고리명은 20자 이내여야 합니다.")
+    .optional(),
+  icon: z
+    .string()
+    .max(50, "아이콘명은 50자 이내여야 합니다.")
+    .nullable()
+    .optional(),
+});
+
+export type UpdateCategoryInput = z.infer<typeof updateCategorySchema>;
+
+export const reorderCategoriesSchema = z.object({
+  orders: z
+    .array(
+      z.object({
+        id: z.string().uuid("유효하지 않은 카테고리 ID입니다."),
+        displayOrder: z.number().int().min(0, "순서는 0 이상이어야 합니다."),
+      }),
+    )
+    .min(1, "순서 변경 항목이 없습니다."),
+});
+
+export type ReorderCategoriesInput = z.infer<typeof reorderCategoriesSchema>;


### PR DESCRIPTION
## Summary

- 가계부 카테고리 CRUD + 순서변경 API 5개 엔드포인트 구현
- `is_system = true` 카테고리(기본 제공 20개)는 수정/삭제 불가 (403)
- 커스텀 카테고리 삭제 시 `ledger_entries.category_id`는 DB `ON DELETE SET NULL`로 자동 처리

## Endpoints

| Method | Path | 설명 |
|--------|------|------|
| `GET` | `/api/categories?type=expense\|income` | 카테고리 목록 (display_order 오름차순) |
| `POST` | `/api/categories` | 커스텀 카테고리 생성 |
| `PATCH` | `/api/categories/[id]` | 이름/아이콘 수정 |
| `DELETE` | `/api/categories/[id]` | 삭제 |
| `PATCH` | `/api/categories/reorder` | display_order 배치 업데이트 |

## Test plan

- [ ] `pnpm vitest run schemas/category.test.ts lib/api/category.test.ts` — 31개 단위 테스트 통과
- [ ] `pnpm type-check` 통과
- [ ] `GET /api/categories?type=expense` → 기본 14개 카테고리 반환
- [ ] `POST /api/categories` → 커스텀 카테고리 생성 (201)
- [ ] `PATCH /api/categories/[id]` (시스템 카테고리) → 403
- [ ] `DELETE /api/categories/[id]` (시스템 카테고리) → 403
- [ ] `PATCH /api/categories/reorder` → display_order 변경 확인

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)