### PR TITLE
feat: 가계부 통계 대시보드 API 구현 (#245)

### DIFF
--- a/.claude/docs/PRD.md
+++ b/.claude/docs/PRD.md
@@ -288,15 +288,42 @@
 
 ---
 
-### 4.3 현금 흐름 분석 (가계부 이후)
+### 4.3 가계부 분석 대시보드 (/ledger/analysis)
 
-| ID | 기능 | 우선순위 | 설명 |
-|----|------|----------|------|
-| FLOW-01 | 월별 수입/지출 요약 | 🔴 필수 | 이번 달 총 수입, 총 지출, 잔액 |
-| FLOW-02 | 카테고리별 지출 비율 | 🔴 필수 | 파이차트/바 차트 |
-| FLOW-03 | 결제수단별 지출 | 🟡 권장 | 어떤 카드/페이로 얼마 썼는지 |
-| FLOW-04 | 월별 추이 | 🟡 권장 | 최근 6개월 수입/지출 추이 |
-| FLOW-05 | 저축률 표시 | 🟡 권장 | (수입 - 지출) / 수입 |
+가계부 홈에서 진입. 현재 월 및 최근 추이를 분석하는 통계 대시보드. **가계부 전용 독립 페이지**로 구성 (기존 투자 대시보드 `/dashboard`와 분리).
+
+#### 데이터 범위 (scope)
+
+| scope | 설명 |
+|-------|------|
+| `all` | 공용 + 본인 개인 (기본값, RLS 자동 적용) |
+| `shared` | 공용 항목만 (가구 전체 동일한 뷰) |
+| `personal` | 본인 개인 항목만 |
+
+> 파트너의 개인 지출 세부 내역은 RLS로 차단. 합산 금액만 `get_private_entry_totals()` SECURITY DEFINER 함수로 제공.
+
+#### 화면 섹션 및 API
+
+| ID | 기능 | 우선순위 | scope 선택 | API |
+|----|------|----------|:---:|-----|
+| FLOW-01 | 가구 전체 월별 요약 | 🔴 필수 | - | `GET /api/ledger/stats/summary` |
+| FLOW-02 | 멤버별 공용/개인 지출 | 🔴 필수 | - | `GET /api/ledger/stats/by-member` |
+| FLOW-03 | 카테고리별 지출 비율 | 🔴 필수 | ✅ | `GET /api/ledger/stats/by-category` |
+| FLOW-04 | 결제수단별 지출 | 🟡 권장 | ✅ | `GET /api/ledger/stats/by-payment-method` |
+| FLOW-05 | 저축률 표시 | 🟡 권장 | - | summary API에 포함 |
+| FLOW-06 | 월별 추이 (최근 N개월) | 🟡 권장 | - | `GET /api/ledger/stats/trend` |
+| FLOW-07 | 일별 지출 분포 | 🟡 권장 | ✅ | `GET /api/ledger/stats/daily` |
+
+#### API 파라미터 요약
+
+| API | 주요 파라미터 | 응답 주요 필드 |
+|-----|-------------|--------------|
+| summary | `year`, `month` | `totalIncome`, `totalSharedExpense`, `totalPersonalExpense`, `savingsRate` |
+| by-member | `year`, `month` | `members[]{sharedExpense, personalExpense, personalExpenseVisible}` |
+| by-category | `year`, `month`, `type`, `scope` | `items[]{categoryName, amount, percentage}` |
+| by-payment-method | `year`, `month`, `scope` | `items[]{paymentMethodName, amount, percentage}` |
+| trend | `months` (기본 6, 최대 12) | `items[]{year, month, totalExpense, savingsRate}` |
+| daily | `year`, `month`, `scope` | `items[]{date, totalIncome, totalExpense}` (캘린더 히트맵용) |
 
 ### 4.4 자산 유형 확장 (향후)
 
@@ -452,7 +479,7 @@
 | 기록 내역 | `/ledger/records` | 캘린더 기반 월간 기록 및 일별 상세 내역 (날짜별 그룹핑) |
 | 기록 추가 | `/ledger/new` | 퍼널(Funnel) 방식의 지출/수입/이체 기록 추가 폼 |
 | 카테고리 관리 | `/ledger/categories` | 카테고리 목록 및 추가/수정/삭제 |
-| 분석 | `/ledger/analysis` | 카테고리별/결제수단별 지출 분석 통계 (대시보드) |
+| 분석 | `/ledger/analysis` | 가계부 통계 대시보드 — 가구 요약/멤버별/카테고리별/결제수단별/월별추이/일별 분포 |
 | 정기 관리 | `/ledger/recurring` | 정기 수입/지출 관리 |
 | 결제수단 관리 | `/ledger/payment-methods` | 결제수단 목록 및 관리 |
 | 결제수단 등록 | `/ledger/payment-methods/new` | 결제수단 등록/수정 폼 |

--- a/app/api/ledger/stats/by-category/route.ts
+++ b/app/api/ledger/stats/by-category/route.ts
@@ -1,0 +1,93 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import { getUserHouseholdId } from "@/lib/api/invitation";
+import type { StatsScope } from "@/lib/api/ledger-stats";
+import { getLedgerStatsByCategory } from "@/lib/api/ledger-stats";
+import { createClient } from "@/lib/supabase/server";
+
+/**
+ * GET /api/ledger/stats/by-category
+ * 가계부 통계 대시보드 - 카테고리별 지출/수입 집계
+ *
+ * Query params:
+ *   ?year=2026&month=4   (없으면 당월)
+ *   ?type=expense        (expense | income, 기본: expense)
+ *   ?scope=all           (all | shared | personal, 기본: all)
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    const householdId = await getUserHouseholdId(supabase, user.id);
+    if (!householdId) {
+      throw new APIError(
+        "HOUSEHOLD_NOT_FOUND",
+        "가구 정보를 찾을 수 없습니다.",
+        404,
+      );
+    }
+
+    const { searchParams } = request.nextUrl;
+    const now = new Date();
+    const year = Number(searchParams.get("year") ?? now.getFullYear());
+    const month = Number(searchParams.get("month") ?? now.getMonth() + 1);
+
+    const typeParam = searchParams.get("type") ?? "expense";
+    if (typeParam !== "expense" && typeParam !== "income") {
+      throw new APIError(
+        "VALIDATION_ERROR",
+        "type은 expense 또는 income이어야 합니다.",
+        400,
+      );
+    }
+    const type = typeParam as "expense" | "income";
+
+    const scopeParam = searchParams.get("scope") ?? "all";
+    if (
+      scopeParam !== "all" &&
+      scopeParam !== "shared" &&
+      scopeParam !== "personal"
+    ) {
+      throw new APIError(
+        "VALIDATION_ERROR",
+        "scope은 all, shared, personal 중 하나여야 합니다.",
+        400,
+      );
+    }
+    const scope = scopeParam as StatsScope;
+
+    const data = await getLedgerStatsByCategory(
+      supabase,
+      householdId,
+      user.id,
+      year,
+      month,
+      type,
+      scope,
+    );
+
+    return NextResponse.json({ data });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+    return NextResponse.json(
+      {
+        error: { code: "INTERNAL_ERROR", message: "서버 오류가 발생했습니다." },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/ledger/stats/by-member/route.ts
+++ b/app/api/ledger/stats/by-member/route.ts
@@ -1,0 +1,64 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import { getUserHouseholdId } from "@/lib/api/invitation";
+import { getLedgerStatsByMember } from "@/lib/api/ledger-stats";
+import { createClient } from "@/lib/supabase/server";
+
+/**
+ * GET /api/ledger/stats/by-member
+ * 가계부 통계 대시보드 - 멤버별 공용/개인 지출 집계
+ *
+ * Query params:
+ *   ?year=2026&month=4  (없으면 당월)
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    const householdId = await getUserHouseholdId(supabase, user.id);
+    if (!householdId) {
+      throw new APIError(
+        "HOUSEHOLD_NOT_FOUND",
+        "가구 정보를 찾을 수 없습니다.",
+        404,
+      );
+    }
+
+    const { searchParams } = request.nextUrl;
+    const now = new Date();
+    const year = Number(searchParams.get("year") ?? now.getFullYear());
+    const month = Number(searchParams.get("month") ?? now.getMonth() + 1);
+
+    const data = await getLedgerStatsByMember(
+      supabase,
+      householdId,
+      user.id,
+      year,
+      month,
+    );
+
+    return NextResponse.json({ data });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+    return NextResponse.json(
+      {
+        error: { code: "INTERNAL_ERROR", message: "서버 오류가 발생했습니다." },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/ledger/stats/by-payment-method/route.ts
+++ b/app/api/ledger/stats/by-payment-method/route.ts
@@ -1,0 +1,81 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import { getUserHouseholdId } from "@/lib/api/invitation";
+import type { StatsScope } from "@/lib/api/ledger-stats";
+import { getLedgerStatsByPaymentMethod } from "@/lib/api/ledger-stats";
+import { createClient } from "@/lib/supabase/server";
+
+/**
+ * GET /api/ledger/stats/by-payment-method
+ * 가계부 통계 대시보드 - 결제수단별 지출 집계 (expense만)
+ *
+ * Query params:
+ *   ?year=2026&month=4   (없으면 당월)
+ *   ?scope=all           (all | shared | personal, 기본: all)
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    const householdId = await getUserHouseholdId(supabase, user.id);
+    if (!householdId) {
+      throw new APIError(
+        "HOUSEHOLD_NOT_FOUND",
+        "가구 정보를 찾을 수 없습니다.",
+        404,
+      );
+    }
+
+    const { searchParams } = request.nextUrl;
+    const now = new Date();
+    const year = Number(searchParams.get("year") ?? now.getFullYear());
+    const month = Number(searchParams.get("month") ?? now.getMonth() + 1);
+
+    const scopeParam = searchParams.get("scope") ?? "all";
+    if (
+      scopeParam !== "all" &&
+      scopeParam !== "shared" &&
+      scopeParam !== "personal"
+    ) {
+      throw new APIError(
+        "VALIDATION_ERROR",
+        "scope은 all, shared, personal 중 하나여야 합니다.",
+        400,
+      );
+    }
+    const scope = scopeParam as StatsScope;
+
+    const data = await getLedgerStatsByPaymentMethod(
+      supabase,
+      householdId,
+      user.id,
+      year,
+      month,
+      scope,
+    );
+
+    return NextResponse.json({ data });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+    return NextResponse.json(
+      {
+        error: { code: "INTERNAL_ERROR", message: "서버 오류가 발생했습니다." },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/ledger/stats/daily/route.ts
+++ b/app/api/ledger/stats/daily/route.ts
@@ -1,0 +1,81 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import { getUserHouseholdId } from "@/lib/api/invitation";
+import type { StatsScope } from "@/lib/api/ledger-stats";
+import { getLedgerStatsDaily } from "@/lib/api/ledger-stats";
+import { createClient } from "@/lib/supabase/server";
+
+/**
+ * GET /api/ledger/stats/daily
+ * 가계부 통계 대시보드 - 특정 월의 일별 수입/지출 집계
+ *
+ * Query params:
+ *   ?year=2026&month=4   (없으면 당월)
+ *   ?scope=all           (all | shared | personal, 기본: all)
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    const householdId = await getUserHouseholdId(supabase, user.id);
+    if (!householdId) {
+      throw new APIError(
+        "HOUSEHOLD_NOT_FOUND",
+        "가구 정보를 찾을 수 없습니다.",
+        404,
+      );
+    }
+
+    const { searchParams } = request.nextUrl;
+    const now = new Date();
+    const year = Number(searchParams.get("year") ?? now.getFullYear());
+    const month = Number(searchParams.get("month") ?? now.getMonth() + 1);
+
+    const scopeParam = searchParams.get("scope") ?? "all";
+    if (
+      scopeParam !== "all" &&
+      scopeParam !== "shared" &&
+      scopeParam !== "personal"
+    ) {
+      throw new APIError(
+        "VALIDATION_ERROR",
+        "scope은 all, shared, personal 중 하나여야 합니다.",
+        400,
+      );
+    }
+    const scope = scopeParam as StatsScope;
+
+    const data = await getLedgerStatsDaily(
+      supabase,
+      householdId,
+      user.id,
+      year,
+      month,
+      scope,
+    );
+
+    return NextResponse.json({ data });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+    return NextResponse.json(
+      {
+        error: { code: "INTERNAL_ERROR", message: "서버 오류가 발생했습니다." },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/ledger/stats/summary/route.ts
+++ b/app/api/ledger/stats/summary/route.ts
@@ -1,0 +1,64 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import { getUserHouseholdId } from "@/lib/api/invitation";
+import { getLedgerStatsSummary } from "@/lib/api/ledger-stats";
+import { createClient } from "@/lib/supabase/server";
+
+/**
+ * GET /api/ledger/stats/summary
+ * 가계부 통계 대시보드 - 월별 가구 전체 요약
+ *
+ * Query params:
+ *   ?year=2026&month=4  (없으면 당월)
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    const householdId = await getUserHouseholdId(supabase, user.id);
+    if (!householdId) {
+      throw new APIError(
+        "HOUSEHOLD_NOT_FOUND",
+        "가구 정보를 찾을 수 없습니다.",
+        404,
+      );
+    }
+
+    const { searchParams } = request.nextUrl;
+    const now = new Date();
+    const year = Number(searchParams.get("year") ?? now.getFullYear());
+    const month = Number(searchParams.get("month") ?? now.getMonth() + 1);
+
+    const data = await getLedgerStatsSummary(
+      supabase,
+      householdId,
+      user.id,
+      year,
+      month,
+    );
+
+    return NextResponse.json({ data });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+    return NextResponse.json(
+      {
+        error: { code: "INTERNAL_ERROR", message: "서버 오류가 발생했습니다." },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/ledger/stats/trend/route.ts
+++ b/app/api/ledger/stats/trend/route.ts
@@ -1,0 +1,62 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import { getUserHouseholdId } from "@/lib/api/invitation";
+import { getLedgerStatsTrend } from "@/lib/api/ledger-stats";
+import { createClient } from "@/lib/supabase/server";
+
+/**
+ * GET /api/ledger/stats/trend
+ * 가계부 통계 대시보드 - 최근 N개월 월별 수입/지출 추이
+ *
+ * Query params:
+ *   ?months=6  (기본: 6, 최대: 12)
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    const householdId = await getUserHouseholdId(supabase, user.id);
+    if (!householdId) {
+      throw new APIError(
+        "HOUSEHOLD_NOT_FOUND",
+        "가구 정보를 찾을 수 없습니다.",
+        404,
+      );
+    }
+
+    const { searchParams } = request.nextUrl;
+    const monthsParam = Number(searchParams.get("months") ?? 6);
+    const months = Math.min(Math.max(monthsParam, 1), 12);
+
+    const data = await getLedgerStatsTrend(
+      supabase,
+      householdId,
+      user.id,
+      months,
+    );
+
+    return NextResponse.json({ data });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+    return NextResponse.json(
+      {
+        error: { code: "INTERNAL_ERROR", message: "서버 오류가 발생했습니다." },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/lib/api/ledger-stats.ts
+++ b/lib/api/ledger-stats.ts
@@ -1,0 +1,538 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { APIError } from "@/lib/api/error";
+import type { Database } from "@/types";
+
+export type StatsScope = "all" | "shared" | "personal";
+
+export interface LedgerStatsSummary {
+  year: number;
+  month: number;
+  totalIncome: number;
+  totalSharedExpense: number;
+  totalPersonalExpense: number;
+  totalExpense: number;
+  balance: number;
+  savingsRate: number;
+}
+
+export interface MemberStatItem {
+  memberId: string;
+  memberName: string;
+  isCurrentUser: boolean;
+  sharedExpense: number;
+  sharedIncome: number;
+  personalExpense: number;
+  personalExpenseVisible: boolean;
+}
+
+export interface LedgerStatsByMemberResult {
+  members: MemberStatItem[];
+}
+
+export interface CategoryStatItem {
+  categoryId: string | null;
+  categoryName: string;
+  categoryIcon: string | null;
+  amount: number;
+  percentage: number;
+  entryCount: number;
+}
+
+export interface LedgerStatsByCategoryResult {
+  type: "expense" | "income";
+  scope: StatsScope;
+  total: number;
+  items: CategoryStatItem[];
+}
+
+export interface PaymentMethodStatItem {
+  paymentMethodId: string | null;
+  paymentMethodName: string;
+  paymentMethodType: string | null;
+  amount: number;
+  percentage: number;
+  entryCount: number;
+}
+
+export interface LedgerStatsByPaymentMethodResult {
+  scope: StatsScope;
+  total: number;
+  items: PaymentMethodStatItem[];
+}
+
+export interface MonthlyTrendItem {
+  year: number;
+  month: number;
+  totalIncome: number;
+  totalExpense: number;
+  balance: number;
+  savingsRate: number;
+}
+
+export interface LedgerStatsTrendResult {
+  items: MonthlyTrendItem[];
+}
+
+export interface DailyStatItem {
+  date: string;
+  totalIncome: number;
+  totalExpense: number;
+  balance: number;
+}
+
+export interface LedgerStatsDailyResult {
+  year: number;
+  month: number;
+  scope: StatsScope;
+  items: DailyStatItem[];
+}
+
+function getMonthRange(
+  year: number,
+  month: number,
+): { from: string; to: string } {
+  const from = new Date(year, month - 1, 1).toISOString();
+  const to = new Date(year, month, 1).toISOString();
+  return { from, to };
+}
+
+function calcSavingsRate(income: number, expense: number): number {
+  if (income === 0) return 0;
+  const balance = income - expense;
+  return Math.round((balance / income) * 10000) / 100;
+}
+
+export async function getLedgerStatsSummary(
+  supabase: SupabaseClient<Database>,
+  householdId: string,
+  userId: string,
+  year: number,
+  month: number,
+): Promise<LedgerStatsSummary> {
+  const { from, to } = getMonthRange(year, month);
+
+  // RLS 적용 조회: 공용 + 본인 개인 항목
+  const { data, error } = await supabase
+    .from("ledger_entries")
+    .select("type, amount, is_shared, owner_id")
+    .eq("household_id", householdId)
+    .in("type", ["expense", "income"])
+    .gte("transacted_at", from)
+    .lt("transacted_at", to);
+
+  if (error) {
+    throw new APIError("STATS_FETCH_ERROR", "통계 조회에 실패했습니다.", 500);
+  }
+
+  const rows = data ?? [];
+
+  let totalIncome = 0;
+  let totalSharedExpense = 0;
+  let myPersonalExpense = 0;
+
+  for (const row of rows) {
+    if (row.type === "income") {
+      totalIncome += row.amount;
+    } else if (row.type === "expense") {
+      if (row.is_shared) {
+        totalSharedExpense += row.amount;
+      } else if (row.owner_id === userId) {
+        myPersonalExpense += row.amount;
+      }
+    }
+  }
+
+  // 파트너 개인 지출 합산 (SECURITY DEFINER)
+  const { data: privateTotals } = await supabase.rpc(
+    "get_private_entry_totals",
+    { hh_id: householdId, p_year: year, p_month: month },
+  );
+
+  const partnerPersonalExpense = (privateTotals ?? [])
+    .filter((r) => r.owner_id !== userId)
+    .reduce((sum, r) => sum + (r.total_amount ?? 0), 0);
+
+  const totalPersonalExpense = myPersonalExpense + partnerPersonalExpense;
+  const totalExpense = totalSharedExpense + totalPersonalExpense;
+  const balance = totalIncome - totalExpense;
+  const savingsRate = calcSavingsRate(totalIncome, totalExpense);
+
+  return {
+    year,
+    month,
+    totalIncome,
+    totalSharedExpense,
+    totalPersonalExpense,
+    totalExpense,
+    balance,
+    savingsRate,
+  };
+}
+
+export async function getLedgerStatsByMember(
+  supabase: SupabaseClient<Database>,
+  householdId: string,
+  userId: string,
+  year: number,
+  month: number,
+): Promise<LedgerStatsByMemberResult> {
+  const { from, to } = getMonthRange(year, month);
+
+  // 가구 멤버 목록 조회
+  const { data: members } = await supabase
+    .from("household_members")
+    .select("user_id, profiles!inner(name)")
+    .eq("household_id", householdId);
+
+  const memberList = (members ?? []).map((m) => ({
+    userId: m.user_id,
+    name: Array.isArray(m.profiles)
+      ? ((m.profiles[0] as { name: string })?.name ?? "알 수 없음")
+      : ((m.profiles as unknown as { name: string })?.name ?? "알 수 없음"),
+  }));
+
+  // RLS 적용 조회: 공용 + 본인 개인
+  const { data, error } = await supabase
+    .from("ledger_entries")
+    .select("owner_id, type, amount, is_shared")
+    .eq("household_id", householdId)
+    .in("type", ["expense", "income"])
+    .gte("transacted_at", from)
+    .lt("transacted_at", to);
+
+  if (error) {
+    throw new APIError("STATS_FETCH_ERROR", "통계 조회에 실패했습니다.", 500);
+  }
+
+  const rows = data ?? [];
+
+  // owner_id → 공용/개인 집계
+  const statsMap = new Map<
+    string,
+    { sharedExpense: number; sharedIncome: number; personalExpense: number }
+  >();
+
+  for (const member of memberList) {
+    statsMap.set(member.userId, {
+      sharedExpense: 0,
+      sharedIncome: 0,
+      personalExpense: 0,
+    });
+  }
+
+  for (const row of rows) {
+    const stat = statsMap.get(row.owner_id);
+    if (!stat) continue;
+
+    if (row.is_shared) {
+      if (row.type === "expense") stat.sharedExpense += row.amount;
+      else if (row.type === "income") stat.sharedIncome += row.amount;
+    } else if (row.owner_id === userId && row.type === "expense") {
+      stat.personalExpense += row.amount;
+    }
+  }
+
+  // 파트너 개인 지출 합산 (SECURITY DEFINER)
+  const { data: privateTotals } = await supabase.rpc(
+    "get_private_entry_totals",
+    { hh_id: householdId, p_year: year, p_month: month },
+  );
+
+  const privateMap = new Map<string, number>();
+  for (const r of privateTotals ?? []) {
+    privateMap.set(r.owner_id, r.total_amount ?? 0);
+  }
+
+  const result: MemberStatItem[] = memberList.map((member) => {
+    const stat = statsMap.get(member.userId) ?? {
+      sharedExpense: 0,
+      sharedIncome: 0,
+      personalExpense: 0,
+    };
+    const isCurrentUser = member.userId === userId;
+    const personalExpense = isCurrentUser
+      ? stat.personalExpense
+      : (privateMap.get(member.userId) ?? 0);
+
+    return {
+      memberId: member.userId,
+      memberName: member.name,
+      isCurrentUser,
+      sharedExpense: stat.sharedExpense,
+      sharedIncome: stat.sharedIncome,
+      personalExpense,
+      personalExpenseVisible: isCurrentUser,
+    };
+  });
+
+  return { members: result };
+}
+
+export async function getLedgerStatsByCategory(
+  supabase: SupabaseClient<Database>,
+  householdId: string,
+  userId: string,
+  year: number,
+  month: number,
+  type: "expense" | "income",
+  scope: StatsScope,
+): Promise<LedgerStatsByCategoryResult> {
+  const { from, to } = getMonthRange(year, month);
+
+  let query = supabase
+    .from("ledger_entries")
+    .select("amount, category_id")
+    .eq("household_id", householdId)
+    .eq("type", type)
+    .gte("transacted_at", from)
+    .lt("transacted_at", to);
+
+  if (scope === "shared") {
+    query = query.eq("is_shared", true);
+  } else if (scope === "personal") {
+    query = query.eq("is_shared", false).eq("owner_id", userId);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    throw new APIError("STATS_FETCH_ERROR", "통계 조회에 실패했습니다.", 500);
+  }
+
+  const rows = data ?? [];
+
+  // category_id 기준 집계
+  const aggregateMap = new Map<
+    string | null,
+    { amount: number; count: number }
+  >();
+
+  for (const row of rows) {
+    const key = row.category_id;
+    const existing = aggregateMap.get(key) ?? { amount: 0, count: 0 };
+    aggregateMap.set(key, {
+      amount: existing.amount + row.amount,
+      count: existing.count + 1,
+    });
+  }
+
+  const total = rows.reduce((sum, r) => sum + r.amount, 0);
+
+  // 카테고리 정보 조회
+  const categoryIds = [
+    ...new Set(rows.map((r) => r.category_id).filter(Boolean) as string[]),
+  ];
+
+  const { data: categories } =
+    categoryIds.length > 0
+      ? await supabase
+          .from("categories")
+          .select("id, name, icon")
+          .in("id", categoryIds)
+      : { data: [] };
+
+  const categoryMap = new Map(
+    (categories ?? []).map((c) => [c.id, { name: c.name, icon: c.icon }]),
+  );
+
+  const items: CategoryStatItem[] = [...aggregateMap.entries()]
+    .map(([categoryId, { amount, count }]) => {
+      const cat = categoryId ? categoryMap.get(categoryId) : undefined;
+      return {
+        categoryId,
+        categoryName: cat?.name ?? "미분류",
+        categoryIcon: cat?.icon ?? null,
+        amount,
+        percentage: total > 0 ? Math.round((amount / total) * 10000) / 100 : 0,
+        entryCount: count,
+      };
+    })
+    .sort((a, b) => b.amount - a.amount);
+
+  return { type, scope, total, items };
+}
+
+export async function getLedgerStatsByPaymentMethod(
+  supabase: SupabaseClient<Database>,
+  householdId: string,
+  userId: string,
+  year: number,
+  month: number,
+  scope: StatsScope,
+): Promise<LedgerStatsByPaymentMethodResult> {
+  const { from, to } = getMonthRange(year, month);
+
+  let query = supabase
+    .from("ledger_entries")
+    .select("amount, from_payment_method_id")
+    .eq("household_id", householdId)
+    .eq("type", "expense")
+    .gte("transacted_at", from)
+    .lt("transacted_at", to);
+
+  if (scope === "shared") {
+    query = query.eq("is_shared", true);
+  } else if (scope === "personal") {
+    query = query.eq("is_shared", false).eq("owner_id", userId);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    throw new APIError("STATS_FETCH_ERROR", "통계 조회에 실패했습니다.", 500);
+  }
+
+  const rows = data ?? [];
+
+  const aggregateMap = new Map<
+    string | null,
+    { amount: number; count: number }
+  >();
+
+  for (const row of rows) {
+    const key = row.from_payment_method_id;
+    const existing = aggregateMap.get(key) ?? { amount: 0, count: 0 };
+    aggregateMap.set(key, {
+      amount: existing.amount + row.amount,
+      count: existing.count + 1,
+    });
+  }
+
+  const total = rows.reduce((sum, r) => sum + r.amount, 0);
+
+  // 결제수단 정보 조회
+  const pmIds = [
+    ...new Set(
+      rows.map((r) => r.from_payment_method_id).filter(Boolean) as string[],
+    ),
+  ];
+
+  const { data: paymentMethods } =
+    pmIds.length > 0
+      ? await supabase
+          .from("payment_methods")
+          .select("id, name, type")
+          .in("id", pmIds)
+      : { data: [] };
+
+  const pmMap = new Map(
+    (paymentMethods ?? []).map((pm) => [
+      pm.id,
+      { name: pm.name, type: pm.type },
+    ]),
+  );
+
+  const items: PaymentMethodStatItem[] = [...aggregateMap.entries()]
+    .map(([pmId, { amount, count }]) => {
+      const pm = pmId ? pmMap.get(pmId) : undefined;
+      return {
+        paymentMethodId: pmId,
+        paymentMethodName: pm?.name ?? "현금/기타",
+        paymentMethodType: pm?.type ?? null,
+        amount,
+        percentage: total > 0 ? Math.round((amount / total) * 10000) / 100 : 0,
+        entryCount: count,
+      };
+    })
+    .sort((a, b) => b.amount - a.amount);
+
+  return { scope, total, items };
+}
+
+export async function getLedgerStatsTrend(
+  supabase: SupabaseClient<Database>,
+  householdId: string,
+  userId: string,
+  months: number,
+): Promise<LedgerStatsTrendResult> {
+  const now = new Date();
+  const currentYear = now.getFullYear();
+  const currentMonth = now.getMonth() + 1;
+
+  const monthList: { year: number; month: number }[] = [];
+  for (let i = months - 1; i >= 0; i--) {
+    let year = currentYear;
+    let month = currentMonth - i;
+    while (month <= 0) {
+      month += 12;
+      year -= 1;
+    }
+    monthList.push({ year, month });
+  }
+
+  const results = await Promise.all(
+    monthList.map(({ year, month }) =>
+      getLedgerStatsSummary(supabase, householdId, userId, year, month),
+    ),
+  );
+
+  const items: MonthlyTrendItem[] = results.map((summary) => ({
+    year: summary.year,
+    month: summary.month,
+    totalIncome: summary.totalIncome,
+    totalExpense: summary.totalExpense,
+    balance: summary.balance,
+    savingsRate: summary.savingsRate,
+  }));
+
+  return { items };
+}
+
+export async function getLedgerStatsDaily(
+  supabase: SupabaseClient<Database>,
+  householdId: string,
+  userId: string,
+  year: number,
+  month: number,
+  scope: StatsScope,
+): Promise<LedgerStatsDailyResult> {
+  const { from, to } = getMonthRange(year, month);
+
+  let query = supabase
+    .from("ledger_entries")
+    .select("type, amount, transacted_at")
+    .eq("household_id", householdId)
+    .in("type", ["expense", "income"])
+    .gte("transacted_at", from)
+    .lt("transacted_at", to);
+
+  if (scope === "shared") {
+    query = query.eq("is_shared", true);
+  } else if (scope === "personal") {
+    query = query.eq("is_shared", false).eq("owner_id", userId);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    throw new APIError("STATS_FETCH_ERROR", "통계 조회에 실패했습니다.", 500);
+  }
+
+  const rows = data ?? [];
+
+  const dailyMap = new Map<string, { income: number; expense: number }>();
+
+  for (const row of rows) {
+    const date = row.transacted_at.slice(0, 10); // "YYYY-MM-DD"
+    const existing = dailyMap.get(date) ?? { income: 0, expense: 0 };
+    if (row.type === "income") {
+      dailyMap.set(date, { ...existing, income: existing.income + row.amount });
+    } else {
+      dailyMap.set(date, {
+        ...existing,
+        expense: existing.expense + row.amount,
+      });
+    }
+  }
+
+  const items: DailyStatItem[] = [...dailyMap.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, { income, expense }]) => ({
+      date,
+      totalIncome: income,
+      totalExpense: expense,
+      balance: income - expense,
+    }));
+
+  return { year, month, scope, items };
+}


### PR DESCRIPTION
## Summary

- `/ledger/analysis` 대시보드 화면에 필요한 통계 API 6종 구현
- `lib/api/ledger-stats.ts`: 통계 집계 함수 모음 (타입 포함)
- PRD 섹션 4.3을 가계부 분석 대시보드 spec으로 업데이트

## API 목록

| 엔드포인트 | 설명 |
|-----------|------|
| `GET /api/ledger/stats/summary` | 가구 전체 월별 요약 (공용/개인 지출 분리, 저축률) |
| `GET /api/ledger/stats/by-member` | 멤버별 공용/개인 지출 집계 |
| `GET /api/ledger/stats/by-category` | 카테고리별 지출/수입 집계 (`scope` 지원) |
| `GET /api/ledger/stats/by-payment-method` | 결제수단별 지출 집계 (`scope` 지원) |
| `GET /api/ledger/stats/trend` | 최근 N개월 월별 추이 |
| `GET /api/ledger/stats/daily` | 특정 월 일별 지출 분포 (`scope` 지원, 캘린더 히트맵용) |

## 설계 포인트

- `scope=all|shared|personal` 파라미터로 공용/개인 데이터 필터링 지원
- 파트너의 개인 지출은 RLS로 세부 내역 차단, `get_private_entry_totals()` SECURITY DEFINER 함수로 합산 금액만 가구 저축률에 반영
- `by-member`는 `personalExpenseVisible` 필드로 프론트에서 파트너 개인 지출 마스킹 처리 안내

## Test plan

- [ ] `GET /api/ledger/stats/summary?year=2026&month=4` 호출 → 가구 요약 반환 확인
- [ ] `GET /api/ledger/stats/by-category?scope=shared` vs `scope=personal` 결과 비교
- [ ] `GET /api/ledger/stats/trend?months=6` → 6개 월 데이터 반환 확인
- [ ] 인증 없이 호출 시 401 반환 확인
- [ ] 데이터 없는 월 조회 시 빈 배열/0 반환 확인

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)