### PR TITLE
[codex] add read-only MCP v0

### DIFF
--- a/.claude/docs/MCP.md
+++ b/.claude/docs/MCP.md
@@ -1,0 +1,434 @@
+# MCP.md
+
+> oat MCP 서버 설계 노트. AI 도구가 사용자의 oat 데이터를 안전하게 조회하고, 이후 생성/수정까지 확장하기 위한 기준 문서입니다.
+
+## TL;DR
+
+- **목표**: 최종적으로 public remote MCP를 제공해 서비스 사용자가 자신의 AI 도구로 oat 데이터를 다룰 수 있게 한다.
+- **v0 범위**: private beta, read-only. 쓰기/삭제는 열지 않는다.
+- **배포 위치**: 기존 Next.js 앱 안의 `app/api/mcp/route.ts`에서 시작한다.
+- **전송 방식**: 원격 배포를 전제로 Streamable HTTP transport를 사용한다.
+- **인증**: 앱에서 사용자별 MCP 토큰을 발급한다. 토큰은 특정 `household_id`에 고정된다.
+- **권한 모델**: 토큰에서 `userId`, `householdId`, `scopes`를 확정하고, MCP tool 입력으로는 받지 않는다.
+- **프라이버시**: 앱의 공용/개인 지출 모델을 그대로 따른다. 파트너 개인 지출 상세는 노출하지 않는다.
+- **감사 로그**: 모든 MCP tool 호출을 기록한다.
+
+---
+
+## 1. 배경
+
+oat는 가족의 현금 흐름과 자산 성장을 함께 추적하는 서비스입니다. MCP를 제공하면 Claude, Cursor, ChatGPT 같은 AI 도구가 사용자의 허가를 받은 범위 안에서 oat 데이터를 조회하고 분석할 수 있습니다.
+
+최종 목표는 public MCP이지만, 금융/가계부 데이터의 민감도를 고려해 첫 버전은 read-only private beta로 시작합니다. 이 단계에서 검증할 것은 다음입니다.
+
+- MCP endpoint 배포와 클라이언트 연결
+- 사용자별 토큰 인증
+- scope 기반 권한 검사
+- 가계부 privacy 모델의 MCP 적용
+- tool 응답 포맷과 데이터 제한
+- audit log 수집
+
+---
+
+## 2. 단계별 전략
+
+| 단계 | 범위 | 인증 | 제공 기능 |
+|------|------|------|----------|
+| v0 Private Beta | 나와 가족 중심 | 사용자별 MCP 토큰 | read-only tools |
+| v1 Controlled Public | 제한된 사용자 공개 | 사용자별 토큰 + scope 관리 | read-only + 일부 write |
+| v2 Public OAuth | 일반 사용자 공개 | OAuth 기반 MCP authorization | 사용자 동의, 토큰 회수, scope별 연결 |
+
+v0의 MCP 토큰 방식은 public OAuth와 충돌하지 않습니다. 서버 내부에서는 모든 인증 방식을 다음 형태로 정규화합니다.
+
+```ts
+type McpAuthContext = {
+  userId: string;
+  householdId: string;
+  scopes: string[];
+  authMethod: "personal_token" | "oauth";
+};
+```
+
+tool 구현은 `authMethod`에 직접 의존하지 않고 `McpAuthContext`만 사용합니다. 이후 OAuth가 도입되어도 tool 로직을 크게 바꾸지 않기 위함입니다.
+
+---
+
+## 3. 배포와 Transport
+
+v0는 기존 Next.js 앱 안에 MCP endpoint를 둡니다.
+
+```text
+app/api/mcp/route.ts
+```
+
+원격 AI 도구 연결을 목표로 하므로 stdio가 아니라 Streamable HTTP transport를 기본으로 합니다.
+
+구현 시 지켜야 할 MCP transport 기준:
+
+- MCP 메시지는 JSON-RPC 2.0 기반입니다.
+- Streamable HTTP 서버는 단일 MCP endpoint에서 POST/GET을 지원합니다.
+- HTTP 요청에는 `Authorization: Bearer <token>`을 사용합니다.
+- 모든 연결에서 `Origin` 검증을 수행합니다.
+- client가 보낸 `MCP-Protocol-Version`을 검증합니다.
+- v0에서는 streaming/SSE를 필수로 만들지 않고, 가능한 경우 JSON 응답 중심으로 단순화합니다.
+
+참고:
+
+- [MCP Transports, 2025-06-18](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports)
+- [MCP Authorization, 2025-06-18](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization)
+
+---
+
+## 4. 인증 모델
+
+### 4.1 사용자별 MCP 토큰
+
+앱 설정 화면에서 사용자가 MCP 토큰을 발급합니다.
+
+```text
+/settings/mcp
+```
+
+토큰 생성 UI:
+
+- 토큰 이름: 예) Claude Desktop, Cursor, ChatGPT
+- 권한: v0에서는 읽기 전용 전체 접근
+- 만료일: 기본 90일
+- 생성 직후 원문 토큰 1회 표시
+
+토큰 목록 UI:
+
+- 이름
+- 권한
+- 생성일
+- 만료일
+- 마지막 사용 시각
+- 회수 버튼
+
+### 4.2 토큰 저장 원칙
+
+원문 토큰은 DB에 저장하지 않습니다.
+
+```text
+사용자에게 표시: oat_mcp_xxxxxxxxx
+DB 저장: token_hash, prefix, last4
+```
+
+권장 테이블:
+
+```sql
+create table public.mcp_tokens (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  household_id uuid not null references public.households(id) on delete cascade,
+  name text not null,
+  token_hash text not null unique,
+  token_prefix text not null,
+  token_last4 text not null,
+  scopes text[] not null,
+  expires_at timestamptz not null,
+  last_used_at timestamptz,
+  revoked_at timestamptz,
+  created_at timestamptz not null default now()
+);
+```
+
+### 4.3 Supabase Auth와의 관계
+
+MCP 토큰은 Supabase Auth 로그인을 대체하지 않습니다. 웹 앱은 기존처럼 Supabase Auth를 사용하고, MCP endpoint는 자체 토큰을 검증한 뒤 내부 `McpAuthContext`를 만듭니다.
+
+```text
+AI 도구
+  -> Authorization: Bearer oat_mcp_xxx
+  -> oat MCP endpoint
+  -> mcp_tokens.token_hash 검증
+  -> McpAuthContext 생성
+  -> 기존 lib/api 함수 또는 MCP 전용 read 함수 호출
+  -> Supabase 접근
+```
+
+v0에서는 서버 내부에서 `service_role` 클라이언트를 사용할 수 있습니다. 단, `service_role`은 RLS를 우회하므로 MCP 함수는 반드시 `McpAuthContext.userId`와 `McpAuthContext.householdId`를 기준으로 명시적 권한 검사를 수행해야 합니다.
+
+금지:
+
+- AI tool 입력으로 `userId` 받기
+- AI tool 입력으로 `householdId` 받기
+- 사용자가 보낸 `household_id`를 그대로 쿼리에 사용하기
+- Supabase service role key를 MCP 클라이언트에 노출하기
+
+---
+
+## 5. Scope
+
+v0는 read-only입니다.
+
+초기 scope:
+
+```text
+read:overview
+read:ledger
+read:assets
+read:references
+```
+
+향후 쓰기 기능을 열 때는 다음처럼 분리합니다.
+
+```text
+ledger:write
+transactions:write
+delete:*        # v0/v1에서는 제공하지 않음
+```
+
+계좌/결제수단 잔액은 분석에 필요하므로 read-only 범위에 포함합니다. 다만 사용자가 동의하는 scope 설명에서는 단순 "목록 조회"가 아니라 "계좌, 결제수단, 잔액, 현금흐름 조회"라고 명확히 표현해야 합니다.
+
+---
+
+## 6. Privacy Model
+
+MCP는 앱의 가계부 privacy 모델을 그대로 따라야 합니다.
+
+| 데이터 | MCP 노출 |
+|--------|----------|
+| 공용 지출 상세 | 같은 가구원이면 노출 |
+| 내 개인 지출 상세 | 노출 |
+| 파트너 개인 지출 상세 | 노출하지 않음 |
+| 파트너 개인 지출 합계 | 월 합계 등 집계만 노출 |
+| 계좌/결제수단 | 같은 가구 컨텍스트에서 read scope가 있으면 노출 |
+| 주식/자산 현황 | 같은 가구 컨텍스트에서 read scope가 있으면 노출 |
+
+`search_ledger_entries`는 파트너 개인 지출 상세를 반환하면 안 됩니다.
+
+`get_financial_overview`, `get_ledger_stats` 같은 집계 응답은 파트너 개인 지출을 합계로만 반영할 수 있습니다.
+
+---
+
+## 7. Audit Log
+
+v0부터 모든 tool 호출을 기록합니다.
+
+권장 테이블:
+
+```sql
+create table public.mcp_audit_logs (
+  id uuid primary key default gen_random_uuid(),
+  token_id uuid references public.mcp_tokens(id) on delete set null,
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  household_id uuid not null references public.households(id) on delete cascade,
+  tool_name text not null,
+  input_summary jsonb,
+  result_status text not null,
+  error_code text,
+  duration_ms integer,
+  created_at timestamptz not null default now()
+);
+```
+
+주의:
+
+- 민감한 원문 입력을 그대로 저장하지 않습니다.
+- 검색어, 메모, 상점명 같은 내용은 필요 최소한으로 요약하거나 저장하지 않습니다.
+- 날짜 범위, limit, scope, tool 이름처럼 운영과 디버깅에 필요한 정보 중심으로 남깁니다.
+
+---
+
+## 8. v0 Tools
+
+v0는 resources 없이 tools만 제공합니다. capabilities와 privacy 설명은 `get_context` 응답에 포함합니다.
+
+### 8.1 `get_context`
+
+현재 MCP 연결의 기본 컨텍스트를 반환합니다.
+
+반환:
+
+- 사용자 프로필
+- household 정보
+- scopes
+- 기본 기간
+- MCP capabilities
+- privacy model summary
+
+### 8.2 `get_financial_overview`
+
+현금흐름과 자산 상태를 한 번에 요약합니다.
+
+기본 기간:
+
+- 이번 달
+
+반환:
+
+- 월 수입/지출/순현금흐름
+- 총자산 요약
+- 주식 평가/수익률 요약
+- 눈에 띄는 변화 또는 highlights
+- privacy metadata
+
+### 8.3 `list_references`
+
+AI가 다른 tool을 호출할 때 필요한 참조 데이터를 반환합니다.
+
+반환:
+
+- 가구원 목록
+- 카테고리 목록
+- 계좌 목록
+- 결제수단 목록
+
+### 8.4 `search_ledger_entries`
+
+기간, 금액, 카테고리, 키워드 등으로 가계부 상세 내역을 조회합니다.
+
+제한:
+
+- 기본 기간은 이번 달
+- 한 번에 최대 100건
+- cursor 또는 page 기반 pagination
+- 파트너 개인 지출 상세 제외
+
+### 8.5 `get_ledger_stats`
+
+기간별 가계부 집계를 반환합니다.
+
+지원 축:
+
+- 월별 추이
+- 카테고리별
+- 가구원별
+- 결제수단별
+
+제한:
+
+- 최대 12개월
+- 파트너 개인 지출은 세부 항목 없이 합계만 반영
+
+### 8.6 `get_asset_snapshot`
+
+자산/주식 snapshot을 반환합니다.
+
+입력 옵션:
+
+```ts
+{
+  includeHoldings?: boolean;
+  includeAllocation?: boolean;
+}
+```
+
+반환:
+
+- 총자산
+- 자산군별 배분
+- 소유자별 배분
+- 주식 보유 현황
+- 수익률 요약
+
+---
+
+## 9. 공통 응답 포맷
+
+모든 tool 응답은 가능한 한 다음 메타데이터를 포함합니다.
+
+```json
+{
+  "meta": {
+    "period": {
+      "from": "2026-05-01",
+      "to": "2026-05-31"
+    },
+    "scope": ["read:overview", "read:ledger"],
+    "privacy": {
+      "included": ["shared ledger details", "own private ledger details"],
+      "aggregatedOnly": ["partner private expenses"],
+      "excluded": ["partner private expense details"]
+    },
+    "limits": {
+      "maxLedgerEntries": 100,
+      "maxStatsMonths": 12
+    }
+  },
+  "summary": {},
+  "data": {}
+}
+```
+
+기간이 없는 tool은 `period: null`을 사용합니다.
+
+---
+
+## 10. 데이터 제한
+
+| Tool | 기본 범위 | 최대 범위 |
+|------|----------|----------|
+| `get_financial_overview` | 이번 달 + 현재 자산 | 최근 12개월 요약 |
+| `search_ledger_entries` | 이번 달 | 100건/page |
+| `get_ledger_stats` | 이번 달 | 12개월 |
+| `get_asset_snapshot` | 현재 snapshot | 12개월 요약 추이 |
+
+전체 raw data를 한 번에 반환하지 않습니다. 필요 시 pagination과 집계 tool을 조합합니다.
+
+---
+
+## 11. Settings UI
+
+설정 하위에 MCP 연결 화면을 둡니다.
+
+```text
+app/(main)/settings/mcp/page.tsx
+```
+
+화면 구성:
+
+- MCP 연결 설명
+- read-only 권한 안내
+- 토큰 목록
+- 새 토큰 생성 다이얼로그
+- 생성된 토큰 1회 표시
+- 토큰 회수
+
+사용자에게 반드시 보여줄 문구:
+
+- 이 토큰으로 AI 도구가 oat 데이터를 읽을 수 있습니다.
+- 토큰은 생성 직후 한 번만 표시됩니다.
+- 파트너 개인 지출 상세는 노출되지 않고, 합계만 분석에 포함됩니다.
+- 토큰은 언제든 회수할 수 있습니다.
+
+---
+
+## 12. 구현 순서 제안
+
+1. `mcp_tokens`, `mcp_audit_logs` 마이그레이션 추가
+2. MCP 토큰 생성/회수 API 추가
+3. `/settings/mcp` UI 추가
+4. MCP auth helper 구현
+5. MCP tool 공통 wrapper 구현
+6. read-only tool 6개 구현
+7. audit log 연결
+8. MCP 클라이언트 연결 테스트
+9. public OAuth 전환을 위한 gap 정리
+
+배포 후 테스트와 MCP 클라이언트 연결 방법은 `.claude/docs/MCP_USAGE.md`를 참고합니다.
+
+---
+
+## 13. 보류한 결정
+
+v0에서는 다루지 않습니다.
+
+- MCP resources
+- write tools
+- delete tools
+- OAuth authorization flow
+- Dynamic Client Registration
+- 장기 streaming/SSE 활용
+- 여러 household를 하나의 토큰으로 선택하는 방식
+
+---
+
+## 14. 열린 질문
+
+- Next.js Route Handler에서 사용할 MCP SDK/transport 구현체를 무엇으로 할 것인가?
+- Vercel 환경에서 Streamable HTTP의 GET/SSE 요구사항을 얼마나 지원할 것인가?
+- `service_role` 기반 MCP read 함수와 기존 RLS 기반 `lib/api` 함수를 어떻게 분리할 것인가?
+- audit log를 사용자에게 보여주는 화면을 v0에 포함할 것인가?
+- public OAuth 단계에서 기존 `mcp_tokens` 테이블을 OAuth access token 저장/검증 모델과 어떻게 통합할 것인가?

