### PR TITLE
[codex] Defer ledger stats to client queries

### DIFF
--- a/app/(main)/ledger/analysis/page.tsx
+++ b/app/(main)/ledger/analysis/page.tsx
@@ -8,16 +8,9 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { PageHeader } from "@/components/layout";
-import { CategoryTopPreview } from "@/components/ledger/analysis/CategoryTopPreview";
+import { LedgerAnalysisOverview } from "@/components/ledger/analysis/LedgerAnalysisOverview";
 import { ScopeTabs } from "@/components/ledger/analysis/ScopeTabs";
-import { SummaryStatCard } from "@/components/ledger/analysis/SummaryStatCard";
-import { getUserHouseholdId } from "@/lib/api/invitation";
-import {
-  getLedgerStatsByCategory,
-  getLedgerStatsSummary,
-} from "@/lib/api/ledger-stats";
 import { requireUser } from "@/lib/supabase/auth";
-import { createClient } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
 
@@ -83,30 +76,11 @@ export default async function LedgerAnalysisPage({
   const scope: "shared" | "personal" =
     rawScope === "personal" ? "personal" : "shared";
 
-  const user = await requireUser();
-  const supabase = await createClient();
-  const householdId = await getUserHouseholdId(supabase, user.id);
+  await requireUser();
 
   const now = new Date();
   const year = now.getFullYear();
   const month = now.getMonth() + 1;
-
-  const [summary, categoryData] = await Promise.all([
-    householdId
-      ? getLedgerStatsSummary(supabase, householdId, user.id, year, month)
-      : null,
-    householdId
-      ? getLedgerStatsByCategory(
-          supabase,
-          householdId,
-          user.id,
-          year,
-          month,
-          "expense",
-          scope,
-        )
-      : null,
-  ]);
 
   const visibleCards = NAV_CARDS.filter(
     (card) => !(card.sharedOnly && scope === "personal"),
@@ -118,22 +92,7 @@ export default async function LedgerAnalysisPage({
 
       <ScopeTabs scope={scope} />
 
-      {summary ? (
-        <SummaryStatCard summary={summary} scope={scope} />
-      ) : (
-        <div className="bg-white rounded-2xl p-6 shadow-sm mb-6">
-          <p className="text-sm text-gray-400 text-center">
-            가구 정보를 불러올 수 없어요
-          </p>
-        </div>
-      )}
-
-      {categoryData && categoryData.items.length > 0 && (
-        <CategoryTopPreview
-          items={categoryData.items}
-          total={categoryData.total}
-        />
-      )}
+      <LedgerAnalysisOverview year={year} month={month} scope={scope} />
 
       <div className="space-y-3">
         <h3 className="text-base font-semibold text-gray-900 px-1">

--- a/app/(main)/ledger/page.tsx
+++ b/app/(main)/ledger/page.tsx
@@ -8,59 +8,22 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { PageHeader } from "@/components/layout";
+import { LedgerSummarySection } from "@/components/ledger/LedgerSummarySection";
 import { Button } from "@/components/ui/button";
-import { getUserHouseholdId } from "@/lib/api/invitation";
-import { getLedgerEntrySummary } from "@/lib/api/ledger";
 import { requireUser } from "@/lib/supabase/auth";
-import { createClient } from "@/lib/supabase/server";
-import { formatCurrency } from "@/lib/utils/format";
 
 export default async function LedgerPage() {
-  const user = await requireUser();
-  const supabase = await createClient();
-
-  const householdId = await getUserHouseholdId(supabase, user.id);
+  await requireUser();
 
   const now = new Date();
   const year = now.getFullYear();
   const month = now.getMonth() + 1;
 
-  const summary = householdId
-    ? await getLedgerEntrySummary(supabase, householdId, year, month)
-    : { totalIncome: 0, totalExpense: 0, balance: 0 };
-
   return (
     <>
       <PageHeader title="가계부" />
 
-      {/* 이번 달 요약 카드 */}
-      <div className="bg-white rounded-2xl p-6 shadow-sm mb-6">
-        <h2 className="text-sm text-gray-500 mb-4">{month}월 현금 흐름</h2>
-
-        <div className="space-y-4">
-          <div className="flex justify-between items-end">
-            <span className="text-gray-700">남은 금액</span>
-            <span className="text-3xl font-bold text-gray-900">
-              {formatCurrency(summary.balance)}
-            </span>
-          </div>
-
-          <div className="h-px bg-gray-100 w-full" />
-
-          <div className="flex justify-between items-center text-sm">
-            <span className="text-gray-500">수입</span>
-            <span className="font-medium text-gray-900">
-              {formatCurrency(summary.totalIncome)}
-            </span>
-          </div>
-          <div className="flex justify-between items-center text-sm">
-            <span className="text-gray-500">지출</span>
-            <span className="font-medium text-gray-900">
-              {formatCurrency(summary.totalExpense)}
-            </span>
-          </div>
-        </div>
-      </div>
+      <LedgerSummarySection year={year} month={month} />
 
       {/* 기능 진입점 목록 */}
       <div className="space-y-3">

--- a/components/ledger/LedgerSummarySection.test.tsx
+++ b/components/ledger/LedgerSummarySection.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useLedgerEntrySummary } from "@/hooks/use-ledger-entries";
+import { ApiQueryError } from "@/lib/api/client";
+import { LedgerSummarySection } from "./LedgerSummarySection";
+
+vi.mock("@/hooks/use-ledger-entries", () => ({
+  useLedgerEntrySummary: vi.fn(),
+}));
+
+describe("LedgerSummarySection", () => {
+  it("월 현금 흐름을 불러오는 동안 스켈레톤을 표시한다", () => {
+    vi.mocked(useLedgerEntrySummary).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    } as ReturnType<typeof useLedgerEntrySummary>);
+
+    const { container } = render(
+      <LedgerSummarySection year={2026} month={5} />,
+    );
+
+    expect(screen.getByText("5월 현금 흐름")).toBeInTheDocument();
+    expect(
+      container.querySelectorAll("[data-slot='skeleton']").length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("가구가 없으면 설정 전 상태로 표시한다", () => {
+    vi.mocked(useLedgerEntrySummary).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new ApiQueryError(
+        "HOUSEHOLD_NOT_FOUND",
+        "가구 정보를 찾을 수 없습니다.",
+        404,
+      ),
+    } as ReturnType<typeof useLedgerEntrySummary>);
+
+    render(<LedgerSummarySection year={2026} month={5} />);
+
+    expect(
+      screen.getByText("가구 정보를 불러올 수 없어요"),
+    ).toBeInTheDocument();
+  });
+
+  it("월 수입, 지출, 잔액을 렌더링한다", () => {
+    vi.mocked(useLedgerEntrySummary).mockReturnValue({
+      data: {
+        totalIncome: 3_000_000,
+        totalExpense: 1_200_000,
+        balance: 1_800_000,
+      },
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useLedgerEntrySummary>);
+
+    render(<LedgerSummarySection year={2026} month={5} />);
+
+    expect(screen.getByText("₩1,800,000")).toBeInTheDocument();
+    expect(screen.getByText("₩3,000,000")).toBeInTheDocument();
+    expect(screen.getByText("₩1,200,000")).toBeInTheDocument();
+  });
+});

--- a/components/ledger/LedgerSummarySection.tsx
+++ b/components/ledger/LedgerSummarySection.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useLedgerEntrySummary } from "@/hooks/use-ledger-entries";
+import { ApiQueryError } from "@/lib/api/client";
+import { formatCurrency } from "@/lib/utils/format";
+import { Skeleton } from "../ui/skeleton";
+
+interface LedgerSummarySectionProps {
+  year: number;
+  month: number;
+}
+
+function isNoHouseholdState(error: unknown) {
+  return error instanceof ApiQueryError && error.isCode("HOUSEHOLD_NOT_FOUND");
+}
+
+export function LedgerSummarySection({
+  year,
+  month,
+}: LedgerSummarySectionProps) {
+  const {
+    data: summary,
+    isLoading,
+    error,
+  } = useLedgerEntrySummary(year, month);
+
+  return (
+    <div className="bg-white rounded-2xl p-6 shadow-sm mb-6">
+      <h2 className="text-sm text-gray-500 mb-4">{month}월 현금 흐름</h2>
+
+      {isLoading ? (
+        <div className="space-y-4">
+          <div className="flex justify-between items-end">
+            <Skeleton className="h-5 w-20" />
+            <Skeleton className="h-9 w-40" />
+          </div>
+          <div className="h-px bg-gray-100 w-full" />
+          <div className="space-y-3">
+            <div className="flex justify-between">
+              <Skeleton className="h-4 w-10" />
+              <Skeleton className="h-4 w-28" />
+            </div>
+            <div className="flex justify-between">
+              <Skeleton className="h-4 w-10" />
+              <Skeleton className="h-4 w-28" />
+            </div>
+          </div>
+        </div>
+      ) : error ? (
+        <p className="text-sm text-gray-400 text-center py-8">
+          {isNoHouseholdState(error)
+            ? "가구 정보를 불러올 수 없어요"
+            : "월 현금 흐름을 불러오지 못했어요"}
+        </p>
+      ) : summary ? (
+        <div className="space-y-4">
+          <div className="flex justify-between items-end">
+            <span className="text-gray-700">남은 금액</span>
+            <span className="text-3xl font-bold text-gray-900">
+              {formatCurrency(summary.balance)}
+            </span>
+          </div>
+
+          <div className="h-px bg-gray-100 w-full" />
+
+          <div className="flex justify-between items-center text-sm">
+            <span className="text-gray-500">수입</span>
+            <span className="font-medium text-gray-900">
+              {formatCurrency(summary.totalIncome)}
+            </span>
+          </div>
+          <div className="flex justify-between items-center text-sm">
+            <span className="text-gray-500">지출</span>
+            <span className="font-medium text-gray-900">
+              {formatCurrency(summary.totalExpense)}
+            </span>
+          </div>
+        </div>
+      ) : (
+        <p className="text-sm text-gray-400 text-center py-8">
+          이번 달 수입/지출 내역이 없어요
+        </p>
+      )}
+    </div>
+  );
+}

--- a/components/ledger/analysis/CategoryTopPreview.tsx
+++ b/components/ledger/analysis/CategoryTopPreview.tsx
@@ -3,26 +3,30 @@ import type { CategoryStatItem } from "@/lib/api/ledger-stats";
 import { formatCurrency } from "@/lib/utils/format";
 
 interface CategoryTopPreviewProps {
+  emptyLabel?: string;
   items: CategoryStatItem[];
   total: number;
+  title?: string;
 }
 
-export function CategoryTopPreview({ items }: CategoryTopPreviewProps) {
+export function CategoryTopPreview({
+  emptyLabel = "이번 달 지출 내역이 없어요",
+  items,
+  title = "이번 달 주요 지출",
+}: CategoryTopPreviewProps) {
   const top3 = items.slice(0, 3);
 
   if (top3.length === 0) {
     return (
       <div className="bg-white rounded-2xl p-5 shadow-sm mb-6">
-        <p className="text-sm text-gray-500 text-center py-2">
-          이번 달 지출 내역이 없어요
-        </p>
+        <p className="text-sm text-gray-500 text-center py-2">{emptyLabel}</p>
       </div>
     );
   }
 
   return (
     <div className="bg-white rounded-2xl p-5 shadow-sm mb-6">
-      <p className="text-xs text-gray-500 mb-3">이번 달 주요 지출</p>
+      <p className="text-xs text-gray-500 mb-3">{title}</p>
       <div className="space-y-3">
         {top3.map((item) => (
           <div key={item.categoryId ?? "null"} className="space-y-1">

--- a/components/ledger/analysis/LedgerAnalysisOverview.test.tsx
+++ b/components/ledger/analysis/LedgerAnalysisOverview.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  useLedgerStatsByCategory,
+  useLedgerStatsSummary,
+} from "@/hooks/use-ledger-stats";
+import { ApiQueryError } from "@/lib/api/client";
+import { LedgerAnalysisOverview } from "./LedgerAnalysisOverview";
+
+vi.mock("@/hooks/use-ledger-stats", () => ({
+  useLedgerStatsSummary: vi.fn(),
+  useLedgerStatsByCategory: vi.fn(),
+}));
+
+const summary = {
+  year: 2026,
+  month: 5,
+  totalIncome: 4_000_000,
+  totalSharedExpense: 1_500_000,
+  totalPersonalExpense: 300_000,
+  totalTransfer: 0,
+};
+
+describe("LedgerAnalysisOverview", () => {
+  it("요약과 카테고리 프리뷰를 불러오는 동안 스켈레톤을 표시한다", () => {
+    vi.mocked(useLedgerStatsSummary).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    } as ReturnType<typeof useLedgerStatsSummary>);
+    vi.mocked(useLedgerStatsByCategory).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    } as ReturnType<typeof useLedgerStatsByCategory>);
+
+    const { container } = render(
+      <LedgerAnalysisOverview year={2026} month={5} scope="shared" />,
+    );
+
+    expect(
+      container.querySelectorAll("[data-slot='skeleton']").length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("개인 scope에서는 개인 지출 요약 문구를 사용한다", () => {
+    vi.mocked(useLedgerStatsSummary).mockReturnValue({
+      data: summary,
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useLedgerStatsSummary>);
+    vi.mocked(useLedgerStatsByCategory).mockReturnValue({
+      data: { items: [], total: 0 },
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useLedgerStatsByCategory>);
+
+    render(<LedgerAnalysisOverview year={2026} month={5} scope="personal" />);
+
+    expect(screen.getByText("5월 내 개인 지출")).toBeInTheDocument();
+    expect(
+      screen.getByText("이번 달 주요 개인 지출이 없어요"),
+    ).toBeInTheDocument();
+  });
+
+  it("가구가 없으면 설정 전 상태로 표시한다", () => {
+    const error = new ApiQueryError(
+      "HOUSEHOLD_NOT_FOUND",
+      "가구 정보를 찾을 수 없습니다.",
+      404,
+    );
+    vi.mocked(useLedgerStatsSummary).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error,
+    } as ReturnType<typeof useLedgerStatsSummary>);
+    vi.mocked(useLedgerStatsByCategory).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error,
+    } as ReturnType<typeof useLedgerStatsByCategory>);
+
+    render(<LedgerAnalysisOverview year={2026} month={5} scope="shared" />);
+
+    expect(
+      screen.getAllByText("가구 정보를 불러올 수 없어요").length,
+    ).toBeGreaterThan(0);
+  });
+});

--- a/components/ledger/analysis/LedgerAnalysisOverview.tsx
+++ b/components/ledger/analysis/LedgerAnalysisOverview.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import {
+  useLedgerStatsByCategory,
+  useLedgerStatsSummary,
+} from "@/hooks/use-ledger-stats";
+import { ApiQueryError } from "@/lib/api/client";
+import type { StatsScope } from "@/lib/api/ledger-stats";
+import { Skeleton } from "../../ui/skeleton";
+import { CategoryTopPreview } from "./CategoryTopPreview";
+import { SummaryStatCard } from "./SummaryStatCard";
+
+interface LedgerAnalysisOverviewProps {
+  year: number;
+  month: number;
+  scope: Extract<StatsScope, "shared" | "personal">;
+}
+
+function isNoHouseholdState(error: unknown) {
+  return error instanceof ApiQueryError && error.isCode("HOUSEHOLD_NOT_FOUND");
+}
+
+function SummarySkeleton() {
+  return (
+    <div className="bg-white rounded-2xl p-6 shadow-sm mb-6">
+      <Skeleton className="h-4 w-36 mb-4" />
+      <div className="space-y-3">
+        <div className="flex justify-between items-end">
+          <Skeleton className="h-5 w-16" />
+          <Skeleton className="h-9 w-40" />
+        </div>
+        <div className="h-px bg-gray-100" />
+        <div className="flex justify-between">
+          <Skeleton className="h-4 w-10" />
+          <Skeleton className="h-4 w-28" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CategoryPreviewSkeleton() {
+  return (
+    <div className="bg-white rounded-2xl p-5 shadow-sm mb-6">
+      <Skeleton className="h-4 w-28 mb-4" />
+      <div className="space-y-3">
+        {[0, 1, 2].map((item) => (
+          <div key={item} className="space-y-2">
+            <div className="flex justify-between">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-4 w-20" />
+            </div>
+            <Skeleton className="h-1.5 w-full" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function EmptyState({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="bg-white rounded-2xl p-6 shadow-sm mb-6">
+      <p className="text-sm text-gray-400 text-center">{children}</p>
+    </div>
+  );
+}
+
+export function LedgerAnalysisOverview({
+  year,
+  month,
+  scope,
+}: LedgerAnalysisOverviewProps) {
+  const summaryQuery = useLedgerStatsSummary(year, month);
+  const categoryQuery = useLedgerStatsByCategory(year, month, "expense", scope);
+
+  const scopeLabel = scope === "personal" ? "개인" : "공용";
+
+  return (
+    <>
+      {summaryQuery.isLoading ? (
+        <SummarySkeleton />
+      ) : summaryQuery.error ? (
+        <EmptyState>
+          {isNoHouseholdState(summaryQuery.error)
+            ? "가구 정보를 불러올 수 없어요"
+            : "현금 흐름을 불러오지 못했어요"}
+        </EmptyState>
+      ) : summaryQuery.data ? (
+        <SummaryStatCard summary={summaryQuery.data} scope={scope} />
+      ) : (
+        <EmptyState>
+          {month}월 {scopeLabel} 요약이 없어요
+        </EmptyState>
+      )}
+
+      {categoryQuery.isLoading ? (
+        <CategoryPreviewSkeleton />
+      ) : categoryQuery.error ? (
+        <EmptyState>
+          {isNoHouseholdState(categoryQuery.error)
+            ? "가구 정보를 불러올 수 없어요"
+            : "주요 지출을 불러오지 못했어요"}
+        </EmptyState>
+      ) : (
+        <CategoryTopPreview
+          emptyLabel={`이번 달 주요 ${scopeLabel} 지출이 없어요`}
+          items={categoryQuery.data?.items ?? []}
+          total={categoryQuery.data?.total ?? 0}
+          title={`이번 달 주요 ${scopeLabel} 지출`}
+        />
+      )}
+    </>
+  );
+}

--- a/components/ledger/analysis/SummaryStatCard.tsx
+++ b/components/ledger/analysis/SummaryStatCard.tsx
@@ -23,13 +23,14 @@ export function SummaryStatCard({ summary, scope }: SummaryStatCardProps) {
   const balance = income - expense;
   const savingsRate = calcSavingsRate(income, expense);
 
-  const scopeLabel = scope === "personal" ? "내 개인" : "공용";
+  const title =
+    scope === "personal"
+      ? `${month}월 내 개인 지출`
+      : `${month}월 공용 현금 흐름`;
 
   return (
     <div className="bg-white rounded-2xl p-6 shadow-sm mb-6">
-      <h2 className="text-sm text-gray-500 mb-4">
-        {month}월 {scopeLabel} 현금 흐름
-      </h2>
+      <h2 className="text-sm text-gray-500 mb-4">{title}</h2>
 
       <div className="space-y-3">
         {scope !== "personal" && (

--- a/hooks/use-ledger-entries.ts
+++ b/hooks/use-ledger-entries.ts
@@ -1,7 +1,11 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import type { LedgerEntryWithDetails } from "@/lib/api/ledger";
+import { fetchApiData } from "@/lib/api/client";
+import type {
+  LedgerEntrySummary,
+  LedgerEntryWithDetails,
+} from "@/lib/api/ledger";
 import { queries } from "@/lib/queries/keys";
 import type {
   CreateLedgerEntryInput,
@@ -63,6 +67,21 @@ export function useLedgerEntries(params?: LedgerEntriesParams) {
   return useQuery({
     queryKey: queries.ledgerEntries.list(params).queryKey,
     queryFn: () => fetchLedgerEntries(params),
+    staleTime: 1000 * 60 * 5,
+  });
+}
+
+// ============================================================================
+// 월간 수입/지출 요약 조회
+// ============================================================================
+
+export function useLedgerEntrySummary(year: number, month: number) {
+  return useQuery({
+    queryKey: queries.ledgerEntries.summary(year, month).queryKey,
+    queryFn: () =>
+      fetchApiData<LedgerEntrySummary>(
+        `/api/ledger-entries/summary?year=${year}&month=${month}`,
+      ),
     staleTime: 1000 * 60 * 5,
   });
 }

--- a/hooks/use-ledger-stats.ts
+++ b/hooks/use-ledger-stats.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
+import { fetchApiData } from "@/lib/api/client";
 import type {
   LedgerStatsByCategoryResult,
   LedgerStatsByMemberResult,
@@ -12,25 +13,11 @@ import type {
 } from "@/lib/api/ledger-stats";
 import { queries } from "@/lib/queries/keys";
 
-interface StatsError {
-  error: { code: string; message: string };
-}
-
-async function fetchJson<T>(url: string): Promise<T> {
-  const response = await fetch(url);
-  const json = await response.json();
-  if (!response.ok) {
-    const err = json as StatsError;
-    throw new Error(err.error?.message ?? "통계 조회에 실패했습니다.");
-  }
-  return (json as { data: T }).data;
-}
-
 export function useLedgerStatsSummary(year: number, month: number) {
   return useQuery({
     queryKey: queries.ledgerStats.summary(year, month).queryKey,
     queryFn: () =>
-      fetchJson<LedgerStatsSummary>(
+      fetchApiData<LedgerStatsSummary>(
         `/api/ledger/stats/summary?year=${year}&month=${month}`,
       ),
     staleTime: 1000 * 60 * 5,
@@ -41,7 +28,7 @@ export function useLedgerStatsByMember(year: number, month: number) {
   return useQuery({
     queryKey: queries.ledgerStats.byMember(year, month).queryKey,
     queryFn: () =>
-      fetchJson<LedgerStatsByMemberResult>(
+      fetchApiData<LedgerStatsByMemberResult>(
         `/api/ledger/stats/by-member?year=${year}&month=${month}`,
       ),
     staleTime: 1000 * 60 * 5,
@@ -57,7 +44,7 @@ export function useLedgerStatsByCategory(
   return useQuery({
     queryKey: queries.ledgerStats.byCategory(year, month, type, scope).queryKey,
     queryFn: () =>
-      fetchJson<LedgerStatsByCategoryResult>(
+      fetchApiData<LedgerStatsByCategoryResult>(
         `/api/ledger/stats/by-category?year=${year}&month=${month}&type=${type}&scope=${scope}`,
       ),
     staleTime: 1000 * 60 * 5,
@@ -72,7 +59,7 @@ export function useLedgerStatsByPaymentMethod(
   return useQuery({
     queryKey: queries.ledgerStats.byPaymentMethod(year, month, scope).queryKey,
     queryFn: () =>
-      fetchJson<LedgerStatsByPaymentMethodResult>(
+      fetchApiData<LedgerStatsByPaymentMethodResult>(
         `/api/ledger/stats/by-payment-method?year=${year}&month=${month}&scope=${scope}`,
       ),
     staleTime: 1000 * 60 * 5,
@@ -83,7 +70,7 @@ export function useLedgerStatsTrend(months = 6, scope?: string) {
   return useQuery({
     queryKey: queries.ledgerStats.trend(months, scope).queryKey,
     queryFn: () =>
-      fetchJson<LedgerStatsTrendResult>(
+      fetchApiData<LedgerStatsTrendResult>(
         `/api/ledger/stats/trend?months=${months}${scope ? `&scope=${scope}` : ""}`,
       ),
     staleTime: 1000 * 60 * 5,
@@ -98,7 +85,7 @@ export function useLedgerStatsDaily(
   return useQuery({
     queryKey: queries.ledgerStats.daily(year, month, scope).queryKey,
     queryFn: () =>
-      fetchJson<LedgerStatsDailyResult>(
+      fetchApiData<LedgerStatsDailyResult>(
         `/api/ledger/stats/daily?year=${year}&month=${month}&scope=${scope}`,
       ),
     staleTime: 1000 * 60 * 5,

--- a/lib/api/client.test.ts
+++ b/lib/api/client.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ApiQueryError, fetchApiData } from "@/lib/api/client";
+
+describe("fetchApiData", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("API 에러 코드와 상태 코드를 보존한다", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({
+        error: {
+          code: "HOUSEHOLD_NOT_FOUND",
+          message: "가구 정보를 찾을 수 없습니다.",
+        },
+      }),
+    } as Response);
+
+    await expect(fetchApiData("/api/example")).rejects.toMatchObject({
+      code: "HOUSEHOLD_NOT_FOUND",
+      status: 404,
+      message: "가구 정보를 찾을 수 없습니다.",
+    });
+  });
+
+  it("성공 응답의 data를 반환한다", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: { total: 1000 } }),
+    } as Response);
+
+    await expect(
+      fetchApiData<{ total: number }>("/api/example"),
+    ).resolves.toEqual({ total: 1000 });
+  });
+
+  it("ApiQueryError로 가구 없음 상태를 식별할 수 있다", () => {
+    const error = new ApiQueryError(
+      "HOUSEHOLD_NOT_FOUND",
+      "가구 정보를 찾을 수 없습니다.",
+      404,
+    );
+
+    expect(error.isCode("HOUSEHOLD_NOT_FOUND")).toBe(true);
+  });
+});

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -1,0 +1,41 @@
+export class ApiQueryError extends Error {
+  constructor(
+    public code: string,
+    public override message: string,
+    public status: number,
+  ) {
+    super(message);
+    this.name = "ApiQueryError";
+  }
+
+  isCode(code: string) {
+    return this.code === code;
+  }
+}
+
+interface ApiDataResponse<T> {
+  data: T;
+}
+
+interface ApiErrorResponse {
+  error?: {
+    code?: string;
+    message?: string;
+  };
+}
+
+export async function fetchApiData<T>(url: string): Promise<T> {
+  const response = await fetch(url);
+  const json = (await response.json()) as ApiDataResponse<T> | ApiErrorResponse;
+
+  if (!response.ok) {
+    const error = (json as ApiErrorResponse).error;
+    throw new ApiQueryError(
+      error?.code ?? "UNKNOWN_ERROR",
+      error?.message ?? "요청에 실패했습니다.",
+      response.status,
+    );
+  }
+
+  return (json as ApiDataResponse<T>).data;
+}


### PR DESCRIPTION
## Summary
- Move /ledger monthly cash flow summary from server-side aggregation to a React Query client section.
- Move /ledger/analysis summary and category preview from SSR aggregation to client-side API queries with skeleton, empty, and error states.
- Preserve API error codes in client query errors so HOUSEHOLD_NOT_FOUND can render as a no-household setup state.

## Notes
- Existing lower analysis pages were checked for server-side ledger stats aggregation and did not need changes.
- personal scope copy now reflects personal spending rather than personal cash flow.

## Validation
- pnpm test passed: 35 test files, 213 tests.