### PR TITLE
[codex] Fix financial account asset card

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,32 @@
+# oat
+
+Family finance context for tracking household money flow and asset growth in one view.
+
+## Language
+
+**Financial Account**:
+A household-managed account that holds or receives money, including both bank accounts and investment accounts.
+_Avoid_: Cash-only account, bank-only account
+
+**Bank Account**:
+A financial account used for ordinary cash, savings, or deposit balances.
+_Avoid_: Cash asset
+
+**Investment Account**:
+A financial account used for investments such as stocks, CMA, ISA, or pension products.
+_Avoid_: Stock-only account
+
+## Relationships
+
+- A **Financial Account** is either a **Bank Account** or an **Investment Account**.
+- A **Household** has zero or more **Financial Accounts**.
+- A **Stock Holding** belongs to an **Investment Account**, but an **Investment Account** can exist before it has any **Stock Holdings**.
+
+## Example dialogue
+
+> **Dev:** "If a user has registered only a stock account but no stock holdings yet, should the asset page say there are no financial assets?"
+> **Domain expert:** "No. A stock account is still a financial account, even before any holdings are recorded."
+
+## Flagged ambiguities
+
+- "Financial account" was previously easy to read as cash or bank accounts only. Resolved: it means the full set of household-managed accounts, including investment accounts.

--- a/app/(main)/assets/page.tsx
+++ b/app/(main)/assets/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { AssetTypeCard } from "@/components/assets";
 import { PageHeader } from "@/components/layout";
 import { Button } from "@/components/ui/button";
+import { getAccounts } from "@/lib/api/account";
 import { getUserHouseholdId } from "@/lib/api/invitation";
 import { getPortfolioSummary } from "@/lib/api/portfolio";
 import { requireUser } from "@/lib/supabase/auth";