--- a/.claude/docs/MCP_USAGE.md
+++ b/.claude/docs/MCP_USAGE.md
@@ -1,0 +1,120 @@
+# MCP_USAGE.md
+
+> oat MCP v0 배포 후 테스트와 기본 사용법입니다.
+
+## 배포 후 체크리스트
+
+1. Supabase 마이그레이션이 배포 DB에 적용됐는지 확인합니다.
+   - `mcp_tokens`
+   - `mcp_audit_logs`
+
+2. 앱 환경변수를 확인합니다.
+   - `NEXT_PUBLIC_SUPABASE_URL`
+   - `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`
+   - `SUPABASE_SECRET_KEY`
+   - `NEXT_PUBLIC_APP_URL`
+
+3. 앱에서 토큰을 발급합니다.
+   - 경로: `/settings/mcp`
+   - 토큰은 생성 직후 한 번만 표시됩니다.
+   - 테스트 후 노출된 토큰은 회수하고 새로 발급합니다.
+
+4. MCP endpoint health check를 확인합니다.
+
+```bash
+curl -i https://YOUR_DOMAIN/api/mcp
+```
+
+성공 시 `oat MCP`, `v0`, `streamable-http` 정보가 JSON으로 반환됩니다.
+
+## 기본 테스트
+
+아래 예시의 `YOUR_DOMAIN`과 `YOUR_TOKEN`을 교체합니다.
+
+### Initialize
+
+```bash
+curl -i -X POST https://YOUR_DOMAIN/api/mcp \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "MCP-Protocol-Version: 2025-06-18" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+      "protocolVersion": "2025-06-18",
+      "capabilities": {},
+      "clientInfo": { "name": "curl", "version": "0" }
+    }
+  }'
+```
+
+### Tool 목록
+
+```bash
+curl -i -X POST https://YOUR_DOMAIN/api/mcp \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "MCP-Protocol-Version: 2025-06-18" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 2,
+    "method": "tools/list"
+  }'
+```
+
+v0 tool:
+
+- `get_context`
+- `get_financial_overview`
+- `list_references`
+- `search_ledger_entries`
+- `get_ledger_stats`
+- `get_asset_snapshot`
+
+### Tool 호출
+
+```bash
+curl -i -X POST https://YOUR_DOMAIN/api/mcp \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "MCP-Protocol-Version: 2025-06-18" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 3,
+    "method": "tools/call",
+    "params": {
+      "name": "get_context",
+      "arguments": {}
+    }
+  }'
+```
+
+## MCP 클라이언트 연결
+
+원격 MCP URL은 다음 형식입니다.
+
+```text
+https://YOUR_DOMAIN/api/mcp
+```
+
+인증 헤더:
+
+```text
+Authorization: Bearer YOUR_TOKEN
+```
+
+클라이언트가 protocol version을 설정할 수 있으면 다음 값을 사용합니다.
+
+```text
+MCP-Protocol-Version: 2025-06-18
+```
+
+## 보안 주의사항
+
+- 토큰을 로그, 문서, 채팅에 남기지 않습니다.
+- 노출된 토큰은 `/settings/mcp`에서 즉시 회수합니다.
+- v0는 read-only입니다.
+- 파트너 개인 가계부 상세는 반환하지 않고, 집계에만 포함합니다.
+- 서버는 모든 MCP tool 호출을 `mcp_audit_logs`에 기록합니다.

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+/.pnpm-store
 /.pnp
 .pnp.*
 .yarn/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,8 @@
 | **CONVENTIONS_FE.md** | `.claude/docs/` | 프론트엔드 패턴 |
 | **CONVENTIONS_BE.md** | `.claude/docs/` | 백엔드/API 패턴 |
 | **API.md** | `.claude/docs/` | API 설계 원칙 |
+| **MCP.md** | `.claude/docs/` | MCP 서버 설계, 인증, tool 범위 |
+| **MCP_USAGE.md** | `.claude/docs/` | MCP 배포 후 테스트, 사용법 |
 | **DESIGN.md** | `.claude/docs/` | UI/UX 원칙 |
 | **EXAMPLES.md** | `.claude/docs/` | 코드 예시 모음 |
 | **ENV.md** | `.claude/docs/` | 환경변수 설정 가이드 |
