### PR TITLE
feat: [UI] 기록 수정/삭제 기능 (#241)

### DIFF
--- a/components/ledger/LedgerEntryDeleteDialog.tsx
+++ b/components/ledger/LedgerEntryDeleteDialog.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { AlertTriangleIcon } from "lucide-react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useDeleteLedgerEntry } from "@/hooks/use-ledger-entries";
+import type { LedgerEntryWithDetails } from "@/lib/api/ledger";
+import { formatCurrency } from "@/lib/utils/format";
+
+interface LedgerEntryDeleteDialogProps {
+  entry: LedgerEntryWithDetails | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function LedgerEntryDeleteDialog({
+  entry,
+  open,
+  onOpenChange,
+}: LedgerEntryDeleteDialogProps) {
+  const deleteMutation = useDeleteLedgerEntry();
+
+  const handleDelete = async () => {
+    if (!entry) return;
+
+    try {
+      await deleteMutation.mutateAsync(entry.id);
+      toast.success("기록이 삭제되었습니다.");
+      onOpenChange(false);
+    } catch (error) {
+      if (error instanceof Error) {
+        toast.error(error.message);
+      } else {
+        toast.error("기록 삭제에 실패했습니다.");
+      }
+    }
+  };
+
+  if (!entry) return null;
+
+  const typeLabel = entry.type === "expense" ? "지출" : "수입";
+  const typeVariant = entry.type === "expense" ? "default" : "secondary";
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <AlertTriangleIcon className="h-5 w-5 text-destructive" />
+            기록 삭제
+          </DialogTitle>
+          <DialogDescription>
+            다음 기록을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* 삭제 대상 정보 */}
+        <div className="rounded-md border p-4 space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="font-medium">
+              {entry.title || entry.categoryName || "미분류"}
+            </span>
+            <Badge variant={typeVariant}>{typeLabel}</Badge>
+          </div>
+          <div className="text-sm text-muted-foreground space-y-1">
+            <div className="flex justify-between">
+              <span>금액</span>
+              <span className="font-medium text-foreground">
+                {formatCurrency(entry.amount)}
+              </span>
+            </div>
+            {entry.categoryName && (
+              <div className="flex justify-between">
+                <span>카테고리</span>
+                <span>{entry.categoryName}</span>
+              </div>
+            )}
+            {(entry.fromPaymentMethodName ||
+              entry.fromAccountName ||
+              entry.toAccountName) && (
+              <div className="flex justify-between">
+                <span>
+                  {entry.type === "expense" ? "결제 방법" : "입금 계좌"}
+                </span>
+                <span>
+                  {entry.fromPaymentMethodName ||
+                    entry.fromAccountName ||
+                    entry.toAccountName}
+                </span>
+              </div>
+            )}
+            <div className="flex justify-between">
+              <span>날짜</span>
+              <span>
+                {new Date(entry.transactedAt).toLocaleDateString("ko-KR")}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={deleteMutation.isPending}
+          >
+            취소
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={handleDelete}
+            disabled={deleteMutation.isPending}
+          >
+            {deleteMutation.isPending ? "삭제 중..." : "삭제"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/ledger/LedgerEntryEditDialog.tsx
+++ b/components/ledger/LedgerEntryEditDialog.tsx
@@ -1,0 +1,437 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { InfoIcon } from "lucide-react";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { DatePickerInput } from "@/components/ui/date-picker";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { useAccounts } from "@/hooks/use-accounts";
+import { useCategories } from "@/hooks/use-categories";
+import { useUpdateLedgerEntry } from "@/hooks/use-ledger-entries";
+import { useMediaQuery } from "@/hooks/use-media-query";
+import { usePaymentMethods } from "@/hooks/use-payment-methods";
+import type { LedgerEntryWithDetails } from "@/lib/api/ledger";
+import type { CategoryType } from "@/types";
+
+interface LedgerEntryEditDialogProps {
+  entry: LedgerEntryWithDetails | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const editFormSchema = z.object({
+  amount: z
+    .string()
+    .min(1, "금액을 입력해주세요.")
+    .refine((val) => !Number.isNaN(Number(val)) && Number(val) > 0, {
+      message: "금액은 0보다 커야 합니다.",
+    }),
+  title: z
+    .string()
+    .min(1, "내용을 입력해주세요.")
+    .max(100, "내용은 100자 이내여야 합니다."),
+  categoryId: z.string().min(1, "카테고리를 선택해주세요."),
+  paymentMethodId: z.string().optional(),
+  accountId: z.string().optional(),
+  transactedAt: z.string().min(1, "날짜를 선택해주세요."),
+  memo: z.string().max(500, "메모는 500자 이내여야 합니다.").optional(),
+});
+
+type EditFormValues = z.infer<typeof editFormSchema>;
+
+export function LedgerEntryEditDialog({
+  entry,
+  open,
+  onOpenChange,
+}: LedgerEntryEditDialogProps) {
+  const updateMutation = useUpdateLedgerEntry();
+  const isDesktop = useMediaQuery("(min-width: 768px)");
+
+  const categoryType = (entry?.type ?? "expense") as CategoryType;
+  const { data: categories = [] } = useCategories(categoryType);
+  const { data: paymentMethods = [] } = usePaymentMethods();
+  const { data: accounts = [] } = useAccounts();
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    watch,
+    setValue,
+    formState: { errors, isSubmitting },
+  } = useForm<EditFormValues>({
+    resolver: zodResolver(editFormSchema),
+  });
+
+  const watchCategoryId = watch("categoryId");
+  const watchTransactedAt = watch("transactedAt");
+  const watchPaymentMethodId = watch("paymentMethodId");
+  const watchAccountId = watch("accountId");
+
+  // entry 변경 시 폼 초기화
+  useEffect(() => {
+    if (entry) {
+      const date = new Date(entry.transactedAt);
+      const formattedDate = date.toISOString().split("T")[0];
+
+      reset({
+        amount: String(entry.amount),
+        title: entry.title ?? "",
+        categoryId: entry.categoryId ?? "",
+        paymentMethodId: entry.fromPaymentMethodId ?? undefined,
+        accountId:
+          entry.type === "expense"
+            ? (entry.fromAccountId ?? undefined)
+            : (entry.toAccountId ?? undefined),
+        transactedAt: formattedDate,
+        memo: entry.memo ?? "",
+      });
+    }
+  }, [entry, reset]);
+
+  const onSubmit = async (data: EditFormValues) => {
+    if (!entry) return;
+
+    try {
+      const transactedAt = data.transactedAt.includes("T")
+        ? data.transactedAt
+        : `${data.transactedAt}T00:00:00.000Z`;
+
+      const updateData: Record<string, unknown> = {
+        amount: Number(data.amount),
+        title: data.title,
+        transactedAt,
+        categoryId: data.categoryId || null,
+        memo: data.memo || null,
+      };
+
+      // 유형에 따라 결제수단/계좌 필드 설정
+      if (entry.type === "expense") {
+        updateData.fromPaymentMethodId = data.paymentMethodId || null;
+        updateData.fromAccountId = data.accountId || null;
+      } else if (entry.type === "income") {
+        updateData.toAccountId = data.accountId || null;
+      }
+
+      await updateMutation.mutateAsync({
+        id: entry.id,
+        data: updateData,
+      });
+      toast.success("기록이 수정되었습니다.");
+      onOpenChange(false);
+    } catch (error) {
+      if (error instanceof Error) {
+        toast.error(error.message);
+      } else {
+        toast.error("기록 수정에 실패했습니다.");
+      }
+    }
+  };
+
+  if (!entry) return null;
+
+  const typeLabel = entry.type === "expense" ? "지출" : "수입";
+  const typeVariant = entry.type === "expense" ? "default" : "secondary";
+  const privacyLabel = entry.isShared ? "공용" : "개인";
+
+  // 결제수단/계좌 통합 value
+  const paymentValue = watchPaymentMethodId
+    ? `pm:${watchPaymentMethodId}`
+    : watchAccountId
+      ? `acc:${watchAccountId}`
+      : "";
+
+  const handlePaymentChange = (v: string) => {
+    if (v.startsWith("pm:")) {
+      setValue("paymentMethodId", v.slice(3));
+      setValue("accountId", undefined);
+    } else if (v.startsWith("acc:")) {
+      setValue("accountId", v.slice(4));
+      setValue("paymentMethodId", undefined);
+    } else {
+      setValue("paymentMethodId", undefined);
+      setValue("accountId", undefined);
+    }
+  };
+
+  const descriptionContent = (
+    <div className="flex items-center gap-2">
+      <Badge variant={typeVariant}>{typeLabel}</Badge>
+      <Badge variant="outline">{privacyLabel}</Badge>
+    </div>
+  );
+
+  const infoBanner = (
+    <div className="flex items-start gap-2 rounded-md bg-muted/50 p-3 text-sm text-muted-foreground">
+      <InfoIcon className="mt-0.5 h-4 w-4 shrink-0" />
+      <p>유형이나 공개범위를 변경하려면 이 기록을 삭제 후 다시 등록해주세요.</p>
+    </div>
+  );
+
+  const formFields = (
+    <>
+      {/* 금액 */}
+      <div className="space-y-2">
+        <Label htmlFor="edit-amount">금액 *</Label>
+        <div className="relative">
+          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500">
+            ₩
+          </span>
+          <Input
+            id="edit-amount"
+            type="number"
+            inputMode="numeric"
+            step="any"
+            min="0"
+            className="pl-7"
+            {...register("amount")}
+          />
+        </div>
+        {errors.amount && (
+          <p className="text-sm text-destructive">{errors.amount.message}</p>
+        )}
+      </div>
+
+      {/* 내용 */}
+      <div className="space-y-2">
+        <Label htmlFor="edit-title">내용 *</Label>
+        <Input
+          id="edit-title"
+          placeholder="예: 이마트 장보기, 스타벅스 아메리카노"
+          {...register("title")}
+        />
+        {errors.title && (
+          <p className="text-sm text-destructive">{errors.title.message}</p>
+        )}
+      </div>
+
+      {/* 카테고리 + 결제수단/계좌 — 2컬럼 그리드 */}
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-2">
+          <Label>카테고리 *</Label>
+          <Select
+            value={watchCategoryId ?? ""}
+            onValueChange={(v) =>
+              setValue("categoryId", v, { shouldValidate: true })
+            }
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="선택" />
+            </SelectTrigger>
+            <SelectContent>
+              {categories.map((cat) => (
+                <SelectItem key={cat.id} value={cat.id}>
+                  {cat.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {errors.categoryId && (
+            <p className="text-sm text-destructive">
+              {errors.categoryId.message}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <Label>{entry.type === "expense" ? "결제 방법" : "입금 계좌"}</Label>
+          {entry.type === "expense" ? (
+            <Select value={paymentValue} onValueChange={handlePaymentChange}>
+              <SelectTrigger>
+                <SelectValue placeholder="선택 안함" />
+              </SelectTrigger>
+              <SelectContent>
+                {paymentMethods.length > 0 && (
+                  <SelectGroup>
+                    <SelectLabel>결제수단</SelectLabel>
+                    {paymentMethods.map((pm) => (
+                      <SelectItem key={pm.id} value={`pm:${pm.id}`}>
+                        {pm.name}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                )}
+                {paymentMethods.length > 0 && accounts.length > 0 && (
+                  <SelectSeparator />
+                )}
+                {accounts.length > 0 && (
+                  <SelectGroup>
+                    <SelectLabel>계좌</SelectLabel>
+                    {accounts.map((acc) => (
+                      <SelectItem key={acc.id} value={`acc:${acc.id}`}>
+                        {acc.name}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                )}
+              </SelectContent>
+            </Select>
+          ) : (
+            <Select
+              value={watchAccountId ?? ""}
+              onValueChange={(v) => setValue("accountId", v || undefined)}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="선택 안함" />
+              </SelectTrigger>
+              <SelectContent>
+                {accounts.map((acc) => (
+                  <SelectItem key={acc.id} value={acc.id}>
+                    {acc.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        </div>
+      </div>
+
+      {/* 날짜 */}
+      <div className="space-y-2">
+        <Label htmlFor="edit-transactedAt">날짜</Label>
+        <DatePickerInput
+          id="edit-transactedAt"
+          value={watchTransactedAt ?? ""}
+          onChange={(v) =>
+            setValue("transactedAt", v, { shouldValidate: true })
+          }
+        />
+        {errors.transactedAt && (
+          <p className="text-sm text-destructive">
+            {errors.transactedAt.message}
+          </p>
+        )}
+      </div>
+
+      {/* 메모 */}
+      <div className="space-y-2">
+        <Label htmlFor="edit-memo">메모 (선택)</Label>
+        <Textarea
+          id="edit-memo"
+          placeholder="추가로 남기고 싶은 내용을 입력하세요"
+          rows={2}
+          className="resize-none"
+          {...register("memo")}
+        />
+        {errors.memo && (
+          <p className="text-sm text-destructive">{errors.memo.message}</p>
+        )}
+      </div>
+    </>
+  );
+
+  if (isDesktop) {
+    return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>기록 수정</DialogTitle>
+            <DialogDescription asChild>{descriptionContent}</DialogDescription>
+          </DialogHeader>
+
+          {infoBanner}
+
+          <form
+            id="ledger-entry-edit-form"
+            onSubmit={handleSubmit(onSubmit)}
+            className="space-y-4"
+          >
+            {formFields}
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isSubmitting}
+              >
+                취소
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? "저장 중..." : "저장"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  // 모바일: Drawer (Bottom Sheet)
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent>
+        <DrawerHeader>
+          <DrawerTitle>기록 수정</DrawerTitle>
+          <DrawerDescription asChild>{descriptionContent}</DrawerDescription>
+        </DrawerHeader>
+
+        <div className="overflow-y-auto flex-1 px-4">
+          <form
+            id="ledger-entry-edit-form"
+            onSubmit={handleSubmit(onSubmit)}
+            className="space-y-4 pb-2"
+          >
+            {infoBanner}
+            {formFields}
+          </form>
+        </div>
+
+        <DrawerFooter>
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isSubmitting}
+              className="flex-1"
+            >
+              취소
+            </Button>
+            <Button
+              type="submit"
+              form="ledger-entry-edit-form"
+              disabled={isSubmitting}
+              className="flex-1"
+            >
+              {isSubmitting ? "저장 중..." : "저장"}
+            </Button>
+          </div>
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/hooks/use-ledger-entries.ts
+++ b/hooks/use-ledger-entries.ts
@@ -1,13 +1,25 @@
 "use client";
 
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { LedgerEntryWithDetails } from "@/lib/api/ledger";
 import { queries } from "@/lib/queries/keys";
-import type { CreateLedgerEntryInput } from "@/schemas/ledger-entry";
+import type {
+  CreateLedgerEntryInput,
+  UpdateLedgerEntryInput,
+} from "@/schemas/ledger-entry";
 import type { LedgerEntry } from "@/types";
 
 interface BatchCreateResponse {
   data: LedgerEntry[];
   count: number;
+}
+
+interface LedgerEntryListResponse {
+  data: LedgerEntryWithDetails[];
+}
+
+interface LedgerEntryResponse {
+  data: LedgerEntry;
 }
 
 interface LedgerError {
@@ -16,6 +28,48 @@ interface LedgerError {
     message: string;
   };
 }
+
+// ============================================================================
+// 가계부 항목 목록 조회
+// ============================================================================
+
+interface LedgerEntriesParams {
+  year?: number;
+  month?: number;
+  date?: string;
+}
+
+async function fetchLedgerEntries(
+  params?: LedgerEntriesParams,
+): Promise<LedgerEntryWithDetails[]> {
+  const searchParams = new URLSearchParams();
+  if (params?.year) searchParams.set("year", String(params.year));
+  if (params?.month) searchParams.set("month", String(params.month));
+  if (params?.date) searchParams.set("date", params.date);
+
+  const url = `/api/ledger-entries${searchParams.toString() ? `?${searchParams}` : ""}`;
+  const response = await fetch(url);
+  const json = await response.json();
+
+  if (!response.ok) {
+    const error = json as LedgerError;
+    throw new Error(error.error.message);
+  }
+
+  return (json as LedgerEntryListResponse).data;
+}
+
+export function useLedgerEntries(params?: LedgerEntriesParams) {
+  return useQuery({
+    queryKey: queries.ledgerEntries.list(params).queryKey,
+    queryFn: () => fetchLedgerEntries(params),
+    staleTime: 1000 * 60 * 5,
+  });
+}
+
+// ============================================================================
+// 가계부 항목 일괄 생성
+// ============================================================================
 
 async function createBatchLedgerEntries(
   entries: CreateLedgerEntryInput[],
@@ -40,6 +94,72 @@ export function useCreateBatchLedgerEntries() {
 
   return useMutation({
     mutationFn: createBatchLedgerEntries,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queries.ledgerEntries._def });
+    },
+  });
+}
+
+// ============================================================================
+// 가계부 항목 수정
+// ============================================================================
+
+interface UpdateLedgerEntryParams {
+  id: string;
+  data: UpdateLedgerEntryInput;
+}
+
+async function updateLedgerEntry({
+  id,
+  data,
+}: UpdateLedgerEntryParams): Promise<LedgerEntry> {
+  const response = await fetch(`/api/ledger-entries/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  const json = await response.json();
+
+  if (!response.ok) {
+    const error = json as LedgerError;
+    throw new Error(error.error.message);
+  }
+
+  return (json as LedgerEntryResponse).data;
+}
+
+export function useUpdateLedgerEntry() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updateLedgerEntry,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queries.ledgerEntries._def });
+    },
+  });
+}
+
+// ============================================================================
+// 가계부 항목 삭제
+// ============================================================================
+
+async function deleteLedgerEntry(id: string): Promise<void> {
+  const response = await fetch(`/api/ledger-entries/${id}`, {
+    method: "DELETE",
+  });
+  const json = await response.json();
+
+  if (!response.ok) {
+    const error = json as LedgerError;
+    throw new Error(error.error.message);
+  }
+}
+
+export function useDeleteLedgerEntry() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: deleteLedgerEntry,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queries.ledgerEntries._def });
     },


### PR DESCRIPTION
## 변경 사항

Closes #241

### 구현 내용

#### 1. React Query 훅 (`hooks/use-ledger-entries.ts`)
- `useLedgerEntries(params?)` — 목록 조회 (GET /api/ledger-entries)
- `useUpdateLedgerEntry()` — 수정 mutation (PATCH /api/ledger-entries/[id])
- `useDeleteLedgerEntry()` — 삭제 mutation (DELETE /api/ledger-entries/[id])
- **캐시 무효화**: `queries.ledgerEntries._def`로 list, summary 하위 키 전체 무효화

#### 2. 수정 Dialog/Drawer (`components/ledger/LedgerEntryEditDialog.tsx`)
- 데스크톱: Dialog / 모바일: Drawer (useMediaQuery 기반 반응형)
- 유형(수입/지출) + 공개범위(공용/개인)는 읽기 전용 Badge 표시
- `유형 변경은 삭제 후 재등록` 안내 배너
- react-hook-form + zod 검증

#### 3. 삭제 확인 Dialog (`components/ledger/LedgerEntryDeleteDialog.tsx`)
- TransactionDeleteDialog 패턴 기반
- 삭제 대상 정보 표시 후 확인/취소

### 검증
- `tsc --noEmit` 통과
- `vitest run` 기존 실패 외 모두 통과