@@ -16,10 +17,13 @@ export default async function AssetsPage() {
   // 가구 ID 조회
   const householdId = await getUserHouseholdId(supabase, user.id);
 
-  // 포트폴리오 요약 조회
-  const portfolio = householdId
-    ? await getPortfolioSummary(supabase, householdId)
-    : { holdingCount: 0, totalValue: 0, totalInvested: 0, returnRate: 0 };
+  // 포트폴리오 요약 및 금융 계좌 조회
+  const [portfolio, accounts] = householdId
+    ? await Promise.all([
+        getPortfolioSummary(supabase, householdId),
+        getAccounts(supabase, householdId),
+      ])
+    : [{ holdingCount: 0, totalValue: 0, totalInvested: 0, returnRate: 0 }, []];
 
   return (
     <>
@@ -56,8 +60,15 @@ export default async function AssetsPage() {
           returnRate={portfolio.returnRate}
         />
 
-        {/* 현금/예적금 - 계좌 관리로 연결됨 */}
-        <AssetTypeCard type="cash" />
+        {/* 금융 계좌 - 은행 계좌와 투자 계좌를 함께 관리 */}
+        <AssetTypeCard
+          type="cash"
+          holdingCount={accounts.length}
+          countLabel="계좌"
+          emptyText="아직 등록된 계좌가 없어요"
+          activeActionText="관리하기"
+          showValue={false}
+        />
 
         {/* 부동산 - 준비 중 */}
         <AssetTypeCard type="real-estate" disabled />

--- a/components/assets/common/AssetTypeCard.test.tsx
+++ b/components/assets/common/AssetTypeCard.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AssetTypeCard } from "./AssetTypeCard";
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe("AssetTypeCard", () => {
+  it("금융 계좌가 있으면 계좌 수와 관리 CTA를 표시한다", () => {
+    render(
+      <AssetTypeCard
+        type="cash"
+        holdingCount={1}
+        countLabel="계좌"
+        emptyText="아직 등록된 계좌가 없어요"
+        activeActionText="관리하기"
+        showValue={false}
+      />,
+    );
+
+    expect(screen.getByText("금융 계좌")).toBeInTheDocument();
+    expect(screen.getByText("1계좌")).toBeInTheDocument();
+    expect(screen.getByText("관리하기")).toBeInTheDocument();
+    expect(
+      screen.queryByText("아직 등록된 계좌가 없어요"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/components/assets/common/AssetTypeCard.tsx
+++ b/components/assets/common/AssetTypeCard.tsx
@@ -1,13 +1,6 @@
 "use client";
 
-import {
-  ChevronRight,
-  Home,
-  type LucideIcon,
-  Package,
-  TrendingUp,
-  Wallet,
-} from "lucide-react";
+import { ChevronRight } from "lucide-react";
 import Link from "next/link";
 import { toast } from "sonner";
 import { type AssetType, BASE_ASSET_TYPE_CONFIG } from "@/lib/constants/assets";
@@ -38,6 +31,10 @@ interface AssetTypeListItemProps {
   holdingCount?: number;
   totalValue?: number;
   returnRate?: number;
+  countLabel?: string;
+  emptyText?: string;
+  activeActionText?: string;
+  showValue?: boolean;
   disabled?: boolean;
   isLoading?: boolean;
 }
@@ -47,6 +44,10 @@ export function AssetTypeListItem({
   holdingCount = 0,
   totalValue = 0,
   returnRate = 0,
+  countLabel = "종목",
+  emptyText = "아직 등록된 자산이 없어요",
+  activeActionText,
+  showValue = true,
   disabled = false,
   isLoading = false,
 }: AssetTypeListItemProps) {
@@ -121,14 +122,21 @@ export function AssetTypeListItem({
       <div className="flex-1">
         <p className="font-medium text-gray-900">{baseConfig.label}</p>
         {isEmpty ? (
-          <p className="text-sm text-gray-400">아직 등록된 자산이 없어요</p>
+          <p className="text-sm text-gray-400">{emptyText}</p>
         ) : (
           <p className="text-sm text-gray-500">
-            {holdingCount}종목
-            <span className="mx-1.5 text-gray-300">·</span>
-            <span className={isPositive ? "text-rose-500" : "text-blue-500"}>
-              {formatPercent(returnRate)}
-            </span>
+            {holdingCount}
+            {countLabel}
+            {showValue && (
+              <>
+                <span className="mx-1.5 text-gray-300">·</span>
+                <span
+                  className={isPositive ? "text-rose-500" : "text-blue-500"}
+                >
+                  {formatPercent(returnRate)}
+                </span>
+              </>
+            )}
           </p>
         )}
       </div>
@@ -136,11 +144,15 @@ export function AssetTypeListItem({
       {/* 금액 또는 시작하기 */}
       {isEmpty ? (
         <span className="text-sm text-indigo-600 font-medium">시작하기</span>
-      ) : (
+      ) : showValue ? (
         <p className="text-lg font-semibold text-gray-900">
           {formatCurrency(totalValue)}
         </p>
-      )}
+      ) : activeActionText ? (
+        <span className="text-sm text-indigo-600 font-medium">
+          {activeActionText}
+        </span>
+      ) : null}
       <ChevronRight className="w-5 h-5 text-gray-400" />
     </Link>
   );


### PR DESCRIPTION
## Summary

Fixes #283.

- Treat the asset page's financial account card as an account inventory summary instead of a holdings summary.
- Fetch household accounts on the asset page and show the total account count for `금융 계좌`.
- Keep `주식/ETF` based on stock holdings while allowing `AssetTypeCard` to customize count labels, empty copy, CTA text, and value visibility.
- Document the domain definition that a financial account includes both bank accounts and investment accounts.

## Root Cause

The `금융 계좌` asset card did not receive account data. It used `AssetTypeCard` defaults, so `holdingCount` stayed `0` and the card always rendered an empty asset state even when a stock account existed.

## Validation

- `pnpm test` — 27 files, 183 tests passed
- `pnpm type-check`
- `pnpm biome check 'app/(main)/assets/page.tsx' components/assets/common/AssetTypeCard.tsx components/assets/common/AssetTypeCard.test.tsx CONTEXT.md`