@@ -306,5 +308,7 @@ const totalReturn = ((totalCurrentValue - totalInvestedAmount) / totalInvestedAm
 - `.claude/docs/CONVENTIONS_FE.md` - 프론트엔드 패턴
 - `.claude/docs/CONVENTIONS_BE.md` - 백엔드/API 패턴
 - `.claude/docs/API.md` - API 설계 원칙
+- `.claude/docs/MCP.md` - MCP 서버 설계, 인증, tool 범위
+- `.claude/docs/MCP_USAGE.md` - MCP 배포 후 테스트, 사용법
 - `.claude/docs/DESIGN.md` - UI/UX 원칙
 - `.claude/docs/EXAMPLES.md` - 코드 예시 모음

--- a/app/(main)/settings/mcp/page.tsx
+++ b/app/(main)/settings/mcp/page.tsx
@@ -1,0 +1,15 @@
+import { PageContainer, PageHeader } from "@/components/layout";
+import { McpTokenManager } from "@/components/settings";
+
+export default function McpSettingsPage() {
+  return (
+    <PageContainer maxWidth="medium">
+      <PageHeader
+        title="MCP 연결"
+        subtitle="AI 도구에서 oat 데이터를 읽을 수 있는 연결을 관리합니다."
+        backHref="/settings"
+      />
+      <McpTokenManager />
+    </PageContainer>
+  );
+}

--- a/app/api/mcp-tokens/[id]/route.ts
+++ b/app/api/mcp-tokens/[id]/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import { getUserHouseholdId } from "@/lib/api/invitation";
+import { revokeMcpToken } from "@/lib/mcp/auth";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    const householdId = await getUserHouseholdId(supabase, user.id);
+
+    if (!householdId) {
+      throw new APIError(
+        "HOUSEHOLD_NOT_FOUND",
+        "가구 정보를 찾을 수 없습니다.",
+        404,
+      );
+    }
+
+    await revokeMcpToken(createAdminClient(), {
+      tokenId: id,
+      userId: user.id,
+      householdId,
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    console.error("MCP token revoke route error:", error);
+    return NextResponse.json(
+      {
+        error: { code: "INTERNAL_ERROR", message: "서버 오류가 발생했습니다." },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/mcp-tokens/route.ts
+++ b/app/api/mcp-tokens/route.ts
@@ -1,0 +1,106 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import { getUserHouseholdId } from "@/lib/api/invitation";
+import {
+  createMcpToken,
+  DEFAULT_MCP_READ_SCOPES,
+  listMcpTokens,
+} from "@/lib/mcp/auth";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
+
+const createMcpTokenSchema = z.object({
+  name: z
+    .string()
+    .min(1, "토큰 이름을 입력해주세요.")
+    .max(80, "토큰 이름은 80자 이내여야 합니다."),
+});
+
+async function getAuthenticatedMcpContext() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+  }
+
+  const householdId = await getUserHouseholdId(supabase, user.id);
+
+  if (!householdId) {
+    throw new APIError(
+      "HOUSEHOLD_NOT_FOUND",
+      "가구 정보를 찾을 수 없습니다.",
+      404,
+    );
+  }
+
+  return { userId: user.id, householdId };
+}
+
+export async function GET() {
+  try {
+    const { userId, householdId } = await getAuthenticatedMcpContext();
+    const admin = createAdminClient();
+    const tokens = await listMcpTokens(admin, userId, householdId);
+
+    return NextResponse.json({ data: tokens });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    console.error("MCP token list route error:", error);
+    return NextResponse.json(
+      {
+        error: { code: "INTERNAL_ERROR", message: "서버 오류가 발생했습니다." },
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const { userId, householdId } = await getAuthenticatedMcpContext();
+    const body = await request.json();
+    const parsed = createMcpTokenSchema.safeParse(body);
+
+    if (!parsed.success) {
+      throw new APIError(
+        "VALIDATION_ERROR",
+        parsed.error.issues[0]?.message ?? "유효하지 않은 요청입니다.",
+        400,
+      );
+    }
+
+    const admin = createAdminClient();
+    const result = await createMcpToken(admin, {
+      userId,
+      householdId,
+      name: parsed.data.name,
+      scopes: [...DEFAULT_MCP_READ_SCOPES],
+    });
+
+    return NextResponse.json({ data: result }, { status: 201 });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    console.error("MCP token create route error:", error);
+    return NextResponse.json(
+      {
+        error: { code: "INTERNAL_ERROR", message: "서버 오류가 발생했습니다." },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -1,0 +1,156 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { APIError } from "@/lib/api/error";
+import { writeMcpAuditLog } from "@/lib/mcp/audit";
+import { authenticateMcpToken } from "@/lib/mcp/auth";
+import { handleMcpJsonRpc } from "@/lib/mcp/protocol";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+function isAllowedOrigin(request: NextRequest): boolean {
+  const origin = request.headers.get("origin");
+  if (!origin) return true;
+
+  const requestOrigin = new URL(request.url).origin;
+  const configuredOrigin = process.env.NEXT_PUBLIC_APP_URL;
+
+  return origin === requestOrigin || origin === configuredOrigin;
+}
+
+function summarizeToolInput(
+  params: unknown,
+): Record<string, unknown> | undefined {
+  const value = params as { arguments?: unknown } | null;
+  const args =
+    value?.arguments && typeof value.arguments === "object"
+      ? (value.arguments as Record<string, unknown>)
+      : undefined;
+
+  if (!args) return undefined;
+
+  return {
+    from: args.from,
+    to: args.to,
+    year: args.year,
+    month: args.month,
+    months: args.months,
+    limit: args.limit,
+    includeHoldings: args.includeHoldings,
+    includeAllocation: args.includeAllocation,
+    hasQuery: typeof args.query === "string" && args.query.trim().length > 0,
+  };
+}
+
+export async function GET() {
+  return NextResponse.json({
+    data: {
+      name: "oat MCP",
+      version: "v0",
+      transport: "streamable-http",
+      endpoint: "/api/mcp",
+    },
+  });
+}
+
+export async function POST(request: NextRequest) {
+  if (!isAllowedOrigin(request)) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "MCP_FORBIDDEN_ORIGIN",
+          message: "허용되지 않은 Origin입니다.",
+        },
+      },
+      { status: 403 },
+    );
+  }
+
+  const protocolVersion = request.headers.get("mcp-protocol-version");
+  if (
+    protocolVersion &&
+    !["2025-03-26", "2025-06-18"].includes(protocolVersion)
+  ) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "MCP_UNSUPPORTED_PROTOCOL_VERSION",
+          message: "지원하지 않는 MCP protocol version입니다.",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const admin = createAdminClient();
+  const startedAt = Date.now();
+  let auth = null;
+  let toolName = "unknown";
+  let inputSummary: Record<string, unknown> | undefined;
+
+  try {
+    auth = await authenticateMcpToken(
+      admin,
+      request.headers.get("authorization"),
+    );
+
+    const message = await request.json();
+    if (
+      message &&
+      typeof message === "object" &&
+      "params" in message &&
+      (message as { method?: unknown }).method === "tools/call"
+    ) {
+      const params = (message as { params?: { name?: unknown } }).params;
+      toolName = typeof params?.name === "string" ? params.name : "unknown";
+      inputSummary = summarizeToolInput(params);
+    } else if (message && typeof message === "object") {
+      toolName = String((message as { method?: unknown }).method ?? "unknown");
+    }
+
+    const response = await handleMcpJsonRpc({
+      message,
+      supabase: admin,
+      auth,
+    });
+
+    if (toolName !== "unknown" && auth) {
+      await writeMcpAuditLog(admin, {
+        auth,
+        toolName,
+        inputSummary,
+        resultStatus: "success",
+        durationMs: Date.now() - startedAt,
+      });
+    }
+
+    if (response.status === 202 || response.body === null) {
+      return new NextResponse(null, { status: 202 });
+    }
+
+    return NextResponse.json(response.body, { status: response.status });
+  } catch (error) {
+    if (auth) {
+      await writeMcpAuditLog(admin, {
+        auth,
+        toolName,
+        inputSummary,
+        resultStatus: "error",
+        errorCode: error instanceof APIError ? error.code : "INTERNAL_ERROR",
+        durationMs: Date.now() - startedAt,
+      });
+    }
+
+    if (error instanceof APIError) {
+      return NextResponse.json(
+        { error: { code: error.code, message: error.message } },
+        { status: error.statusCode },
+      );
+    }
+
+    console.error("MCP route error:", error);
+    return NextResponse.json(
+      {
+        error: { code: "INTERNAL_ERROR", message: "서버 오류가 발생했습니다." },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/components/settings/McpTokenManager.tsx
+++ b/components/settings/McpTokenManager.tsx
@@ -1,0 +1,281 @@
+"use client";
+
+import { Check, Copy, KeyRound, Loader2, Plus, RotateCcw } from "lucide-react";
+import { useEffect, useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+
+interface McpTokenListItem {
+  id: string;
+  name: string;
+  tokenPrefix: string;
+  tokenLast4: string;
+  scopes: string[];
+  expiresAt: string;
+  lastUsedAt: string | null;
+  revokedAt: string | null;
+  createdAt: string;
+}
+
+interface CreateMcpTokenResponse {
+  data: {
+    token: string;
+    item: McpTokenListItem;
+  };
+}
+
+interface McpTokensResponse {
+  data: McpTokenListItem[];
+}
+
+interface ApiErrorResponse {
+  error: {
+    message: string;
+  };
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return "-";
+
+  return new Intl.DateTimeFormat("ko-KR", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  }).format(new Date(value));
+}
+
+async function readError(response: Response): Promise<Error> {
+  const json = (await response.json()) as ApiErrorResponse;
+  return new Error(json.error?.message ?? "요청에 실패했습니다.");
+}
+
+export function McpTokenManager() {
+  const [tokens, setTokens] = useState<McpTokenListItem[]>([]);
+  const [name, setName] = useState("Claude");
+  const [createdToken, setCreatedToken] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function loadTokens() {
+      try {
+        const response = await fetch("/api/mcp-tokens");
+        if (!response.ok) throw await readError(response);
+        const json = (await response.json()) as McpTokensResponse;
+        if (isMounted) setTokens(json.data);
+      } catch (error) {
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : "MCP 토큰 목록 조회에 실패했습니다.",
+        );
+      } finally {
+        if (isMounted) setIsLoading(false);
+      }
+    }
+
+    loadTokens();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const handleCreate = () => {
+    startTransition(async () => {
+      try {
+        const response = await fetch("/api/mcp-tokens", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name }),
+        });
+
+        if (!response.ok) throw await readError(response);
+
+        const json = (await response.json()) as CreateMcpTokenResponse;
+        setCreatedToken(json.data.token);
+        setTokens((current) => [json.data.item, ...current]);
+        setCopied(false);
+        toast.success("MCP 토큰을 생성했습니다.");
+      } catch (error) {
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : "MCP 토큰 생성에 실패했습니다.",
+        );
+      }
+    });
+  };
+
+  const handleRevoke = (tokenId: string) => {
+    startTransition(async () => {
+      try {
+        const response = await fetch(`/api/mcp-tokens/${tokenId}`, {
+          method: "DELETE",
+        });
+
+        if (!response.ok) throw await readError(response);
+
+        setTokens((current) =>
+          current.map((token) =>
+            token.id === tokenId
+              ? { ...token, revokedAt: new Date().toISOString() }
+              : token,
+          ),
+        );
+        toast.success("MCP 토큰을 회수했습니다.");
+      } catch (error) {
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : "MCP 토큰 회수에 실패했습니다.",
+        );
+      }
+    });
+  };
+
+  const handleCopy = async () => {
+    if (!createdToken) return;
+
+    await navigator.clipboard.writeText(createdToken);
+    setCopied(true);
+    toast.success("토큰을 복사했습니다.");
+  };
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <KeyRound className="h-4 w-4" />새 MCP 토큰
+          </CardTitle>
+          <CardDescription>
+            읽기 전용 토큰이 생성되며 90일 뒤 만료됩니다.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="flex gap-2">
+            <Input
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              maxLength={80}
+              placeholder="토큰 이름"
+            />
+            <Button
+              type="button"
+              onClick={handleCreate}
+              disabled={isPending || name.trim().length === 0}
+            >
+              {isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Plus className="h-4 w-4" />
+              )}
+              생성
+            </Button>
+          </div>
+
+          {createdToken && (
+            <div className="rounded-lg border bg-gray-50 p-3">
+              <div className="flex items-start justify-between gap-3">
+                <code className="break-all text-sm text-gray-900">
+                  {createdToken}
+                </code>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon-sm"
+                  onClick={handleCopy}
+                  aria-label="MCP 토큰 복사"
+                >
+                  {copied ? (
+                    <Check className="h-4 w-4" />
+                  ) : (
+                    <Copy className="h-4 w-4" />
+                  )}
+                </Button>
+              </div>
+              <p className="mt-2 text-xs text-gray-500">
+                이 값은 다시 표시되지 않습니다.
+              </p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">토큰 목록</CardTitle>
+          <CardDescription>
+            AI 도구에서 사용하는 oat MCP 연결을 관리합니다.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="flex items-center justify-center py-8 text-gray-500">
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              불러오는 중
+            </div>
+          ) : tokens.length === 0 ? (
+            <div className="rounded-lg bg-gray-50 px-4 py-8 text-center text-sm text-gray-500">
+              생성된 MCP 토큰이 없습니다.
+            </div>
+          ) : (
+            <div className="divide-y">
+              {tokens.map((token) => {
+                const isRevoked = Boolean(token.revokedAt);
+                return (
+                  <div
+                    key={token.id}
+                    className="flex flex-col gap-3 py-4 first:pt-0 last:pb-0 sm:flex-row sm:items-center sm:justify-between"
+                  >
+                    <div className="min-w-0 space-y-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <p className="font-medium text-gray-900">
+                          {token.name}
+                        </p>
+                        <Badge variant={isRevoked ? "secondary" : "outline"}>
+                          {isRevoked ? "회수됨" : "읽기 전용"}
+                        </Badge>
+                      </div>
+                      <p className="text-sm text-gray-500">
+                        {token.tokenPrefix}...{token.tokenLast4}
+                      </p>
+                      <p className="text-xs text-gray-400">
+                        만료 {formatDate(token.expiresAt)} · 마지막 사용{" "}
+                        {formatDate(token.lastUsedAt)}
+                      </p>
+                    </div>
+
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handleRevoke(token.id)}
+                      disabled={isPending || isRevoked}
+                    >
+                      <RotateCcw className="h-4 w-4" />
+                      회수
+                    </Button>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/settings/SettingsMenu.tsx
+++ b/components/settings/SettingsMenu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Bell, LogOut, Monitor, Shield, User, Users } from "lucide-react";
+import { Bell, Bot, LogOut, Monitor, Shield, User, Users } from "lucide-react";
 import { useTransition } from "react";
 import { signOutAction } from "@/app/(auth)/logout/actions";
 import { SettingsMenuItem } from "./SettingsMenuItem";
@@ -37,6 +37,13 @@ export function SettingsMenu() {
         description="비밀번호 변경"
         href="/settings/security"
         disabled
+      />
+
+      <SettingsMenuItem
+        icon={Bot}
+        label="MCP 연결"
+        description="AI 도구 연결 토큰 관리"
+        href="/settings/mcp"
       />
 
       <SettingsMenuItem

--- a/components/settings/index.ts
+++ b/components/settings/index.ts
@@ -1,2 +1,3 @@
+export { McpTokenManager } from "./McpTokenManager";
 export { SettingsMenu } from "./SettingsMenu";
 export { SettingsMenuItem } from "./SettingsMenuItem";

--- a/lib/mcp/audit.ts
+++ b/lib/mcp/audit.ts
@@ -1,0 +1,32 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database, Json } from "@/types";
+import type { McpAuthContext } from "./auth";
+
+type LooseSupabaseClient = SupabaseClient<Database>;
+
+export async function writeMcpAuditLog(
+  supabase: LooseSupabaseClient,
+  params: {
+    auth: McpAuthContext;
+    toolName: string;
+    inputSummary?: Record<string, unknown>;
+    resultStatus: "success" | "error";
+    errorCode?: string;
+    durationMs: number;
+  },
+) {
+  const { error } = await supabase.from("mcp_audit_logs").insert({
+    token_id: params.auth.tokenId,
+    user_id: params.auth.userId,
+    household_id: params.auth.householdId,
+    tool_name: params.toolName,
+    input_summary: (params.inputSummary ?? null) as Json,
+    result_status: params.resultStatus,
+    error_code: params.errorCode ?? null,
+    duration_ms: params.durationMs,
+  });
+
+  if (error) {
+    console.error("MCP audit log error:", error);
+  }
+}

--- a/lib/mcp/auth.test.ts
+++ b/lib/mcp/auth.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  createMcpTokenSecret,
+  DEFAULT_MCP_TOKEN_TTL_DAYS,
+  getMcpTokenExpiresAt,
+  hashMcpToken,
+  parseBearerToken,
+  toMcpTokenPreview,
+} from "./auth";
+
+describe("MCP auth helpers", () => {
+  it("creates an oat MCP token with previewable prefix and last4", () => {
+    const token = createMcpTokenSecret();
+
+    expect(token).toMatch(/^oat_mcp_[A-Za-z0-9_-]{32,}$/);
+    expect(toMcpTokenPreview(token)).toEqual({
+      prefix: "oat_mcp",
+      last4: token.slice(-4),
+    });
+  });
+
+  it("hashes tokens without returning the raw token", () => {
+    const token = "oat_mcp_test_token";
+    const hash = hashMcpToken(token);
+
+    expect(hash).not.toBe(token);
+    expect(hash).toHaveLength(64);
+    expect(hashMcpToken(token)).toBe(hash);
+  });
+
+  it("parses bearer tokens and rejects malformed headers", () => {
+    expect(parseBearerToken("Bearer oat_mcp_abc")).toBe("oat_mcp_abc");
+    expect(parseBearerToken("bearer oat_mcp_abc")).toBe("oat_mcp_abc");
+    expect(parseBearerToken(null)).toBeNull();
+    expect(parseBearerToken("oat_mcp_abc")).toBeNull();
+    expect(parseBearerToken("Bearer")).toBeNull();
+  });
+
+  it("defaults token expiry to 90 days", () => {
+    const now = new Date("2026-05-08T00:00:00.000Z");
+    const expiresAt = getMcpTokenExpiresAt(now);
+
+    expect(DEFAULT_MCP_TOKEN_TTL_DAYS).toBe(90);
+    expect(expiresAt).toBe("2026-08-06T00:00:00.000Z");
+  });
+});

--- a/lib/mcp/auth.ts
+++ b/lib/mcp/auth.ts
@@ -1,0 +1,248 @@
+import { createHash, randomBytes } from "node:crypto";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { APIError } from "@/lib/api/error";
+import type { Database } from "@/types";
+
+export const DEFAULT_MCP_TOKEN_TTL_DAYS = 90;
+export const DEFAULT_MCP_READ_SCOPES = [
+  "read:overview",
+  "read:ledger",
+  "read:assets",
+  "read:references",
+] as const;
+
+export type McpReadScope = (typeof DEFAULT_MCP_READ_SCOPES)[number];
+
+export interface McpAuthContext {
+  tokenId: string;
+  userId: string;
+  householdId: string;
+  scopes: string[];
+  authMethod: "personal_token";
+}
+
+export interface McpTokenListItem {
+  id: string;
+  name: string;
+  tokenPrefix: string;
+  tokenLast4: string;
+  scopes: string[];
+  expiresAt: string;
+  lastUsedAt: string | null;
+  revokedAt: string | null;
+  createdAt: string;
+}
+
+type LooseSupabaseClient = SupabaseClient<Database>;
+
+interface McpTokenRow {
+  id: string;
+  user_id: string;
+  household_id: string;
+  name: string;
+  token_prefix: string;
+  token_last4: string;
+  scopes: string[];
+  expires_at: string;
+  last_used_at: string | null;
+  revoked_at: string | null;
+  created_at: string;
+}
+
+function toTokenListItem(row: McpTokenRow): McpTokenListItem {
+  return {
+    id: row.id,
+    name: row.name,
+    tokenPrefix: row.token_prefix,
+    tokenLast4: row.token_last4,
+    scopes: row.scopes,
+    expiresAt: row.expires_at,
+    lastUsedAt: row.last_used_at,
+    revokedAt: row.revoked_at,
+    createdAt: row.created_at,
+  };
+}
+
+export function createMcpTokenSecret(): string {
+  return `oat_mcp_${randomBytes(32).toString("base64url")}`;
+}
+
+export function hashMcpToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+export function toMcpTokenPreview(token: string): {
+  prefix: string;
+  last4: string;
+} {
+  return {
+    prefix: token.split("_").slice(0, 2).join("_"),
+    last4: token.slice(-4),
+  };
+}
+
+export function parseBearerToken(header: string | null): string | null {
+  if (!header) return null;
+
+  const match = /^Bearer\s+(.+)$/i.exec(header.trim());
+  return match?.[1] ?? null;
+}
+
+export function getMcpTokenExpiresAt(
+  now = new Date(),
+  ttlDays = DEFAULT_MCP_TOKEN_TTL_DAYS,
+): string {
+  const expiresAt = new Date(now);
+  expiresAt.setUTCDate(expiresAt.getUTCDate() + ttlDays);
+  return expiresAt.toISOString();
+}
+
+export async function listMcpTokens(
+  supabase: LooseSupabaseClient,
+  userId: string,
+  householdId: string,
+): Promise<McpTokenListItem[]> {
+  const { data, error } = await supabase
+    .from("mcp_tokens")
+    .select(
+      "id, user_id, household_id, name, token_prefix, token_last4, scopes, expires_at, last_used_at, revoked_at, created_at",
+    )
+    .eq("user_id", userId)
+    .eq("household_id", householdId)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    console.error("MCP token list error:", error);
+    throw new APIError(
+      "MCP_TOKEN_ERROR",
+      "MCP 토큰 목록 조회에 실패했습니다.",
+      500,
+    );
+  }
+
+  return ((data ?? []) as McpTokenRow[]).map(toTokenListItem);
+}
+
+export async function createMcpToken(
+  supabase: LooseSupabaseClient,
+  params: {
+    userId: string;
+    householdId: string;
+    name: string;
+    scopes?: string[];
+    now?: Date;
+  },
+): Promise<{ token: string; item: McpTokenListItem }> {
+  const token = createMcpTokenSecret();
+  const preview = toMcpTokenPreview(token);
+  const scopes = params.scopes ?? [...DEFAULT_MCP_READ_SCOPES];
+
+  const { data, error } = await supabase
+    .from("mcp_tokens")
+    .insert({
+      user_id: params.userId,
+      household_id: params.householdId,
+      name: params.name,
+      token_hash: hashMcpToken(token),
+      token_prefix: preview.prefix,
+      token_last4: preview.last4,
+      scopes,
+      expires_at: getMcpTokenExpiresAt(params.now),
+    })
+    .select(
+      "id, user_id, household_id, name, token_prefix, token_last4, scopes, expires_at, last_used_at, revoked_at, created_at",
+    )
+    .single();
+
+  if (error) {
+    console.error("MCP token create error:", error);
+    throw new APIError("MCP_TOKEN_ERROR", "MCP 토큰 생성에 실패했습니다.", 500);
+  }
+
+  return { token, item: toTokenListItem(data as McpTokenRow) };
+}
+
+export async function revokeMcpToken(
+  supabase: LooseSupabaseClient,
+  params: { tokenId: string; userId: string; householdId: string },
+): Promise<void> {
+  const { error } = await supabase
+    .from("mcp_tokens")
+    .update({ revoked_at: new Date().toISOString() })
+    .eq("id", params.tokenId)
+    .eq("user_id", params.userId)
+    .eq("household_id", params.householdId)
+    .is("revoked_at", null);
+
+  if (error) {
+    console.error("MCP token revoke error:", error);
+    throw new APIError("MCP_TOKEN_ERROR", "MCP 토큰 회수에 실패했습니다.", 500);
+  }
+}
+
+export async function authenticateMcpToken(
+  supabase: LooseSupabaseClient,
+  authorizationHeader: string | null,
+): Promise<McpAuthContext> {
+  const token = parseBearerToken(authorizationHeader);
+
+  if (!token) {
+    throw new APIError("MCP_UNAUTHORIZED", "MCP 토큰이 필요합니다.", 401);
+  }
+
+  const { data, error } = await supabase
+    .from("mcp_tokens")
+    .select("id, user_id, household_id, scopes, expires_at, revoked_at")
+    .eq("token_hash", hashMcpToken(token))
+    .maybeSingle();
+
+  if (error) {
+    console.error("MCP token auth error:", error);
+    throw new APIError(
+      "MCP_UNAUTHORIZED",
+      "MCP 토큰 인증에 실패했습니다.",
+      401,
+    );
+  }
+
+  const row = data as {
+    id: string;
+    user_id: string;
+    household_id: string;
+    scopes: string[];
+    expires_at: string;
+    revoked_at: string | null;
+  } | null;
+
+  if (!row || row.revoked_at || new Date(row.expires_at) <= new Date()) {
+    throw new APIError(
+      "MCP_UNAUTHORIZED",
+      "유효하지 않은 MCP 토큰입니다.",
+      401,
+    );
+  }
+
+  const { data: membership } = await supabase
+    .from("household_members")
+    .select("user_id")
+    .eq("household_id", row.household_id)
+    .eq("user_id", row.user_id)
+    .maybeSingle();
+
+  if (!membership) {
+    throw new APIError("MCP_FORBIDDEN", "가구 접근 권한이 없습니다.", 403);
+  }
+
+  await supabase
+    .from("mcp_tokens")
+    .update({ last_used_at: new Date().toISOString() })
+    .eq("id", row.id);
+
+  return {
+    tokenId: row.id,
+    userId: row.user_id,
+    householdId: row.household_id,
+    scopes: row.scopes,
+    authMethod: "personal_token",
+  };
+}

--- a/lib/mcp/protocol.test.ts
+++ b/lib/mcp/protocol.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { handleMcpJsonRpc } from "./protocol";
+
+const auth = {
+  tokenId: "token-1",
+  userId: "user-1",
+  householdId: "household-1",
+  scopes: ["read:overview", "read:ledger", "read:assets", "read:references"],
+  authMethod: "personal_token" as const,
+};
+
+describe("MCP JSON-RPC handler", () => {
+  it("returns initialize capabilities", async () => {
+    const response = await handleMcpJsonRpc({
+      message: {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "2025-06-18" },
+      },
+      supabase: {},
+      auth,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      jsonrpc: "2.0",
+      id: 1,
+      result: {
+        protocolVersion: "2025-06-18",
+        capabilities: { tools: {} },
+        serverInfo: { name: "oat" },
+      },
+    });
+  });
+
+  it("lists v0 tools", async () => {
+    const response = await handleMcpJsonRpc({
+      message: {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/list",
+      },
+      supabase: {},
+      auth,
+    });
+
+    expect(response.body).not.toBeNull();
+    const body = response.body as {
+      result: { tools: { name: string }[] };
+    };
+
+    expect(body.result.tools.map((tool) => tool.name)).toEqual([
+      "get_context",
+      "get_financial_overview",
+      "list_references",
+      "search_ledger_entries",
+      "get_ledger_stats",
+      "get_asset_snapshot",
+    ]);
+  });
+
+  it("returns 202 for notifications without a body", async () => {
+    const response = await handleMcpJsonRpc({
+      message: {
+        jsonrpc: "2.0",
+        method: "notifications/initialized",
+      },
+      supabase: {},
+      auth,
+    });
+
+    expect(response).toEqual({ status: 202, body: null });
+  });
+});

--- a/lib/mcp/protocol.ts
+++ b/lib/mcp/protocol.ts
@@ -1,0 +1,162 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { APIError } from "@/lib/api/error";
+import type { Database } from "@/types";
+import type { McpAuthContext } from "./auth";
+import { executeMcpTool, MCP_TOOL_DEFINITIONS } from "./tools";
+
+type LooseSupabaseClient = SupabaseClient<Database> | Record<string, never>;
+
+interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id?: string | number | null;
+  method?: string;
+  params?: unknown;
+}
+
+interface HandleMcpJsonRpcParams {
+  message: JsonRpcRequest;
+  supabase: LooseSupabaseClient;
+  auth: McpAuthContext;
+}
+
+export interface McpJsonRpcResponse {
+  status: number;
+  body: Record<string, unknown> | null;
+}
+
+function jsonRpcResult(id: JsonRpcRequest["id"], result: unknown) {
+  return {
+    jsonrpc: "2.0",
+    id,
+    result,
+  };
+}
+
+function jsonRpcError(
+  id: JsonRpcRequest["id"],
+  code: number,
+  message: string,
+  data?: unknown,
+) {
+  return {
+    jsonrpc: "2.0",
+    id: id ?? null,
+    error: {
+      code,
+      message,
+      data,
+    },
+  };
+}
+
+function toToolContent(result: unknown) {
+  return [
+    {
+      type: "text",
+      text: JSON.stringify(result, null, 2),
+    },
+  ];
+}
+
+function getToolCallParams(params: unknown): {
+  name: string;
+  arguments: Record<string, unknown>;
+} {
+  const value = params as { name?: unknown; arguments?: unknown } | null;
+
+  if (!value || typeof value.name !== "string") {
+    throw new APIError(
+      "MCP_INVALID_REQUEST",
+      "MCP tool 이름이 필요합니다.",
+      400,
+    );
+  }
+
+  return {
+    name: value.name,
+    arguments:
+      value.arguments && typeof value.arguments === "object"
+        ? (value.arguments as Record<string, unknown>)
+        : {},
+  };
+}
+
+export async function handleMcpJsonRpc({
+  message,
+  supabase,
+  auth,
+}: HandleMcpJsonRpcParams): Promise<McpJsonRpcResponse> {
+  if (message.id === undefined || message.id === null) {
+    return { status: 202, body: null };
+  }
+
+  try {
+    switch (message.method) {
+      case "initialize":
+        return {
+          status: 200,
+          body: jsonRpcResult(message.id, {
+            protocolVersion: "2025-06-18",
+            capabilities: {
+              tools: {},
+            },
+            serverInfo: {
+              name: "oat",
+              version: "0.1.0",
+            },
+          }),
+        };
+
+      case "tools/list":
+        return {
+          status: 200,
+          body: jsonRpcResult(message.id, {
+            tools: MCP_TOOL_DEFINITIONS,
+          }),
+        };
+
+      case "tools/call": {
+        const tool = getToolCallParams(message.params);
+        const result = await executeMcpTool(
+          supabase as SupabaseClient<Database>,
+          auth,
+          tool.name,
+          tool.arguments,
+        );
+
+        return {
+          status: 200,
+          body: jsonRpcResult(message.id, {
+            content: toToolContent(result),
+          }),
+        };
+      }
+
+      default:
+        return {
+          status: 200,
+          body: jsonRpcError(
+            message.id,
+            -32601,
+            `Unsupported MCP method: ${message.method ?? "unknown"}`,
+          ),
+        };
+    }
+  } catch (error) {
+    if (error instanceof APIError) {
+      return {
+        status: 200,
+        body: jsonRpcError(message.id, -32000, error.message, {
+          code: error.code,
+          statusCode: error.statusCode,
+        }),
+      };
+    }
+
+    console.error("MCP JSON-RPC error:", error);
+    return {
+      status: 200,
+      body: jsonRpcError(message.id, -32603, "Internal MCP server error"),
+    };
+  }
+}

--- a/lib/mcp/tools.test.ts
+++ b/lib/mcp/tools.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildMcpMeta,
+  clampLedgerLimit,
+  isLedgerEntryVisibleToMcp,
+  MCP_TOOL_DEFINITIONS,
+  normalizeMcpPeriod,
+} from "./tools";
+
+describe("MCP tool helpers", () => {
+  it("exposes the v0 read-only tool set", () => {
+    expect(MCP_TOOL_DEFINITIONS.map((tool) => tool.name)).toEqual([
+      "get_context",
+      "get_financial_overview",
+      "list_references",
+      "search_ledger_entries",
+      "get_ledger_stats",
+      "get_asset_snapshot",
+    ]);
+  });
+
+  it("defaults the period to the current month and caps explicit ranges", () => {
+    const now = new Date("2026-05-08T09:00:00.000Z");
+
+    expect(normalizeMcpPeriod({}, now)).toEqual({
+      from: "2026-05-01",
+      to: "2026-05-31",
+    });
+
+    expect(
+      normalizeMcpPeriod({ from: "2025-01-01", to: "2026-05-31" }, now),
+    ).toEqual({
+      from: "2025-06-01",
+      to: "2026-05-31",
+    });
+  });
+
+  it("caps ledger entry result limits at 100", () => {
+    expect(clampLedgerLimit(undefined)).toBe(50);
+    expect(clampLedgerLimit(10)).toBe(10);
+    expect(clampLedgerLimit(500)).toBe(100);
+  });
+
+  it("includes scope and privacy metadata in tool responses", () => {
+    expect(
+      buildMcpMeta({
+        period: { from: "2026-05-01", to: "2026-05-31" },
+        scopes: ["read:ledger"],
+      }),
+    ).toEqual({
+      period: { from: "2026-05-01", to: "2026-05-31" },
+      scope: ["read:ledger"],
+      privacy: {
+        included: ["shared ledger details", "own private ledger details"],
+        aggregatedOnly: ["partner private expenses"],
+        excluded: ["partner private expense details"],
+      },
+      limits: {
+        maxLedgerEntries: 100,
+        maxStatsMonths: 12,
+      },
+    });
+  });
+
+  it("only exposes shared ledger entries and the token user's private entries", () => {
+    expect(
+      isLedgerEntryVisibleToMcp({
+        ownerId: "partner",
+        isShared: false,
+        currentUserId: "me",
+      }),
+    ).toBe(false);
+    expect(
+      isLedgerEntryVisibleToMcp({
+        ownerId: "me",
+        isShared: false,
+        currentUserId: "me",
+      }),
+    ).toBe(true);
+    expect(
+      isLedgerEntryVisibleToMcp({
+        ownerId: "partner",
+        isShared: true,
+        currentUserId: "me",
+      }),
+    ).toBe(true);
+  });
+});

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -1,0 +1,909 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { APIError } from "@/lib/api/error";
+import { getExchangeRateSafe } from "@/lib/api/exchange";
+import { getHoldings } from "@/lib/api/holdings";
+import { getPaymentMethods } from "@/lib/api/payment-method";
+import { getPortfolioSummary } from "@/lib/api/portfolio";
+import type { Database } from "@/types";
+import type { McpAuthContext } from "./auth";
+
+export const MAX_LEDGER_ENTRIES = 100;
+export const DEFAULT_LEDGER_ENTRIES_LIMIT = 50;
+export const MAX_STATS_MONTHS = 12;
+
+export const MCP_TOOL_DEFINITIONS = [
+  {
+    name: "get_context",
+    description:
+      "현재 oat MCP 연결의 사용자, 가구, 권한, privacy 모델을 조회합니다.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "get_financial_overview",
+    description: "이번 달 현금흐름과 현재 자산/주식 요약을 함께 조회합니다.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        from: { type: "string", description: "YYYY-MM-DD" },
+        to: { type: "string", description: "YYYY-MM-DD" },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "list_references",
+    description: "가구원, 카테고리, 계좌, 결제수단 참조 목록을 조회합니다.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "search_ledger_entries",
+    description:
+      "가계부 상세 내역을 조회합니다. 파트너 개인 지출 상세는 제외됩니다.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        from: { type: "string", description: "YYYY-MM-DD" },
+        to: { type: "string", description: "YYYY-MM-DD" },
+        query: { type: "string" },
+        limit: { type: "number", minimum: 1, maximum: MAX_LEDGER_ENTRIES },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "get_ledger_stats",
+    description:
+      "가계부 요약, 멤버별, 카테고리별, 결제수단별 집계를 조회합니다.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        year: { type: "number" },
+        month: { type: "number" },
+        months: { type: "number", minimum: 1, maximum: MAX_STATS_MONTHS },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "get_asset_snapshot",
+    description: "총자산, 주식 보유, 자산 배분과 수익률 snapshot을 조회합니다.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        includeHoldings: { type: "boolean" },
+        includeAllocation: { type: "boolean" },
+      },
+      additionalProperties: false,
+    },
+  },
+] as const;
+
+export type McpToolName = (typeof MCP_TOOL_DEFINITIONS)[number]["name"];
+
+export interface McpPeriod {
+  from: string;
+  to: string;
+}
+
+type LooseSupabaseClient = SupabaseClient<Database>;
+
+function toDateOnly(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function startOfUtcMonth(date: Date): Date {
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1, 0, 0, 0, 0),
+  );
+}
+
+function endOfUtcMonth(date: Date): Date {
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + 1, 0, 0, 0, 0, 0),
+  );
+}
+
+function addUtcMonths(date: Date, months: number): Date {
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + months, 1),
+  );
+}
+
+export function normalizeMcpPeriod(
+  input: { from?: string; to?: string },
+  now = new Date(),
+): McpPeriod {
+  if (!input.from && !input.to) {
+    return {
+      from: toDateOnly(startOfUtcMonth(now)),
+      to: toDateOnly(endOfUtcMonth(now)),
+    };
+  }
+
+  const to = input.to ? new Date(`${input.to}T00:00:00.000Z`) : now;
+  const toMonthStart = startOfUtcMonth(to);
+  const minFrom = addUtcMonths(toMonthStart, -(MAX_STATS_MONTHS - 1));
+  const requestedFrom = input.from
+    ? new Date(`${input.from}T00:00:00.000Z`)
+    : toMonthStart;
+  const from = requestedFrom < minFrom ? minFrom : requestedFrom;
+
+  return {
+    from: toDateOnly(from),
+    to: toDateOnly(to),
+  };
+}
+
+export function clampLedgerLimit(limit: unknown): number {
+  if (typeof limit !== "number" || !Number.isFinite(limit)) {
+    return DEFAULT_LEDGER_ENTRIES_LIMIT;
+  }
+
+  return Math.min(Math.max(Math.floor(limit), 1), MAX_LEDGER_ENTRIES);
+}
+
+export function buildMcpMeta({
+  period,
+  scopes,
+}: {
+  period: McpPeriod | null;
+  scopes: string[];
+}) {
+  return {
+    period,
+    scope: scopes,
+    privacy: {
+      included: ["shared ledger details", "own private ledger details"],
+      aggregatedOnly: ["partner private expenses"],
+      excluded: ["partner private expense details"],
+    },
+    limits: {
+      maxLedgerEntries: MAX_LEDGER_ENTRIES,
+      maxStatsMonths: MAX_STATS_MONTHS,
+    },
+  };
+}
+
+export function isLedgerEntryVisibleToMcp({
+  ownerId,
+  isShared,
+  currentUserId,
+}: {
+  ownerId: string;
+  isShared: boolean;
+  currentUserId: string;
+}): boolean {
+  return isShared || ownerId === currentUserId;
+}
+
+function hasAnyScope(auth: McpAuthContext, scopes: string[]): boolean {
+  return scopes.some((scope) => auth.scopes.includes(scope));
+}
+
+function requireScope(auth: McpAuthContext, scopes: string[]) {
+  if (!hasAnyScope(auth, scopes)) {
+    throw new APIError("MCP_FORBIDDEN", "MCP tool 권한이 없습니다.", 403);
+  }
+}
+
+function periodToIsoRange(period: McpPeriod): { from: string; to: string } {
+  const to = new Date(`${period.to}T00:00:00.000Z`);
+  to.setUTCDate(to.getUTCDate() + 1);
+
+  return {
+    from: `${period.from}T00:00:00.000Z`,
+    to: to.toISOString(),
+  };
+}
+
+function getYearMonth(args: Record<string, unknown>, now = new Date()) {
+  const year = typeof args.year === "number" ? args.year : now.getUTCFullYear();
+  const month =
+    typeof args.month === "number" ? args.month : now.getUTCMonth() + 1;
+
+  return { year, month };
+}
+
+async function fetchMembers(
+  supabase: LooseSupabaseClient,
+  householdId: string,
+) {
+  const { data: members, error } = await supabase
+    .from("household_members")
+    .select("user_id, role")
+    .eq("household_id", householdId);
+
+  if (error) {
+    throw new APIError("MCP_FETCH_ERROR", "가구원 조회에 실패했습니다.", 500);
+  }
+
+  const userIds = [...new Set((members ?? []).map((member) => member.user_id))];
+  const { data: profiles } =
+    userIds.length > 0
+      ? await supabase
+          .from("profiles")
+          .select("id, name, email")
+          .in("id", userIds)
+      : { data: [] };
+
+  const profileMap = new Map((profiles ?? []).map((p) => [p.id, p]));
+
+  return (members ?? []).map((member) => {
+    const profile = profileMap.get(member.user_id);
+    return {
+      id: member.user_id,
+      name: profile?.name ?? "알 수 없음",
+      email: profile?.email ?? null,
+      role: member.role,
+    };
+  });
+}
+
+async function getContext(supabase: LooseSupabaseClient, auth: McpAuthContext) {
+  requireScope(auth, ["read:overview"]);
+
+  const [{ data: profile }, { data: household }] = await Promise.all([
+    supabase
+      .from("profiles")
+      .select("id, name, email")
+      .eq("id", auth.userId)
+      .maybeSingle(),
+    supabase
+      .from("households")
+      .select("id, name")
+      .eq("id", auth.householdId)
+      .maybeSingle(),
+  ]);
+
+  return {
+    meta: buildMcpMeta({ period: null, scopes: auth.scopes }),
+    summary: {
+      server: "oat MCP",
+      version: "v0",
+      mode: "read-only",
+    },
+    data: {
+      user: profile,
+      household,
+      capabilities: MCP_TOOL_DEFINITIONS.map((tool) => ({
+        name: tool.name,
+        description: tool.description,
+      })),
+    },
+  };
+}
+
+async function listReferences(
+  supabase: LooseSupabaseClient,
+  auth: McpAuthContext,
+) {
+  requireScope(auth, ["read:references"]);
+
+  const [members, { data: categories }, { data: accounts }, paymentMethods] =
+    await Promise.all([
+      fetchMembers(supabase, auth.householdId),
+      supabase
+        .from("categories")
+        .select("id, type, name, icon, display_order, is_system")
+        .eq("household_id", auth.householdId)
+        .order("display_order", { ascending: true }),
+      supabase
+        .from("accounts")
+        .select(
+          "id, owner_id, name, broker, account_type, category, balance, balance_updated_at, is_default",
+        )
+        .eq("household_id", auth.householdId)
+        .order("created_at", { ascending: false }),
+      getPaymentMethods(supabase as SupabaseClient<Database>, auth.householdId),
+    ]);
+
+  const memberMap = new Map(members.map((member) => [member.id, member.name]));
+
+  return {
+    meta: buildMcpMeta({ period: null, scopes: auth.scopes }),
+    summary: {
+      memberCount: members.length,
+      categoryCount: (categories ?? []).length,
+      accountCount: (accounts ?? []).length,
+      paymentMethodCount: paymentMethods.length,
+    },
+    data: {
+      members,
+      categories: categories ?? [],
+      accounts: (accounts ?? []).map((account) => ({
+        ...account,
+        ownerName: memberMap.get(account.owner_id) ?? "알 수 없음",
+      })),
+      paymentMethods,
+    },
+  };
+}
+
+async function searchLedgerEntries(
+  supabase: LooseSupabaseClient,
+  auth: McpAuthContext,
+  args: Record<string, unknown>,
+) {
+  requireScope(auth, ["read:ledger"]);
+
+  const period = normalizeMcpPeriod({
+    from: typeof args.from === "string" ? args.from : undefined,
+    to: typeof args.to === "string" ? args.to : undefined,
+  });
+  const { from, to } = periodToIsoRange(period);
+  const limit = clampLedgerLimit(args.limit);
+
+  const query = supabase
+    .from("ledger_entries")
+    .select(
+      "id, owner_id, type, amount, title, category_id, from_account_id, from_payment_method_id, to_account_id, to_payment_method_id, is_shared, memo, transacted_at, created_at, updated_at",
+    )
+    .eq("household_id", auth.householdId)
+    .gte("transacted_at", from)
+    .lt("transacted_at", to)
+    .or(`is_shared.eq.true,owner_id.eq.${auth.userId}`)
+    .order("transacted_at", { ascending: false })
+    .limit(limit);
+
+  const { data, error } = await query;
+
+  if (error) {
+    throw new APIError(
+      "MCP_LEDGER_FETCH_ERROR",
+      "가계부 내역 조회에 실패했습니다.",
+      500,
+    );
+  }
+
+  const keyword = typeof args.query === "string" ? args.query.trim() : "";
+  const rows = (data ?? [])
+    .filter((row) =>
+      isLedgerEntryVisibleToMcp({
+        ownerId: row.owner_id,
+        isShared: row.is_shared,
+        currentUserId: auth.userId,
+      }),
+    )
+    .filter((row) => {
+      if (!keyword) return true;
+      const haystack = `${row.title ?? ""} ${row.memo ?? ""}`.toLowerCase();
+      return haystack.includes(keyword.toLowerCase());
+    });
+
+  return {
+    meta: buildMcpMeta({ period, scopes: auth.scopes }),
+    summary: {
+      count: rows.length,
+      limit,
+    },
+    data: {
+      entries: rows,
+    },
+  };
+}
+
+function incrementAggregate(
+  map: Map<string | null, { amount: number; count: number }>,
+  key: string | null,
+  amount: number,
+) {
+  const existing = map.get(key) ?? { amount: 0, count: 0 };
+  map.set(key, {
+    amount: existing.amount + amount,
+    count: existing.count + 1,
+  });
+}
+
+function calcSavingsRate(income: number, expense: number): number {
+  if (income === 0) return 0;
+  return Math.round(((income - expense) / income) * 10000) / 100;
+}
+
+async function fetchCategoryMap(
+  supabase: LooseSupabaseClient,
+  aggregateMap: Map<string | null, { amount: number; count: number }>,
+) {
+  const ids = [...aggregateMap.keys()].filter(Boolean) as string[];
+  const { data } =
+    ids.length > 0
+      ? await supabase.from("categories").select("id, name, icon").in("id", ids)
+      : { data: [] };
+
+  return new Map(
+    (data ?? []).map((category) => [
+      category.id,
+      { name: category.name, icon: category.icon },
+    ]),
+  );
+}
+
+function buildCategoryStats(
+  categoryMap: Map<string, { name: string; icon: string | null }>,
+  aggregateMap: Map<string | null, { amount: number; count: number }>,
+  type: "expense" | "income",
+) {
+  const total = [...aggregateMap.values()].reduce(
+    (sum, item) => sum + item.amount,
+    0,
+  );
+  const items = [...aggregateMap.entries()]
+    .map(([categoryId, { amount, count }]) => {
+      const category = categoryId ? categoryMap.get(categoryId) : undefined;
+      return {
+        categoryId,
+        categoryName: category?.name ?? "미분류",
+        categoryIcon: category?.icon ?? null,
+        amount,
+        percentage: total > 0 ? Math.round((amount / total) * 10000) / 100 : 0,
+        entryCount: count,
+      };
+    })
+    .sort((a, b) => b.amount - a.amount);
+
+  return { type, scope: "all", total, items };
+}
+
+async function fetchPaymentMethodMap(
+  supabase: LooseSupabaseClient,
+  aggregateMap: Map<string | null, { amount: number; count: number }>,
+) {
+  const ids = [...aggregateMap.keys()].filter(Boolean) as string[];
+  const { data } =
+    ids.length > 0
+      ? await supabase
+          .from("payment_methods")
+          .select("id, name, type")
+          .in("id", ids)
+      : { data: [] };
+
+  return new Map(
+    (data ?? []).map((method) => [
+      method.id,
+      { name: method.name, type: method.type },
+    ]),
+  );
+}
+
+function buildPaymentMethodStats(
+  paymentMethodMap: Map<string, { name: string; type: string | null }>,
+  aggregateMap: Map<string | null, { amount: number; count: number }>,
+) {
+  const total = [...aggregateMap.values()].reduce(
+    (sum, item) => sum + item.amount,
+    0,
+  );
+  const items = [...aggregateMap.entries()]
+    .map(([paymentMethodId, { amount, count }]) => {
+      const paymentMethod = paymentMethodId
+        ? paymentMethodMap.get(paymentMethodId)
+        : undefined;
+      return {
+        paymentMethodId,
+        paymentMethodName: paymentMethod?.name ?? "현금/기타",
+        paymentMethodType: paymentMethod?.type ?? null,
+        amount,
+        percentage: total > 0 ? Math.round((amount / total) * 10000) / 100 : 0,
+        entryCount: count,
+      };
+    })
+    .sort((a, b) => b.amount - a.amount);
+
+  return { scope: "all", total, items };
+}
+
+async function buildTrendStats(
+  supabase: LooseSupabaseClient,
+  auth: McpAuthContext,
+  months: number,
+) {
+  const now = new Date();
+  const monthList: { year: number; month: number }[] = [];
+  for (let i = months - 1; i >= 0; i--) {
+    const cursor = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - i, 1),
+    );
+    monthList.push({
+      year: cursor.getUTCFullYear(),
+      month: cursor.getUTCMonth() + 1,
+    });
+  }
+
+  const first = monthList[0];
+  const last = monthList[monthList.length - 1];
+  const from = new Date(Date.UTC(first.year, first.month - 1, 1)).toISOString();
+  const to = new Date(Date.UTC(last.year, last.month, 1)).toISOString();
+  const { data: rows } = await supabase
+    .from("ledger_entries")
+    .select("owner_id, type, amount, is_shared, transacted_at")
+    .eq("household_id", auth.householdId)
+    .gte("transacted_at", from)
+    .lt("transacted_at", to)
+    .or(`is_shared.eq.true,owner_id.eq.${auth.userId}`);
+
+  const monthMap = new Map<string, { income: number; expense: number }>();
+  for (const { year, month } of monthList) {
+    monthMap.set(`${year}-${month}`, { income: 0, expense: 0 });
+  }
+
+  for (const row of rows ?? []) {
+    if (
+      !isLedgerEntryVisibleToMcp({
+        ownerId: row.owner_id,
+        isShared: row.is_shared,
+        currentUserId: auth.userId,
+      })
+    ) {
+      continue;
+    }
+
+    const date = new Date(row.transacted_at);
+    const key = `${date.getUTCFullYear()}-${date.getUTCMonth() + 1}`;
+    const existing = monthMap.get(key);
+    if (!existing) continue;
+    if (row.type === "income") existing.income += row.amount;
+    if (row.type === "expense") existing.expense += row.amount;
+  }
+
+  for (const { year, month } of monthList) {
+    const { data: privateTotals } = await supabase.rpc(
+      "get_private_entry_totals",
+      { hh_id: auth.householdId, p_year: year, p_month: month },
+    );
+    const privateTotalRows = (privateTotals ?? []) as {
+      owner_id: string;
+      total_amount: number | null;
+    }[];
+    const partnerPersonalExpense = privateTotalRows
+      .filter((row) => row.owner_id !== auth.userId)
+      .reduce((sum, row) => sum + (row.total_amount ?? 0), 0);
+    const existing = monthMap.get(`${year}-${month}`);
+    if (existing) existing.expense += partnerPersonalExpense;
+  }
+
+  return {
+    items: monthList.map(({ year, month }) => {
+      const item = monthMap.get(`${year}-${month}`) ?? {
+        income: 0,
+        expense: 0,
+      };
+      return {
+        year,
+        month,
+        totalIncome: item.income,
+        totalExpense: item.expense,
+        balance: item.income - item.expense,
+        savingsRate: calcSavingsRate(item.income, item.expense),
+      };
+    }),
+  };
+}
+
+async function getLedgerStats(
+  supabase: LooseSupabaseClient,
+  auth: McpAuthContext,
+  args: Record<string, unknown>,
+) {
+  requireScope(auth, ["read:ledger"]);
+
+  const { year, month } = getYearMonth(args);
+  const months =
+    typeof args.months === "number"
+      ? Math.min(Math.max(Math.floor(args.months), 1), MAX_STATS_MONTHS)
+      : 6;
+  const monthCursor = new Date(Date.UTC(year, month - 1, 1));
+  const period = normalizeMcpPeriod({
+    from: toDateOnly(startOfUtcMonth(monthCursor)),
+    to: toDateOnly(endOfUtcMonth(monthCursor)),
+  });
+  const { from, to } = periodToIsoRange(period);
+  const [members, { data: rows }, { data: privateTotals }] = await Promise.all([
+    fetchMembers(supabase, auth.householdId),
+    supabase
+      .from("ledger_entries")
+      .select(
+        "owner_id, type, amount, category_id, from_payment_method_id, is_shared, transacted_at",
+      )
+      .eq("household_id", auth.householdId)
+      .gte("transacted_at", from)
+      .lt("transacted_at", to)
+      .or(`is_shared.eq.true,owner_id.eq.${auth.userId}`),
+    supabase.rpc("get_private_entry_totals", {
+      hh_id: auth.householdId,
+      p_year: year,
+      p_month: month,
+    }),
+  ]);
+
+  const visibleRows = (rows ?? []).filter((row) =>
+    isLedgerEntryVisibleToMcp({
+      ownerId: row.owner_id,
+      isShared: row.is_shared,
+      currentUserId: auth.userId,
+    }),
+  );
+  const privateTotalRows = (privateTotals ?? []) as {
+    owner_id: string;
+    total_amount: number | null;
+  }[];
+  const partnerPersonalExpense = privateTotalRows
+    .filter((row) => row.owner_id !== auth.userId)
+    .reduce((sum, row) => sum + (row.total_amount ?? 0), 0);
+
+  let totalIncome = 0;
+  let totalSharedExpense = 0;
+  let myPersonalExpense = 0;
+  const byMemberMap = new Map<
+    string,
+    { sharedExpense: number; sharedIncome: number; personalExpense: number }
+  >();
+  const expenseCategoryMap = new Map<
+    string | null,
+    { amount: number; count: number }
+  >();
+  const incomeCategoryMap = new Map<
+    string | null,
+    { amount: number; count: number }
+  >();
+  const paymentMethodMap = new Map<
+    string | null,
+    { amount: number; count: number }
+  >();
+
+  for (const member of members) {
+    byMemberMap.set(member.id, {
+      sharedExpense: 0,
+      sharedIncome: 0,
+      personalExpense: 0,
+    });
+  }
+
+  for (const row of visibleRows) {
+    const memberStats = byMemberMap.get(row.owner_id);
+
+    if (row.type === "income") {
+      totalIncome += row.amount;
+      if (row.is_shared && memberStats) memberStats.sharedIncome += row.amount;
+      incrementAggregate(incomeCategoryMap, row.category_id, row.amount);
+    }
+
+    if (row.type === "expense") {
+      if (row.is_shared) {
+        totalSharedExpense += row.amount;
+        if (memberStats) memberStats.sharedExpense += row.amount;
+      } else if (row.owner_id === auth.userId) {
+        myPersonalExpense += row.amount;
+        if (memberStats) memberStats.personalExpense += row.amount;
+      }
+
+      incrementAggregate(expenseCategoryMap, row.category_id, row.amount);
+      incrementAggregate(
+        paymentMethodMap,
+        row.from_payment_method_id,
+        row.amount,
+      );
+    }
+  }
+
+  const totalPersonalExpense = myPersonalExpense + partnerPersonalExpense;
+  const totalExpense = totalSharedExpense + totalPersonalExpense;
+  const summary = {
+    year,
+    month,
+    totalIncome,
+    totalSharedExpense,
+    totalPersonalExpense,
+    totalExpense,
+    balance: totalIncome - totalExpense,
+    savingsRate: calcSavingsRate(totalIncome, totalExpense),
+  };
+
+  const privateMap = new Map<string, number>();
+  for (const row of privateTotalRows) {
+    privateMap.set(row.owner_id, row.total_amount ?? 0);
+  }
+
+  const byMember = {
+    members: members.map((member) => {
+      const stat = byMemberMap.get(member.id) ?? {
+        sharedExpense: 0,
+        sharedIncome: 0,
+        personalExpense: 0,
+      };
+      const isCurrentUser = member.id === auth.userId;
+      return {
+        memberId: member.id,
+        memberName: member.name,
+        isCurrentUser,
+        sharedExpense: stat.sharedExpense,
+        sharedIncome: stat.sharedIncome,
+        personalExpense: isCurrentUser
+          ? stat.personalExpense
+          : (privateMap.get(member.id) ?? 0),
+        personalExpenseVisible: isCurrentUser,
+      };
+    }),
+  };
+
+  const byExpenseCategory = buildCategoryStats(
+    await fetchCategoryMap(supabase, expenseCategoryMap),
+    expenseCategoryMap,
+    "expense",
+  );
+  const byIncomeCategory = buildCategoryStats(
+    await fetchCategoryMap(supabase, incomeCategoryMap),
+    incomeCategoryMap,
+    "income",
+  );
+  const byPaymentMethod = buildPaymentMethodStats(
+    await fetchPaymentMethodMap(supabase, paymentMethodMap),
+    paymentMethodMap,
+  );
+  const trend = await buildTrendStats(supabase, auth, months);
+
+  return {
+    meta: buildMcpMeta({ period, scopes: auth.scopes }),
+    summary,
+    data: {
+      byMember,
+      byCategory: {
+        expense: byExpenseCategory,
+        income: byIncomeCategory,
+      },
+      byPaymentMethod,
+      trend,
+    },
+  };
+}
+
+async function getAssetSnapshot(
+  supabase: LooseSupabaseClient,
+  auth: McpAuthContext,
+  args: Record<string, unknown>,
+) {
+  requireScope(auth, ["read:assets"]);
+
+  const includeHoldings = args.includeHoldings !== false;
+  const includeAllocation = args.includeAllocation !== false;
+  const typed = supabase as SupabaseClient<Database>;
+  const [portfolio, holdingsResult, exchangeRateResult] = await Promise.all([
+    getPortfolioSummary(typed, auth.householdId),
+    getHoldings(typed, auth.householdId, {
+      pagination: { page: 1, pageSize: includeHoldings ? 1000 : 1 },
+    }),
+    getExchangeRateSafe(typed, "USD", "KRW"),
+  ]);
+
+  const holdings = holdingsResult.data;
+  const allocationByAssetType = new Map<string, number>();
+  const allocationByOwner = new Map<string, number>();
+
+  for (const holding of holdings) {
+    allocationByAssetType.set(
+      holding.assetType,
+      (allocationByAssetType.get(holding.assetType) ?? 0) +
+        holding.totalInvested,
+    );
+    allocationByOwner.set(
+      holding.owner.name,
+      (allocationByOwner.get(holding.owner.name) ?? 0) + holding.totalInvested,
+    );
+  }
+
+  return {
+    meta: buildMcpMeta({ period: null, scopes: auth.scopes }),
+    summary: portfolio,
+    data: {
+      exchangeRate: exchangeRateResult?.rate ?? null,
+      holdings: includeHoldings ? holdings : undefined,
+      allocation: includeAllocation
+        ? {
+            byAssetType: [...allocationByAssetType.entries()].map(
+              ([assetType, totalInvested]) => ({ assetType, totalInvested }),
+            ),
+            byOwner: [...allocationByOwner.entries()].map(
+              ([ownerName, totalInvested]) => ({ ownerName, totalInvested }),
+            ),
+          }
+        : undefined,
+    },
+  };
+}
+
+async function getFinancialOverview(
+  supabase: LooseSupabaseClient,
+  auth: McpAuthContext,
+  args: Record<string, unknown>,
+) {
+  requireScope(auth, ["read:overview"]);
+
+  const period = normalizeMcpPeriod({
+    from: typeof args.from === "string" ? args.from : undefined,
+    to: typeof args.to === "string" ? args.to : undefined,
+  });
+  const monthDate = new Date(`${period.to}T00:00:00.000Z`);
+  const typed = supabase as SupabaseClient<Database>;
+  const ledgerAuth: McpAuthContext = {
+    ...auth,
+    scopes: [...new Set([...auth.scopes, "read:ledger"])],
+  };
+
+  const [ledgerResult, asset, { data: accounts }, paymentMethods] =
+    await Promise.all([
+      getLedgerStats(supabase, ledgerAuth, {
+        year: monthDate.getUTCFullYear(),
+        month: monthDate.getUTCMonth() + 1,
+        months: 1,
+      }),
+      getAssetSnapshot(supabase, auth, {
+        includeHoldings: false,
+        includeAllocation: true,
+      }),
+      supabase
+        .from("accounts")
+        .select("id, balance")
+        .eq("household_id", auth.householdId),
+      getPaymentMethods(typed, auth.householdId),
+    ]);
+
+  const accountRows = (accounts ?? []) as { balance: number | null }[];
+  const accountBalance = accountRows.reduce(
+    (sum, account) => sum + (account.balance ?? 0),
+    0,
+  );
+  const paymentMethodBalance = paymentMethods.reduce<number>(
+    (sum, paymentMethod) => sum + (paymentMethod.balance ?? 0),
+    0,
+  );
+
+  return {
+    meta: buildMcpMeta({ period, scopes: auth.scopes }),
+    summary: {
+      cashFlow: ledgerResult.summary,
+      portfolio: asset.summary,
+      liquidBalance: accountBalance + paymentMethodBalance,
+    },
+    data: {
+      balances: {
+        accounts: accountBalance,
+        paymentMethods: paymentMethodBalance,
+      },
+      asset: asset.data,
+    },
+  };
+}
+
+export async function executeMcpTool(
+  supabase: LooseSupabaseClient,
+  auth: McpAuthContext,
+  name: string,
+  args: Record<string, unknown> = {},
+) {
+  switch (name) {
+    case "get_context":
+      return getContext(supabase, auth);
+    case "get_financial_overview":
+      return getFinancialOverview(supabase, auth, args);
+    case "list_references":
+      return listReferences(supabase, auth);
+    case "search_ledger_entries":
+      return searchLedgerEntries(supabase, auth, args);
+    case "get_ledger_stats":
+      return getLedgerStats(supabase, auth, args);
+    case "get_asset_snapshot":
+      return getAssetSnapshot(supabase, auth, args);
+    default:
+      throw new APIError(
+        "MCP_TOOL_NOT_FOUND",
+        "MCP tool을 찾을 수 없습니다.",
+        404,
+      );
+  }
+}

