### PR TITLE
feat: 가계부 기록 조회 페이지 구현 (#272)

### DIFF
--- a/app/(main)/ledger/records/page.tsx
+++ b/app/(main)/ledger/records/page.tsx
@@ -1,0 +1,7 @@
+import { LedgerRecordsClient } from "@/components/ledger/records/LedgerRecordsClient";
+import { requireUser } from "@/lib/supabase/auth";
+
+export default async function LedgerRecordsPage() {
+  await requireUser();
+  return <LedgerRecordsClient />;
+}

--- a/components/ledger/funnel/SelectTypeStep.tsx
+++ b/components/ledger/funnel/SelectTypeStep.tsx
@@ -27,10 +27,10 @@ export function SelectTypeStep({ onSelect, onBack }: SelectTypeStepProps) {
         <button
           type="button"
           onClick={() => onSelect("expense")}
-          className="w-full flex items-center gap-4 p-5 rounded-2xl border-2 border-gray-100 bg-white hover:border-red-200 hover:bg-red-50 transition-colors text-left"
+          className="w-full flex items-center gap-4 p-5 rounded-2xl border-2 border-gray-100 bg-white hover:border-blue-200 hover:bg-blue-50 transition-colors text-left"
         >
-          <div className="w-12 h-12 rounded-full bg-red-100 flex items-center justify-center shrink-0">
-            <TrendingDownIcon className="w-6 h-6 text-red-500" />
+          <div className="w-12 h-12 rounded-full bg-blue-100 flex items-center justify-center shrink-0">
+            <TrendingDownIcon className="w-6 h-6 text-blue-500" />
           </div>
           <div>
             <p className="text-lg font-semibold text-gray-900">지출</p>
@@ -41,10 +41,10 @@ export function SelectTypeStep({ onSelect, onBack }: SelectTypeStepProps) {
         <button
           type="button"
           onClick={() => onSelect("income")}
-          className="w-full flex items-center gap-4 p-5 rounded-2xl border-2 border-gray-100 bg-white hover:border-blue-200 hover:bg-blue-50 transition-colors text-left"
+          className="w-full flex items-center gap-4 p-5 rounded-2xl border-2 border-gray-100 bg-white hover:border-red-200 hover:bg-red-50 transition-colors text-left"
         >
-          <div className="w-12 h-12 rounded-full bg-blue-100 flex items-center justify-center shrink-0">
-            <TrendingUpIcon className="w-6 h-6 text-blue-500" />
+          <div className="w-12 h-12 rounded-full bg-red-100 flex items-center justify-center shrink-0">
+            <TrendingUpIcon className="w-6 h-6 text-red-500" />
           </div>
           <div>
             <p className="text-lg font-semibold text-gray-900">수입</p>

--- a/components/ledger/records/LedgerCalendar.tsx
+++ b/components/ledger/records/LedgerCalendar.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { type ComponentProps, useCallback } from "react";
+import type { DayButton } from "react-day-picker";
+import { Calendar, CalendarDayButton } from "@/components/ui/calendar";
+import type { LedgerEntryWithDetails } from "@/lib/api/ledger";
+
+function formatAmountShort(amount: number): string {
+  if (amount >= 10_000) {
+    const man = Math.floor(amount / 10_000);
+    return `${man}만`;
+  }
+  return amount.toLocaleString("ko-KR");
+}
+
+interface LedgerCalendarProps {
+  currentMonth: Date;
+  onMonthChange: (month: Date) => void;
+  selectedDate: Date;
+  onDateSelect: (date: Date) => void;
+  entriesByDate: Map<string, LedgerEntryWithDetails[]>;
+}
+
+export function LedgerCalendar({
+  currentMonth,
+  onMonthChange,
+  selectedDate,
+  onDateSelect,
+  entriesByDate,
+}: LedgerCalendarProps) {
+  const DayButtonWithAmounts = useCallback(
+    function DayButtonWithAmounts({
+      day,
+      modifiers,
+      children,
+      ...props
+    }: ComponentProps<typeof DayButton>) {
+      const d = day.date;
+      const dateKey = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+      const dayEntries = entriesByDate.get(dateKey) ?? [];
+
+      let income = 0;
+      let expense = 0;
+      for (const e of dayEntries) {
+        if (e.type === "income") income += e.amount;
+        else if (e.type === "expense") expense += e.amount;
+      }
+
+      const isSelected =
+        modifiers.selected &&
+        !modifiers.range_start &&
+        !modifiers.range_end &&
+        !modifiers.range_middle;
+
+      return (
+        // 버튼 전체 배경 선택 스타일 제거 — 원형 숫자 span에서만 선택 표시
+        <CalendarDayButton
+          day={day}
+          modifiers={modifiers}
+          {...props}
+          className="flex-col gap-0 py-1 data-[selected-single=true]:!bg-transparent data-[selected-single=true]:!text-inherit hover:!bg-transparent"
+        >
+          {/* 날짜 숫자 — 고정 높이 원형 버튼 영역 */}
+          <span
+            className={`flex h-8 w-8 items-center justify-center rounded-full text-sm font-medium transition-colors ${
+              isSelected
+                ? "bg-gray-800 text-white"
+                : modifiers.today
+                  ? "bg-gray-100 text-gray-900"
+                  : "text-gray-900"
+            }`}
+          >
+            {children}
+          </span>
+
+          {/* 금액 텍스트 — 선택 상태 무관, 항상 동일 색상 */}
+          <span className="flex min-h-[22px] flex-col items-center justify-start gap-0.5 pt-0.5">
+            {income > 0 && (
+              <span className="text-[9px] font-medium text-blue-500 leading-none">
+                +{formatAmountShort(income)}
+              </span>
+            )}
+            {expense > 0 && (
+              <span className="text-[9px] text-gray-400 leading-none">
+                -{formatAmountShort(expense)}
+              </span>
+            )}
+          </span>
+        </CalendarDayButton>
+      );
+    },
+    [entriesByDate],
+  );
+
+  return (
+    <div className="bg-white rounded-2xl shadow-sm p-2 ">
+      <Calendar
+        mode="single"
+        month={currentMonth}
+        onMonthChange={onMonthChange}
+        selected={selectedDate}
+        onSelect={(d) => d && onDateSelect(d)}
+        hideNavigation
+        components={{ DayButton: DayButtonWithAmounts }}
+        className="w-full"
+      />
+    </div>
+  );
+}

--- a/components/ledger/records/LedgerCalendar.tsx
+++ b/components/ledger/records/LedgerCalendar.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { RefreshCw } from "lucide-react";
 import { type ComponentProps, useCallback } from "react";
 import type { DayButton } from "react-day-picker";
+import { Button } from "@/components/ui/button";
 import { Calendar, CalendarDayButton } from "@/components/ui/calendar";
 import type { LedgerEntryWithDetails } from "@/lib/api/ledger";
 
@@ -19,6 +21,7 @@ interface LedgerCalendarProps {
   selectedDate: Date;
   onDateSelect: (date: Date) => void;
   entriesByDate: Map<string, LedgerEntryWithDetails[]>;
+  onRefresh: () => void;
 }
 
 export function LedgerCalendar({
@@ -27,6 +30,7 @@ export function LedgerCalendar({
   selectedDate,
   onDateSelect,
   entriesByDate,
+  onRefresh,
 }: LedgerCalendarProps) {
   const DayButtonWithAmounts = useCallback(
     function DayButtonWithAmounts({
@@ -76,12 +80,12 @@ export function LedgerCalendar({
           {/* 금액 텍스트 — 선택 상태 무관, 항상 동일 색상 */}
           <span className="flex min-h-[22px] flex-col items-center justify-start gap-0.5 pt-0.5">
             {income > 0 && (
-              <span className="text-[9px] font-medium text-blue-500 leading-none">
+              <span className="text-[9px] font-medium text-red-500 leading-none">
                 +{formatAmountShort(income)}
               </span>
             )}
             {expense > 0 && (
-              <span className="text-[9px] text-gray-400 leading-none">
+              <span className="text-[9px] text-blue-500 leading-none">
                 -{formatAmountShort(expense)}
               </span>
             )}
@@ -93,7 +97,16 @@ export function LedgerCalendar({
   );
 
   return (
-    <div className="bg-white rounded-2xl shadow-sm p-2 ">
+    <div className="relative bg-white rounded-2xl shadow-sm p-2">
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={onRefresh}
+        className="absolute top-5 right-6 h-7 w-7 text-gray-400 hover:text-gray-600 z-10"
+        title="새로고침"
+      >
+        <RefreshCw className="w-3.5 h-3.5" />
+      </Button>
       <Calendar
         mode="single"
         month={currentMonth}

--- a/components/ledger/records/LedgerDayEntryList.tsx
+++ b/components/ledger/records/LedgerDayEntryList.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { format } from "date-fns";
+import { ko } from "date-fns/locale";
+import type { LedgerEntryWithDetails } from "@/lib/api/ledger";
+import { LedgerEntryRow } from "./LedgerEntryRow";
+
+interface LedgerDayEntryListProps {
+  selectedDate: Date;
+  entries: LedgerEntryWithDetails[];
+  onEdit: (entry: LedgerEntryWithDetails) => void;
+  onDelete: (entry: LedgerEntryWithDetails) => void;
+}
+
+export function LedgerDayEntryList({
+  selectedDate,
+  entries,
+  onEdit,
+  onDelete,
+}: LedgerDayEntryListProps) {
+  const dateLabel = format(selectedDate, "M월 d일 (eee)", { locale: ko });
+
+  return (
+    <div className="bg-white rounded-2xl shadow-sm mt-4 md:mt-0">
+      <div className="px-4 pt-4 pb-2">
+        <h3 className="text-sm font-semibold text-gray-700">{dateLabel}</h3>
+      </div>
+
+      {entries.length === 0 ? (
+        <p className="px-4 pb-4 text-sm text-gray-400">
+          이 날의 기록이 없습니다.
+        </p>
+      ) : (
+        <div className="px-4 pb-2">
+          {entries.map((entry) => (
+            <LedgerEntryRow
+              key={entry.id}
+              entry={entry}
+              onEdit={onEdit}
+              onDelete={onDelete}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/ledger/records/LedgerEntryRow.tsx
+++ b/components/ledger/records/LedgerEntryRow.tsx
@@ -25,7 +25,7 @@ export function LedgerEntryRow({
 }: LedgerEntryRowProps) {
   const isIncome = entry.type === "income";
   const amountSign = isIncome ? "+" : "-";
-  const amountColor = isIncome ? "text-red-500" : "text-gray-900";
+  const amountColor = isIncome ? "text-red-500" : "text-blue-500";
 
   const paymentLabel =
     entry.fromPaymentMethodName ?? entry.fromAccountName ?? entry.toAccountName;

--- a/components/ledger/records/LedgerEntryRow.tsx
+++ b/components/ledger/records/LedgerEntryRow.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { MoreVertical, UserIcon } from "lucide-react";
+import { CategoryIcon } from "@/components/ledger/CategoryIcon";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import type { LedgerEntryWithDetails } from "@/lib/api/ledger";
+import { formatCurrency } from "@/lib/utils/format";
+
+interface LedgerEntryRowProps {
+  entry: LedgerEntryWithDetails;
+  onEdit: (entry: LedgerEntryWithDetails) => void;
+  onDelete: (entry: LedgerEntryWithDetails) => void;
+}
+
+export function LedgerEntryRow({
+  entry,
+  onEdit,
+  onDelete,
+}: LedgerEntryRowProps) {
+  const isIncome = entry.type === "income";
+  const amountSign = isIncome ? "+" : "-";
+  const amountColor = isIncome ? "text-red-500" : "text-gray-900";
+
+  const paymentLabel =
+    entry.fromPaymentMethodName ?? entry.fromAccountName ?? entry.toAccountName;
+
+  const metaParts = [entry.categoryName, entry.ownerName, paymentLabel].filter(
+    Boolean,
+  );
+
+  return (
+    <div className="flex items-center gap-3 py-3 border-b last:border-b-0">
+      {/* 카테고리 아이콘 */}
+      <div className="flex-shrink-0 w-11 h-11 rounded-xl bg-gray-100 flex items-center justify-center">
+        <CategoryIcon
+          iconName={entry.categoryIcon}
+          className="w-5 h-5 text-gray-600"
+        />
+      </div>
+
+      {/* 내용 */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-1">
+          <span className="font-semibold text-gray-900 text-sm truncate">
+            {entry.title ?? entry.categoryName ?? "미분류"}
+          </span>
+          {!entry.isShared && (
+            <UserIcon className="w-3 h-3 text-gray-400 flex-shrink-0" />
+          )}
+        </div>
+        {metaParts.length > 0 && (
+          <p className="text-xs text-gray-400 truncate mt-0.5">
+            {metaParts.join(" · ")}
+          </p>
+        )}
+      </div>
+
+      {/* 금액 + 메뉴 */}
+      <div className="flex items-center gap-1 flex-shrink-0">
+        <span className={`text-sm font-semibold ${amountColor}`}>
+          {amountSign}
+          {formatCurrency(entry.amount)}
+        </span>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon" className="h-8 w-8">
+              <MoreVertical className="w-4 h-4 text-gray-400" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={() => onEdit(entry)}>
+              수정
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              className="text-destructive"
+              onClick={() => onDelete(entry)}
+            >
+              삭제
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </div>
+  );
+}

--- a/components/ledger/records/LedgerRecordsClient.tsx
+++ b/components/ledger/records/LedgerRecordsClient.tsx
@@ -1,22 +1,34 @@
 "use client";
 
-import { addMonths, format, startOfMonth, subMonths } from "date-fns";
-import { ko } from "date-fns/locale";
+import { useQueryClient } from "@tanstack/react-query";
+import { addMonths, getYear, startOfMonth, subMonths } from "date-fns";
 import { ChevronLeft, ChevronRight, Plus } from "lucide-react";
 import Link from "next/link";
 import { useMemo, useState } from "react";
 import { LedgerEntryDeleteDialog } from "@/components/ledger/LedgerEntryDeleteDialog";
 import { LedgerEntryEditDialog } from "@/components/ledger/LedgerEntryEditDialog";
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useLedgerEntries } from "@/hooks/use-ledger-entries";
 import {
   calculateLedgerSummary,
   type LedgerEntryWithDetails,
 } from "@/lib/api/ledger";
+import { queries } from "@/lib/queries/keys";
 import { formatCurrency, formatDateISO } from "@/lib/utils/format";
 import { LedgerCalendar } from "./LedgerCalendar";
 import { LedgerDayEntryList } from "./LedgerDayEntryList";
+
+const CURRENT_YEAR = getYear(new Date());
+const YEAR_OPTIONS = Array.from({ length: 11 }, (_, i) => CURRENT_YEAR - 5 + i);
+const MONTH_OPTIONS = Array.from({ length: 12 }, (_, i) => i + 1);
 
 export function LedgerRecordsClient() {
   const [currentMonth, setCurrentMonth] = useState<Date>(() =>
@@ -28,23 +40,36 @@ export function LedgerRecordsClient() {
   const [editOpen, setEditOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
 
+  const queryClient = useQueryClient();
+
+  const prevMonth = useMemo(() => subMonths(currentMonth, 1), [currentMonth]);
+  const nextMonth = useMemo(() => addMonths(currentMonth, 1), [currentMonth]);
+
+  const { data: prevEntries = [] } = useLedgerEntries({
+    year: prevMonth.getFullYear(),
+    month: prevMonth.getMonth() + 1,
+  });
   const { data: entries = [], isLoading } = useLedgerEntries({
     year: currentMonth.getFullYear(),
     month: currentMonth.getMonth() + 1,
+  });
+  const { data: nextEntries = [] } = useLedgerEntries({
+    year: nextMonth.getFullYear(),
+    month: nextMonth.getMonth() + 1,
   });
 
   const summary = useMemo(() => calculateLedgerSummary(entries), [entries]);
 
   const entriesByDate = useMemo(() => {
     const map = new Map<string, LedgerEntryWithDetails[]>();
-    for (const entry of entries) {
+    for (const entry of [...prevEntries, ...entries, ...nextEntries]) {
       const key = entry.transactedAt.slice(0, 10);
       const list = map.get(key) ?? [];
       list.push(entry);
       map.set(key, list);
     }
     return map;
-  }, [entries]);
+  }, [prevEntries, entries, nextEntries]);
 
   const dayEntries = entriesByDate.get(formatDateISO(selectedDate)) ?? [];
 
@@ -65,6 +90,26 @@ export function LedgerRecordsClient() {
 
   const handleMonthChange = (month: Date) =>
     setCurrentMonth(startOfMonth(month));
+
+  const handleYearChange = (year: string) => {
+    setCurrentMonth((m) => {
+      const next = new Date(m);
+      next.setFullYear(Number(year));
+      return startOfMonth(next);
+    });
+  };
+
+  const handleRefresh = () => {
+    queryClient.invalidateQueries({ queryKey: queries.ledgerEntries._def });
+  };
+
+  const handleMonthSelect = (month: string) => {
+    setCurrentMonth((m) => {
+      const next = new Date(m);
+      next.setMonth(Number(month) - 1);
+      return startOfMonth(next);
+    });
+  };
 
   const handleDateSelect = (date: Date) => {
     setSelectedDate(date);
@@ -116,6 +161,7 @@ export function LedgerRecordsClient() {
       selectedDate={selectedDate}
       onDateSelect={handleDateSelect}
       entriesByDate={entriesByDate}
+      onRefresh={handleRefresh}
     />
   );
 
@@ -126,9 +172,38 @@ export function LedgerRecordsClient() {
         <Button variant="ghost" size="icon" onClick={goToPrevMonth}>
           <ChevronLeft className="w-5 h-5" />
         </Button>
-        <span className="text-lg font-semibold text-gray-900">
-          {format(currentMonth, "yyyy년 M월", { locale: ko })}
-        </span>
+        <div className="flex items-center gap-1">
+          <Select
+            value={String(currentMonth.getFullYear())}
+            onValueChange={handleYearChange}
+          >
+            <SelectTrigger className="h-auto w-auto gap-0.5 border-none shadow-none px-1.5 py-0.5 text-lg font-semibold text-gray-900 focus:ring-0 rounded-lg hover:bg-gray-100 transition-colors">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {YEAR_OPTIONS.map((y) => (
+                <SelectItem key={y} value={String(y)}>
+                  {y}년
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select
+            value={String(currentMonth.getMonth() + 1)}
+            onValueChange={handleMonthSelect}
+          >
+            <SelectTrigger className="h-auto w-auto gap-0.5 border-none shadow-none px-1.5 py-0.5 text-lg font-semibold text-gray-900 focus:ring-0 rounded-lg hover:bg-gray-100 transition-colors">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {MONTH_OPTIONS.map((m) => (
+                <SelectItem key={m} value={String(m)}>
+                  {m}월
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
         <Button variant="ghost" size="icon" onClick={goToNextMonth}>
           <ChevronRight className="w-5 h-5" />
         </Button>

--- a/components/ledger/records/LedgerRecordsClient.tsx
+++ b/components/ledger/records/LedgerRecordsClient.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { addMonths, format, startOfMonth, subMonths } from "date-fns";
+import { ko } from "date-fns/locale";
+import { ChevronLeft, ChevronRight, Plus } from "lucide-react";
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { LedgerEntryDeleteDialog } from "@/components/ledger/LedgerEntryDeleteDialog";
+import { LedgerEntryEditDialog } from "@/components/ledger/LedgerEntryEditDialog";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useLedgerEntries } from "@/hooks/use-ledger-entries";
+import {
+  calculateLedgerSummary,
+  type LedgerEntryWithDetails,
+} from "@/lib/api/ledger";
+import { formatCurrency, formatDateISO } from "@/lib/utils/format";
+import { LedgerCalendar } from "./LedgerCalendar";
+import { LedgerDayEntryList } from "./LedgerDayEntryList";
+
+export function LedgerRecordsClient() {
+  const [currentMonth, setCurrentMonth] = useState<Date>(() =>
+    startOfMonth(new Date()),
+  );
+  const [selectedDate, setSelectedDate] = useState<Date>(new Date());
+  const [selectedEntry, setSelectedEntry] =
+    useState<LedgerEntryWithDetails | null>(null);
+  const [editOpen, setEditOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  const { data: entries = [], isLoading } = useLedgerEntries({
+    year: currentMonth.getFullYear(),
+    month: currentMonth.getMonth() + 1,
+  });
+
+  const summary = useMemo(() => calculateLedgerSummary(entries), [entries]);
+
+  const entriesByDate = useMemo(() => {
+    const map = new Map<string, LedgerEntryWithDetails[]>();
+    for (const entry of entries) {
+      const key = entry.transactedAt.slice(0, 10);
+      const list = map.get(key) ?? [];
+      list.push(entry);
+      map.set(key, list);
+    }
+    return map;
+  }, [entries]);
+
+  const dayEntries = entriesByDate.get(formatDateISO(selectedDate)) ?? [];
+
+  const handleEdit = (entry: LedgerEntryWithDetails) => {
+    setSelectedEntry(entry);
+    setEditOpen(true);
+  };
+
+  const handleDelete = (entry: LedgerEntryWithDetails) => {
+    setSelectedEntry(entry);
+    setDeleteOpen(true);
+  };
+
+  const goToPrevMonth = () =>
+    setCurrentMonth((m) => startOfMonth(subMonths(m, 1)));
+  const goToNextMonth = () =>
+    setCurrentMonth((m) => startOfMonth(addMonths(m, 1)));
+
+  const handleMonthChange = (month: Date) =>
+    setCurrentMonth(startOfMonth(month));
+
+  const handleDateSelect = (date: Date) => {
+    setSelectedDate(date);
+    // 선택된 날짜가 현재 표시 월과 다르면 월도 변경
+    if (
+      date.getFullYear() !== currentMonth.getFullYear() ||
+      date.getMonth() !== currentMonth.getMonth()
+    ) {
+      setCurrentMonth(startOfMonth(date));
+    }
+  };
+
+  const summaryCard = isLoading ? (
+    <Skeleton className="h-16 rounded-2xl mb-4" />
+  ) : (
+    <div className="bg-white rounded-2xl p-4 shadow-sm mb-4 grid grid-cols-3 gap-2 text-center">
+      <div>
+        <p className="text-xs text-gray-500 mb-1">입금</p>
+        <p className="text-sm font-semibold text-red-500">
+          +{formatCurrency(summary.totalIncome)}
+        </p>
+      </div>
+      <div>
+        <p className="text-xs text-gray-500 mb-1">지출</p>
+        <p className="text-sm font-semibold text-blue-500">
+          -{formatCurrency(summary.totalExpense)}
+        </p>
+      </div>
+      <div>
+        <p className="text-xs text-gray-500 mb-1">잔액</p>
+        <p
+          className={`text-sm font-semibold ${
+            summary.balance >= 0 ? "text-gray-900" : "text-blue-500"
+          }`}
+        >
+          {summary.balance >= 0 ? "+" : ""}
+          {formatCurrency(summary.balance)}
+        </p>
+      </div>
+    </div>
+  );
+
+  const calendarSection = isLoading ? (
+    <Skeleton className="h-72 rounded-2xl" />
+  ) : (
+    <LedgerCalendar
+      currentMonth={currentMonth}
+      onMonthChange={handleMonthChange}
+      selectedDate={selectedDate}
+      onDateSelect={handleDateSelect}
+      entriesByDate={entriesByDate}
+    />
+  );
+
+  return (
+    <div className="pb-6">
+      {/* 월 네비게이션 헤더 */}
+      <div className="flex items-center justify-between mb-4">
+        <Button variant="ghost" size="icon" onClick={goToPrevMonth}>
+          <ChevronLeft className="w-5 h-5" />
+        </Button>
+        <span className="text-lg font-semibold text-gray-900">
+          {format(currentMonth, "yyyy년 M월", { locale: ko })}
+        </span>
+        <Button variant="ghost" size="icon" onClick={goToNextMonth}>
+          <ChevronRight className="w-5 h-5" />
+        </Button>
+      </div>
+
+      {/* md 이상: 캘린더(좌) + 목록(우) 2컬럼 / 모바일: 단일 컬럼 */}
+      <div className="md:grid md:grid-cols-[auto_1fr] md:gap-6 md:items-start">
+        {/* 좌측: 요약 + 캘린더 */}
+        <div className="md:w-[450px]">
+          {summaryCard}
+          {calendarSection}
+        </div>
+
+        {/* 우측(데스크탑) / 하단(모바일): 항목 목록 + 등록 버튼 */}
+        <div className="flex flex-col gap-4">
+          <LedgerDayEntryList
+            selectedDate={selectedDate}
+            entries={dayEntries}
+            onEdit={handleEdit}
+            onDelete={handleDelete}
+          />
+          <Button asChild className="w-full" size="icon-sm">
+            <Link href="/ledger/new">
+              <Plus className="w-5 h-5" />
+              가계부 등록
+            </Link>
+          </Button>
+        </div>
+      </div>
+
+      {/* 수정/삭제 다이얼로그 */}
+      <LedgerEntryEditDialog
+        entry={selectedEntry}
+        open={editOpen}
+        onOpenChange={setEditOpen}
+      />
+      <LedgerEntryDeleteDialog
+        entry={selectedEntry}
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+      />
+    </div>
+  );
+}

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ko } from "date-fns/locale";
 import {
   ChevronDownIcon,
   ChevronLeftIcon,
@@ -22,6 +23,7 @@ function Calendar({
   buttonVariant = "ghost",
   formatters,
   components,
+  locale = ko,
   ...props
 }: React.ComponentProps<typeof DayPicker> & {
   buttonVariant?: React.ComponentProps<typeof Button>["variant"];
@@ -30,6 +32,7 @@ function Calendar({
 
   return (
     <DayPicker
+      locale={locale}
       showOutsideDays={showOutsideDays}
       className={cn(
         "group/calendar bg-background p-3 [--cell-size:--spacing(8)] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent",

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -116,7 +116,7 @@ function Calendar({
         range_middle: cn("rounded-none", defaultClassNames.range_middle),
         range_end: cn("rounded-r-md bg-accent", defaultClassNames.range_end),
         today: cn(
-          "rounded-md bg-accent text-accent-foreground data-[selected=true]:rounded-none",
+          "text-accent-foreground data-[selected=true]:rounded-none bg-transparent font-bold",
           defaultClassNames.today,
         ),
         outside: cn(


### PR DESCRIPTION
## Summary

- 캘린더 기반 월간 수입/지출 조회 페이지(`/ledger/records`) 신규 구현
- 전월/다음달 데이터를 함께 조회하여 캘린더 가장자리 날짜에도 금액 표시
- 년/월 Select 드롭다운으로 빠른 월 이동 지원
- 캘린더 우측 상단 새로고침 버튼으로 다른 구성원 기록 즉시 반영 가능
- 캘린더 한글 로케일 기본값 적용 (요일·월 한글 표기, 전체 Calendar 컴포넌트 적용)
- 수입(red)/지출(blue) 컬러 규칙 전체 통일 — 캘린더, 항목 행, 등록 유형 선택 화면

## Changes

**신규 파일**
- `app/(main)/ledger/records/page.tsx` — 서버 컴포넌트 (인증만)
- `components/ledger/records/LedgerRecordsClient.tsx` — 클라이언트 오케스트레이터
- `components/ledger/records/LedgerCalendar.tsx` — 날짜별 수입/지출 금액 표시 캘린더
- `components/ledger/records/LedgerDayEntryList.tsx` — 선택된 날짜 항목 리스트
- `components/ledger/records/LedgerEntryRow.tsx` — 개별 항목 행 (수정/삭제 드롭다운)

**수정 파일**
- `components/ui/calendar.tsx` — `locale = ko` 기본값 추가
- `components/ledger/funnel/SelectTypeStep.tsx` — 수입/지출 컬러 규칙 수정
- `components/ledger/records/LedgerEntryRow.tsx` — 지출 컬러 gray → blue 통일

## Test plan

- [ ] `/ledger/records` 접근 시 캘린더 및 요약 카드 정상 표시
- [ ] 캘린더 요일/월이 한글로 표시됨
- [ ] 날짜 클릭 시 해당일 항목 목록 갱신
- [ ] 캘린더 가장자리(전월/다음달) 날짜에 금액 표시
- [ ] 년/월 Select로 월 이동
- [ ] 새로고침 버튼 클릭 시 최신 데이터 반영
- [ ] 항목 ⋮ 메뉴 → 수정/삭제 다이얼로그 정상 동작
- [ ] 수입(빨강)/지출(파랑) 컬러 일관성 확인

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)