### PR TITLE
[codex] Add entry points for hidden pages

### DIFF
--- a/app/(main)/household/page.tsx
+++ b/app/(main)/household/page.tsx
@@ -1,43 +1,5 @@
-import { HouseholdMembersCard } from "@/components/household/HouseholdMembersCard";
-import { HouseholdSettings } from "@/components/household/HouseholdSettings";
-import { PageContainer, PageHeader } from "@/components/layout";
-import { getHouseholdWithMembers } from "@/lib/api/household";
-import { requireUser } from "@/lib/supabase/auth";
-import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
 
-export default async function HouseholdPage() {
-  const user = await requireUser();
-  const supabase = await createClient();
-  const household = await getHouseholdWithMembers(supabase, user.id);
-
-  const isOwner =
-    household?.members.find((m) => m.userId === user.id)?.role === "owner";
-
-  return (
-    <PageContainer maxWidth="medium">
-      <PageHeader title="가구 관리" />
-
-      {household ? (
-        <>
-          {/* 가구 설정 */}
-          <HouseholdSettings
-            householdId={household.id}
-            householdName={household.name}
-            isOwner={isOwner}
-          />
-
-          {/* 구성원 목록 및 초대 */}
-          <HouseholdMembersCard
-            members={household.members}
-            currentUserId={user.id}
-            isOwner={isOwner}
-          />
-        </>
-      ) : (
-        <div className="text-center py-12">
-          <p className="text-gray-500">가구 정보를 찾을 수 없습니다.</p>
-        </div>
-      )}
-    </PageContainer>
-  );
+export default function LegacyHouseholdPage() {
+  redirect("/settings/household");
 }

--- a/app/(main)/settings/household/page.tsx
+++ b/app/(main)/settings/household/page.tsx
@@ -1,0 +1,41 @@
+import { HouseholdMembersCard } from "@/components/household/HouseholdMembersCard";
+import { HouseholdSettings } from "@/components/household/HouseholdSettings";
+import { PageContainer, PageHeader } from "@/components/layout";
+import { getHouseholdWithMembers } from "@/lib/api/household";
+import { requireUser } from "@/lib/supabase/auth";
+import { createClient } from "@/lib/supabase/server";
+
+export default async function HouseholdPage() {
+  const user = await requireUser();
+  const supabase = await createClient();
+  const household = await getHouseholdWithMembers(supabase, user.id);
+
+  const isOwner =
+    household?.members.find((m) => m.userId === user.id)?.role === "owner";
+
+  return (
+    <PageContainer maxWidth="medium">
+      <PageHeader title="가구 관리" backHref="/settings" />
+
+      {household ? (
+        <>
+          <HouseholdSettings
+            householdId={household.id}
+            householdName={household.name}
+            isOwner={isOwner}
+          />
+
+          <HouseholdMembersCard
+            members={household.members}
+            currentUserId={user.id}
+            isOwner={isOwner}
+          />
+        </>
+      ) : (
+        <div className="text-center py-12">
+          <p className="text-gray-500">가구 정보를 찾을 수 없습니다.</p>
+        </div>
+      )}
+    </PageContainer>
+  );
+}

--- a/components/accounts/AccountNewForm.test.tsx
+++ b/components/accounts/AccountNewForm.test.tsx
@@ -62,6 +62,7 @@ vi.mock("next/navigation", () => ({
     push: mockPush,
     back: vi.fn(),
   })),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
 }));
 
 const mockMutateAsync = vi.fn().mockResolvedValue({});

--- a/components/assets/stock/PortfolioNavSection.test.tsx
+++ b/components/assets/stock/PortfolioNavSection.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { PortfolioNavSection } from "./PortfolioNavSection";
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe("PortfolioNavSection", () => {
+  it("주식 대시보드 진입점을 항상 렌더링한다", () => {
+    render(<PortfolioNavSection />);
+
+    expect(screen.getByRole("link", { name: /주식 대시보드/ })).toHaveAttribute(
+      "href",
+      "/dashboard/stocks",
+    );
+  });
+});

--- a/components/assets/stock/PortfolioNavSection.tsx
+++ b/components/assets/stock/PortfolioNavSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { BarChart3, Receipt, Settings, Wallet } from "lucide-react";
+import { BarChart3, ChartPie, Receipt, Settings, Wallet } from "lucide-react";
 import { AnalysisCard } from "@/components/dashboard/AnalysisCard";
 
 const navItems = [
@@ -19,6 +19,14 @@ const navItems = [
     href: "/assets/stock/transactions",
     color: "text-green-600",
     bgColor: "bg-green-50",
+  },
+  {
+    icon: ChartPie,
+    label: "주식 대시보드",
+    description: "수익률과 비중을 자세히 분석해 보세요",
+    href: "/dashboard/stocks",
+    color: "text-purple-600",
+    bgColor: "bg-purple-50",
   },
   {
     icon: Wallet,

--- a/components/settings/SettingsMenu.test.tsx
+++ b/components/settings/SettingsMenu.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SettingsMenu } from "./SettingsMenu";
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/app/(auth)/logout/actions", () => ({
+  signOutAction: vi.fn(),
+}));
+
+describe("SettingsMenu", () => {
+  it("가구 관리 페이지로 이동하는 메뉴를 렌더링한다", () => {
+    render(<SettingsMenu />);
+
+    expect(screen.getByRole("link", { name: /가구 관리/ })).toHaveAttribute(
+      "href",
+      "/settings/household",
+    );
+  });
+});

--- a/components/settings/SettingsMenu.tsx
+++ b/components/settings/SettingsMenu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Bell, LogOut, Monitor, Shield, User } from "lucide-react";
+import { Bell, LogOut, Monitor, Shield, User, Users } from "lucide-react";
 import { useTransition } from "react";
 import { signOutAction } from "@/app/(auth)/logout/actions";
 import { SettingsMenuItem } from "./SettingsMenuItem";
@@ -22,6 +22,13 @@ export function SettingsMenu() {
         description="이름, 이메일 관리"
         href="/settings/profile"
         disabled
+      />
+
+      <SettingsMenuItem
+        icon={Users}
+        label="가구 관리"
+        description="가구 이름, 구성원, 초대 관리"
+        href="/settings/household"
       />
 
       <SettingsMenuItem


### PR DESCRIPTION
## Summary

- Add a persistent stock dashboard entry point from the stock asset management section.
- Move household management under /settings/household and keep /household as a legacy redirect.
- Add component tests for the new entry points and fix the account form test navigation mock exposed by the full test run.

## Validation

- pnpm test
- pnpm type-check

Closes #278