--- a/supabase/migrations/20260508001000_create_mcp_tables.sql
+++ b/supabase/migrations/20260508001000_create_mcp_tables.sql
@@ -1,0 +1,47 @@
+-- MCP v0: personal read-only tokens and audit logs
+
+create table public.mcp_tokens (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  household_id uuid not null references public.households(id) on delete cascade,
+  name text not null check (char_length(name) between 1 and 80),
+  token_hash text not null unique,
+  token_prefix text not null,
+  token_last4 text not null,
+  scopes text[] not null,
+  expires_at timestamptz not null,
+  last_used_at timestamptz,
+  revoked_at timestamptz,
+  created_at timestamptz not null default now()
+);
+
+create index mcp_tokens_user_household_idx
+  on public.mcp_tokens(user_id, household_id);
+
+create index mcp_tokens_token_hash_idx
+  on public.mcp_tokens(token_hash);
+
+create table public.mcp_audit_logs (
+  id uuid primary key default gen_random_uuid(),
+  token_id uuid references public.mcp_tokens(id) on delete set null,
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  household_id uuid not null references public.households(id) on delete cascade,
+  tool_name text not null,
+  input_summary jsonb,
+  result_status text not null,
+  error_code text,
+  duration_ms integer,
+  created_at timestamptz not null default now()
+);
+
+create index mcp_audit_logs_user_household_created_idx
+  on public.mcp_audit_logs(user_id, household_id, created_at desc);
+
+create index mcp_audit_logs_token_created_idx
+  on public.mcp_audit_logs(token_id, created_at desc);
+
+alter table public.mcp_tokens enable row level security;
+alter table public.mcp_audit_logs enable row level security;
+
+-- No direct client policies in v0.
+-- Token management and MCP access go through server routes with explicit user/household checks.

--- a/types/index.ts
+++ b/types/index.ts
@@ -41,6 +41,8 @@ export type ExchangeRate = Tables<"exchange_rates">;
 export type Tag = Tables<"tags">;
 export type HoldingTag = Tables<"holding_tags">;
 export type TargetAllocation = Tables<"target_allocations">;
+export type McpToken = Tables<"mcp_tokens">;
+export type McpAuditLog = Tables<"mcp_audit_logs">;
 
 // 가계부 테이블 타입
 export type LedgerEntry = Tables<"ledger_entries">;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -450,6 +450,127 @@ export type Database = {
           },
         ];
       };
+      mcp_audit_logs: {
+        Row: {
+          created_at: string;
+          duration_ms: number | null;
+          error_code: string | null;
+          household_id: string;
+          id: string;
+          input_summary: Json | null;
+          result_status: string;
+          token_id: string | null;
+          tool_name: string;
+          user_id: string;
+        };
+        Insert: {
+          created_at?: string;
+          duration_ms?: number | null;
+          error_code?: string | null;
+          household_id: string;
+          id?: string;
+          input_summary?: Json | null;
+          result_status: string;
+          token_id?: string | null;
+          tool_name: string;
+          user_id: string;
+        };
+        Update: {
+          created_at?: string;
+          duration_ms?: number | null;
+          error_code?: string | null;
+          household_id?: string;
+          id?: string;
+          input_summary?: Json | null;
+          result_status?: string;
+          token_id?: string | null;
+          tool_name?: string;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "mcp_audit_logs_household_id_fkey";
+            columns: ["household_id"];
+            isOneToOne: false;
+            referencedRelation: "households";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "mcp_audit_logs_token_id_fkey";
+            columns: ["token_id"];
+            isOneToOne: false;
+            referencedRelation: "mcp_tokens";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "mcp_audit_logs_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      mcp_tokens: {
+        Row: {
+          created_at: string;
+          expires_at: string;
+          household_id: string;
+          id: string;
+          last_used_at: string | null;
+          name: string;
+          revoked_at: string | null;
+          scopes: string[];
+          token_hash: string;
+          token_last4: string;
+          token_prefix: string;
+          user_id: string;
+        };
+        Insert: {
+          created_at?: string;
+          expires_at: string;
+          household_id: string;
+          id?: string;
+          last_used_at?: string | null;
+          name: string;
+          revoked_at?: string | null;
+          scopes: string[];
+          token_hash: string;
+          token_last4: string;
+          token_prefix: string;
+          user_id: string;
+        };
+        Update: {
+          created_at?: string;
+          expires_at?: string;
+          household_id?: string;
+          id?: string;
+          last_used_at?: string | null;
+          name?: string;
+          revoked_at?: string | null;
+          scopes?: string[];
+          token_hash?: string;
+          token_last4?: string;
+          token_prefix?: string;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "mcp_tokens_household_id_fkey";
+            columns: ["household_id"];
+            isOneToOne: false;
+            referencedRelation: "households";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "mcp_tokens_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
       payment_methods: {
         Row: {
           balance: number | null;


### PR DESCRIPTION
## Summary

- Add read-only MCP v0 endpoint at `/api/mcp` with JSON-RPC handling for initialize, tool listing, and tool calls.
- Add user-scoped MCP token management with hashed token storage, 90-day expiry, revocation, and audit logging.
- Add `/settings/mcp` UI for creating, copying, listing, and revoking MCP tokens.
- Add MCP design and usage docs, including deployment verification curl examples.

## Notes

- v0 is read-only and exposes six tools: `get_context`, `get_financial_overview`, `list_references`, `search_ledger_entries`, `get_ledger_stats`, and `get_asset_snapshot`.
- Partner private ledger entry details are excluded; partner private expenses are only included in aggregate form.
- The generated Supabase types were refreshed after the MCP migration was applied.

## Validation

- `pnpm test -- --runInBand lib/mcp/auth.test.ts lib/mcp/tools.test.ts lib/mcp/protocol.test.ts`
- `pnpm type-check`
- Local curl verification against `localhost:3000/api/mcp` for health, initialize, tools/list, get_context, list_references, get_financial_overview, get_ledger_stats, and get_asset_snapshot.

## Follow-up

- Revoke any MCP token that was shared during local testing.
- Configure the deployed MCP URL in target clients after deployment.