### PR TITLE
[codex] Add oat MCP bridge package

### DIFF
--- a/.claude/docs/MCP_USAGE.md
+++ b/.claude/docs/MCP_USAGE.md
@@ -93,23 +93,226 @@ curl -i -X POST https://YOUR_DOMAIN/api/mcp \
 
 ## MCP 클라이언트 연결
 
-원격 MCP URL은 다음 형식입니다.
+stdio MCP 클라이언트는 npm bridge 패키지를 통해 oat hosted MCP endpoint에 연결합니다.
+
+패키지:
 
 ```text
-https://YOUR_DOMAIN/api/mcp
+@oat-app/mcp-bridge
 ```
 
-인증 헤더:
+기본 endpoint:
 
 ```text
-Authorization: Bearer YOUR_TOKEN
+https://oat-blond.vercel.app/api/mcp
 ```
 
-클라이언트가 protocol version을 설정할 수 있으면 다음 값을 사용합니다.
+환경변수:
 
 ```text
-MCP-Protocol-Version: 2025-06-18
+OAT_MCP_TOKEN       필수. /settings/mcp에서 발급한 토큰
+OAT_MCP_URL         선택. preview/staging endpoint override
+OAT_MCP_DEBUG       선택. 1이면 stderr debug 로그 출력
+OAT_MCP_TIMEOUT_MS  선택. 기본 30000
 ```
+
+토큰은 command args로 받지 않습니다.
+
+### Claude Code
+
+Claude Code는 `claude mcp add`로 stdio server를 등록합니다.
+
+```bash
+claude mcp add oat \
+  --transport stdio \
+  --env OAT_MCP_TOKEN=oat_mcp_xxx \
+  -- npx -y @oat-app/mcp-bridge
+```
+
+확인:
+
+```bash
+claude mcp list
+claude mcp get oat
+```
+
+배포 전에는 npm 패키지 대신 빌드된 로컬 CLI를 등록해서 테스트합니다.
+
+```bash
+pnpm --filter @oat-app/mcp-bridge build
+```
+
+```bash
+claude mcp add oat-local \
+  --transport stdio \
+  --env OAT_MCP_TOKEN=oat_mcp_xxx \
+  --env OAT_MCP_DEBUG=1 \
+  -- node /Users/jinho/project/oat-287/packages/mcp-bridge/dist/index.js
+```
+
+확인:
+
+```bash
+claude mcp list
+claude mcp get oat-local
+```
+
+테스트 후 제거:
+
+```bash
+claude mcp remove oat-local
+```
+
+### Codex
+
+Codex는 `~/.codex/config.toml`의 `mcp_servers`에 stdio server를 등록합니다.
+
+```toml
+[mcp_servers.oat]
+command = "npx"
+args = ["-y", "@oat-app/mcp-bridge"]
+env = { OAT_MCP_TOKEN = "oat_mcp_xxx" }
+```
+
+배포 전에는 npm 패키지 대신 빌드된 로컬 CLI를 등록해서 테스트합니다.
+
+```bash
+pnpm --filter @oat-app/mcp-bridge build
+```
+
+```toml
+[mcp_servers.oat-local]
+command = "node"
+args = ["/Users/jinho/project/oat-287/packages/mcp-bridge/dist/index.js"]
+env = { OAT_MCP_TOKEN = "oat_mcp_xxx", OAT_MCP_DEBUG = "1" }
+```
+
+새 Codex 세션을 시작한 뒤 oat MCP tool 목록 조회나 `get_context` 호출을 요청합니다. 테스트 후 `oat-local` 설정은 제거합니다.
+
+### ChatGPT
+
+ChatGPT는 stdio bridge 패키지를 실행하지 않습니다. ChatGPT 테스트는 hosted remote MCP endpoint를 직접 대상으로 합니다.
+
+```text
+https://oat-blond.vercel.app/api/mcp
+```
+
+현재 oat v0는 personal bearer token 방식이므로, 배포 전 ChatGPT 경로 검증은 OpenAI Responses API의 remote MCP tool 테스트가 가장 명확합니다.
+
+```bash
+curl https://api.openai.com/v1/responses \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-5.1",
+    "input": "Use the oat MCP server to list available tools, then call get_context.",
+    "tools": [
+      {
+        "type": "mcp",
+        "server_label": "oat",
+        "server_url": "https://oat-blond.vercel.app/api/mcp",
+        "authorization": "Bearer oat_mcp_xxx"
+      }
+    ]
+  }'
+```
+
+ChatGPT 웹 custom connector도 같은 remote endpoint를 사용합니다. 다만 connector 설정에서 bearer token을 remote MCP server에 전달할 수 없으면 oat v0에서는 정상 제약입니다. ChatGPT 웹 connector의 완전 지원은 OAuth 기반 MCP auth 단계에서 다룹니다.
+
+### Claude Desktop
+
+`claude_desktop_config.json`의 `mcpServers`에 추가합니다.
+
+```json
+{
+  "mcpServers": {
+    "oat": {
+      "command": "npx",
+      "args": ["-y", "@oat-app/mcp-bridge"],
+      "env": {
+        "OAT_MCP_TOKEN": "oat_mcp_xxx"
+      }
+    }
+  }
+}
+```
+
+### Preview endpoint
+
+상용 endpoint가 아닌 preview 배포를 테스트할 때만 `OAT_MCP_URL`을 추가합니다.
+
+```json
+{
+  "env": {
+    "OAT_MCP_TOKEN": "oat_mcp_xxx",
+    "OAT_MCP_URL": "https://YOUR_PREVIEW_DOMAIN/api/mcp"
+  }
+}
+```
+
+## Bridge 패키지 배포
+
+패키지는 `packages/mcp-bridge`에서 관리하고 npm에는 `@oat-app/mcp-bridge`로 공개 배포합니다.
+
+배포 전 검증:
+
+```bash
+pnpm mcp-bridge:prepublish
+```
+
+실제 endpoint smoke test:
+
+```bash
+OAT_MCP_TOKEN=oat_mcp_xxx pnpm --filter @oat-app/mcp-bridge smoke
+```
+
+Codex 로컬 CLI 테스트:
+
+```bash
+pnpm --filter @oat-app/mcp-bridge build
+```
+
+`~/.codex/config.toml`:
+
+```toml
+[mcp_servers.oat-local]
+command = "node"
+args = ["/Users/jinho/project/oat-287/packages/mcp-bridge/dist/index.js"]
+env = { OAT_MCP_TOKEN = "oat_mcp_xxx", OAT_MCP_DEBUG = "1" }
+```
+
+ChatGPT/Responses API remote MCP 테스트:
+
+```bash
+curl https://api.openai.com/v1/responses \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-5.1",
+    "input": "Use the oat MCP server to list available tools, then call get_context.",
+    "tools": [
+      {
+        "type": "mcp",
+        "server_label": "oat",
+        "server_url": "https://oat-blond.vercel.app/api/mcp",
+        "authorization": "Bearer oat_mcp_xxx"
+      }
+    ]
+  }'
+```
+
+배포:
+
+```bash
+npm whoami
+pnpm mcp-bridge:publish
+```
+
+주의:
+
+- `@oat-app` npm scope에 publish 권한이 있어야 합니다.
+- npm 2FA가 켜져 있으면 publish 단계에서 OTP가 필요할 수 있습니다.
+- publish 전 `pack --dry-run`으로 npm tarball에 `dist`, `README.md`, `LICENSE`만 포함되는지 확인합니다.
 
 ## 보안 주의사항
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+/packages/*/node_modules/
 /.pnpm-store
 /.pnp
 .pnp.*
@@ -40,6 +41,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+/packages/*/dist/
 
 .mcp.json
 

--- a/components/settings/McpTokenManager.tsx
+++ b/components/settings/McpTokenManager.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { Check, Copy, KeyRound, Loader2, Plus, RotateCcw } from "lucide-react";
+import {
+  Check,
+  Copy,
+  KeyRound,
+  Loader2,
+  Plus,
+  RotateCcw,
+  Terminal,
+} from "lucide-react";
 import { useEffect, useState, useTransition } from "react";
 import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
@@ -63,8 +71,30 @@ export function McpTokenManager() {
   const [name, setName] = useState("Claude");
   const [createdToken, setCreatedToken] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  const [copiedGuide, setCopiedGuide] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isPending, startTransition] = useTransition();
+  const tokenForGuide = createdToken ?? "oat_mcp_xxx";
+  const claudeCodeCommand = `claude mcp add oat \\
+  --transport stdio \\
+  --env OAT_MCP_TOKEN=${tokenForGuide} \\
+  -- npx -y @oat-app/mcp-bridge`;
+  const codexConfig = `[mcp_servers.oat]
+command = "npx"
+args = ["-y", "@oat-app/mcp-bridge"]
+env = { OAT_MCP_TOKEN = "${tokenForGuide}" }`;
+  const claudeDesktopConfig = `{
+  "mcpServers": {
+    "oat": {
+      "command": "npx",
+      "args": ["-y", "@oat-app/mcp-bridge"],
+      "env": {
+        "OAT_MCP_TOKEN": "${tokenForGuide}"
+      }
+    }
+  }
+}`;
+  const previewOverride = `OAT_MCP_URL=https://YOUR_PREVIEW_DOMAIN/api/mcp`;
 
   useEffect(() => {
     let isMounted = true;
@@ -154,6 +184,12 @@ export function McpTokenManager() {
     toast.success("토큰을 복사했습니다.");
   };
 
+  const handleCopyGuide = async (key: string, value: string) => {
+    await navigator.clipboard.writeText(value);
+    setCopiedGuide(key);
+    toast.success("설정을 복사했습니다.");
+  };
+
   return (
     <div className="space-y-4">
       <Card>
@@ -212,6 +248,63 @@ export function McpTokenManager() {
               </p>
             </div>
           )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Terminal className="h-4 w-4" />
+            클라이언트 연결
+          </CardTitle>
+          <CardDescription>
+            @oat-app/mcp-bridge는 기본적으로 oat 상용 MCP endpoint에 연결합니다.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <ConnectionSnippet
+            title="Claude Code"
+            value={claudeCodeCommand}
+            copied={copiedGuide === "claude-code"}
+            onCopy={() => handleCopyGuide("claude-code", claudeCodeCommand)}
+          />
+          <ConnectionSnippet
+            title="Codex"
+            value={codexConfig}
+            copied={copiedGuide === "codex"}
+            onCopy={() => handleCopyGuide("codex", codexConfig)}
+          />
+          <ConnectionSnippet
+            title="Claude Desktop"
+            value={claudeDesktopConfig}
+            copied={copiedGuide === "claude-desktop"}
+            onCopy={() =>
+              handleCopyGuide("claude-desktop", claudeDesktopConfig)
+            }
+          />
+          <div className="rounded-lg border border-dashed p-3">
+            <div className="mb-2 flex items-center justify-between gap-3">
+              <p className="text-sm font-medium text-gray-900">
+                Preview endpoint
+              </p>
+              <Button
+                type="button"
+                variant="outline"
+                size="icon-sm"
+                onClick={() => handleCopyGuide("preview", previewOverride)}
+                aria-label="Preview endpoint 설정 복사"
+              >
+                {copiedGuide === "preview" ? (
+                  <Check className="h-4 w-4" />
+                ) : (
+                  <Copy className="h-4 w-4" />
+                )}
+              </Button>
+            </div>
+            <code className="block break-all rounded bg-gray-50 p-2 text-xs text-gray-800">
+              {previewOverride}
+            </code>
+          </div>
         </CardContent>
       </Card>
 
@@ -276,6 +369,44 @@ export function McpTokenManager() {
           )}
         </CardContent>
       </Card>
+    </div>
+  );
+}
+
+interface ConnectionSnippetProps {
+  title: string;
+  value: string;
+  copied: boolean;
+  onCopy: () => void;
+}
+
+function ConnectionSnippet({
+  title,
+  value,
+  copied,
+  onCopy,
+}: ConnectionSnippetProps) {
+  return (
+    <div className="rounded-lg border p-3">
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <p className="text-sm font-medium text-gray-900">{title}</p>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon-sm"
+          onClick={onCopy}
+          aria-label={`${title} MCP 설정 복사`}
+        >
+          {copied ? (
+            <Check className="h-4 w-4" />
+          ) : (
+            <Copy className="h-4 w-4" />
+          )}
+        </Button>
+      </div>
+      <pre className="max-h-64 overflow-x-auto rounded bg-gray-50 p-3 text-xs leading-relaxed text-gray-800">
+        <code>{value}</code>
+      </pre>
     </div>
   );
 }

--- a/docs/adr/0002-package-oat-mcp-bridge-as-workspace-package.md
+++ b/docs/adr/0002-package-oat-mcp-bridge-as-workspace-package.md
@@ -1,0 +1,7 @@
+# Package oat MCP bridge as a workspace package
+
+oat exposes its real MCP server as the hosted Streamable HTTP endpoint at `/api/mcp`, but Claude Code, Codex, and Claude Desktop may still need a stdio MCP process to connect reliably. We will keep the Next.js app at the repository root and add only `packages/mcp-bridge` as a lightweight pnpm workspace package, published publicly as `@oat-app/mcp-bridge@0.1.0` under MIT.
+
+The bridge is a transport adapter, not a second source of MCP tools: tokens remain env-only, auth and data access stay on the hosted oat server, and tool definitions are not duplicated in the package. It will use the official MCP TypeScript SDK for stdio/protocol behavior, default to `https://oat-blond.vercel.app/api/mcp` when `OAT_MCP_URL` is not set, support `OAT_MCP_DEBUG=1` for stderr-only diagnostics, and keep JSON-RPC response normalization in isolated modules with tests.
+
+We are deliberately not moving the app into `apps/web` yet and not creating a shared package for MCP contracts. That avoids a broad repo migration and prevents the bridge from depending on oat server internals; if more packages or shared contracts appear later, the workspace can expand without changing this bridge boundary.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,11 @@
     "sync:holiday": "tsx scripts/sync-holiday.ts",
     "test": "vitest run",
     "test:watch": "vitest",
+    "mcp-bridge:build": "pnpm --filter @oat-app/mcp-bridge build",
+    "mcp-bridge:test": "pnpm --filter @oat-app/mcp-bridge test",
+    "mcp-bridge:pack": "pnpm --filter @oat-app/mcp-bridge pack --dry-run",
+    "mcp-bridge:prepublish": "pnpm mcp-bridge:build && pnpm mcp-bridge:test && pnpm mcp-bridge:pack",
+    "mcp-bridge:publish": "pnpm mcp-bridge:prepublish && pnpm --filter @oat-app/mcp-bridge publish --access public",
     "prepare": "husky"
   },
   "dependencies": {

--- a/packages/mcp-bridge/LICENSE
+++ b/packages/mcp-bridge/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 oat
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/mcp-bridge/README.md
+++ b/packages/mcp-bridge/README.md
@@ -1,0 +1,122 @@
+# @oat-app/mcp-bridge
+
+`@oat-app/mcp-bridge` connects stdio MCP clients to the hosted oat MCP endpoint.
+
+The oat MCP server remains hosted at `https://oat-blond.vercel.app/api/mcp`.
+This package is only a local transport bridge.
+
+## Claude Code
+
+```bash
+claude mcp add oat \
+  --transport stdio \
+  --env OAT_MCP_TOKEN=oat_mcp_xxx \
+  -- npx -y @oat-app/mcp-bridge
+```
+
+Use a preview endpoint only when needed:
+
+```bash
+claude mcp add oat-preview \
+  --transport stdio \
+  --env OAT_MCP_TOKEN=oat_mcp_xxx \
+  --env OAT_MCP_URL=https://YOUR_PREVIEW_DOMAIN/api/mcp \
+  -- npx -y @oat-app/mcp-bridge
+```
+
+Verify with:
+
+```bash
+claude mcp list
+claude mcp get oat
+```
+
+## Generic MCP JSON
+
+Use this form for clients that accept `mcpServers` JSON.
+
+```json
+{
+  "mcpServers": {
+    "oat": {
+      "command": "npx",
+      "args": ["-y", "@oat-app/mcp-bridge"],
+      "env": {
+        "OAT_MCP_TOKEN": "oat_mcp_xxx"
+      }
+    }
+  }
+}
+```
+
+## Claude Desktop
+
+Add the same server entry to `claude_desktop_config.json`.
+
+```json
+{
+  "mcpServers": {
+    "oat": {
+      "command": "npx",
+      "args": ["-y", "@oat-app/mcp-bridge"],
+      "env": {
+        "OAT_MCP_TOKEN": "oat_mcp_xxx"
+      }
+    }
+  }
+}
+```
+
+## Codex
+
+Add this to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.oat]
+command = "npx"
+args = ["-y", "@oat-app/mcp-bridge"]
+env = { OAT_MCP_TOKEN = "oat_mcp_xxx" }
+```
+
+## ChatGPT
+
+ChatGPT does not use this stdio bridge package. For ChatGPT, test the hosted
+remote MCP endpoint directly:
+
+```text
+https://oat-blond.vercel.app/api/mcp
+```
+
+## Environment
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `OAT_MCP_TOKEN` | Yes | oat MCP token from `/settings/mcp` |
+| `OAT_MCP_URL` | No | Endpoint override. Defaults to `https://oat-blond.vercel.app/api/mcp` |
+| `OAT_MCP_DEBUG` | No | Set to `1` for stderr debug logs |
+| `OAT_MCP_TIMEOUT_MS` | No | Request timeout. Defaults to `30000` |
+
+Tokens are accepted only through environment variables. `--token` and `--url`
+arguments are intentionally not supported.
+
+## Debugging
+
+```json
+{
+  "env": {
+    "OAT_MCP_TOKEN": "oat_mcp_xxx",
+    "OAT_MCP_DEBUG": "1"
+  }
+}
+```
+
+Debug logs are written to stderr. stdout is reserved for MCP protocol messages.
+Token values are not printed.
+
+## Local Smoke Test
+
+```bash
+OAT_MCP_TOKEN=oat_mcp_xxx pnpm --filter @oat-app/mcp-bridge smoke
+```
+
+Use `OAT_MCP_URL` to test a preview deployment.

--- a/packages/mcp-bridge/package.json
+++ b/packages/mcp-bridge/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@oat-app/mcp-bridge",
+  "version": "0.1.0",
+  "description": "stdio MCP bridge for the hosted oat MCP endpoint",
+  "license": "MIT",
+  "type": "module",
+  "bin": {
+    "oat-mcp-bridge": "dist/index.js"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run",
+    "smoke": "tsx scripts/smoke.ts",
+    "prepublishOnly": "pnpm build && pnpm test"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.23.3"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "tsx": "^4.21.0",
+    "typescript": "^5",
+    "vitest": "^4.1.3"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/mcp-bridge/scripts/smoke.ts
+++ b/packages/mcp-bridge/scripts/smoke.ts
@@ -1,0 +1,39 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { loadConfig } from "../src/config.js";
+import { PACKAGE_NAME, PACKAGE_VERSION } from "../src/constants.js";
+
+const config = loadConfig();
+
+const client = new Client({
+  name: `${PACKAGE_NAME}-smoke`,
+  version: PACKAGE_VERSION,
+});
+
+const transport = new StreamableHTTPClientTransport(config.url, {
+  requestInit: {
+    headers: {
+      Authorization: `Bearer ${config.token}`,
+      "User-Agent": `${PACKAGE_NAME}-smoke/${PACKAGE_VERSION}`,
+      "X-Oat-Mcp-Bridge": PACKAGE_NAME,
+    },
+  },
+});
+transport.setProtocolVersion(config.protocolVersion);
+
+try {
+  await client.connect(transport, { timeout: config.timeoutMs });
+  const tools = await client.listTools(undefined, {
+    timeout: config.timeoutMs,
+  });
+  process.stdout.write(
+    `Connected to ${config.url.toString()} and found ${tools.tools.length} tools.\n`,
+  );
+
+  await client.callTool({ name: "get_context", arguments: {} }, undefined, {
+    timeout: config.timeoutMs,
+  });
+  process.stdout.write("get_context smoke call succeeded.\n");
+} finally {
+  await client.close();
+}

--- a/packages/mcp-bridge/src/bridge.ts
+++ b/packages/mcp-bridge/src/bridge.ts
@@ -1,0 +1,60 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import type { BridgeConfig } from "./config.js";
+import { PACKAGE_NAME, PACKAGE_VERSION } from "./constants.js";
+import type { Logger } from "./logger.js";
+import { RemoteMcpClient } from "./remote.js";
+
+export async function runBridge(
+  config: BridgeConfig,
+  logger: Logger,
+): Promise<void> {
+  const remote = new RemoteMcpClient(config, logger);
+  await remote.connect();
+
+  const server = new Server(
+    {
+      name: PACKAGE_NAME,
+      version: PACKAGE_VERSION,
+    },
+    {
+      capabilities: {
+        tools: {},
+      },
+    },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, (request) =>
+    remote.listTools(request.params),
+  );
+  server.setRequestHandler(CallToolRequestSchema, (request) =>
+    remote.callTool(request.params),
+  );
+
+  const transport = new StdioServerTransport();
+  transport.onerror = (error) => {
+    logger.error("stdio transport error", { message: error.message });
+  };
+
+  const close = async () => {
+    await server.close();
+    await remote.close();
+  };
+
+  process.once("SIGINT", () => {
+    close()
+      .catch((error: unknown) => {
+        logger.error("failed to close bridge", {
+          message: error instanceof Error ? error.message : String(error),
+        });
+      })
+      .finally(() => process.exit(0));
+  });
+
+  await server.connect(transport);
+  logger.debug("stdio bridge started", { url: config.url.toString() });
+}

--- a/packages/mcp-bridge/src/config.test.ts
+++ b/packages/mcp-bridge/src/config.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { ConfigError, loadConfig } from "./config.js";
+import { DEFAULT_MCP_URL, DEFAULT_TIMEOUT_MS } from "./constants.js";
+
+describe("loadConfig", () => {
+  it("uses the hosted oat MCP URL by default", () => {
+    const config = loadConfig({ OAT_MCP_TOKEN: "oat_mcp_test" });
+
+    expect(config.url.toString()).toBe(DEFAULT_MCP_URL);
+    expect(config.timeoutMs).toBe(DEFAULT_TIMEOUT_MS);
+    expect(config.debug).toBe(false);
+  });
+
+  it("allows endpoint, timeout, and debug overrides", () => {
+    const config = loadConfig({
+      OAT_MCP_TOKEN: "oat_mcp_test",
+      OAT_MCP_URL: "https://preview.example.com/api/mcp",
+      OAT_MCP_TIMEOUT_MS: "1000",
+      OAT_MCP_DEBUG: "1",
+    });
+
+    expect(config.url.toString()).toBe("https://preview.example.com/api/mcp");
+    expect(config.timeoutMs).toBe(1000);
+    expect(config.debug).toBe(true);
+  });
+
+  it("requires an MCP token", () => {
+    expect(() => loadConfig({})).toThrow(ConfigError);
+    expect(() => loadConfig({ OAT_MCP_TOKEN: " " })).toThrow(
+      "OAT_MCP_TOKEN is required.",
+    );
+  });
+
+  it("requires a valid timeout", () => {
+    expect(() =>
+      loadConfig({
+        OAT_MCP_TOKEN: "oat_mcp_test",
+        OAT_MCP_TIMEOUT_MS: "0",
+      }),
+    ).toThrow("OAT_MCP_TIMEOUT_MS must be a positive integer.");
+  });
+});

--- a/packages/mcp-bridge/src/config.ts
+++ b/packages/mcp-bridge/src/config.ts
@@ -1,0 +1,60 @@
+import {
+  DEFAULT_MCP_URL,
+  DEFAULT_TIMEOUT_MS,
+  MCP_PROTOCOL_VERSION,
+  PACKAGE_NAME,
+  PACKAGE_VERSION,
+} from "./constants.js";
+
+export interface BridgeConfig {
+  url: URL;
+  token: string;
+  debug: boolean;
+  timeoutMs: number;
+  protocolVersion: string;
+  userAgent: string;
+}
+
+export class ConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ConfigError";
+  }
+}
+
+function parseTimeout(value: string | undefined): number {
+  if (!value) return DEFAULT_TIMEOUT_MS;
+
+  const timeoutMs = Number(value);
+  if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) {
+    throw new ConfigError("OAT_MCP_TIMEOUT_MS must be a positive integer.");
+  }
+
+  return timeoutMs;
+}
+
+function parseUrl(value: string | undefined): URL {
+  try {
+    return new URL(value ?? DEFAULT_MCP_URL);
+  } catch {
+    throw new ConfigError("OAT_MCP_URL must be a valid URL.");
+  }
+}
+
+export function loadConfig(
+  env: Record<string, string | undefined> = process.env,
+): BridgeConfig {
+  const token = env.OAT_MCP_TOKEN?.trim();
+  if (!token) {
+    throw new ConfigError("OAT_MCP_TOKEN is required.");
+  }
+
+  return {
+    url: parseUrl(env.OAT_MCP_URL?.trim() || undefined),
+    token,
+    debug: env.OAT_MCP_DEBUG === "1" || env.OAT_MCP_DEBUG === "true",
+    timeoutMs: parseTimeout(env.OAT_MCP_TIMEOUT_MS),
+    protocolVersion: MCP_PROTOCOL_VERSION,
+    userAgent: `${PACKAGE_NAME}/${PACKAGE_VERSION}`,
+  };
+}

--- a/packages/mcp-bridge/src/constants.ts
+++ b/packages/mcp-bridge/src/constants.ts
@@ -1,0 +1,5 @@
+export const PACKAGE_NAME = "@oat-app/mcp-bridge";
+export const PACKAGE_VERSION = "0.1.0";
+export const DEFAULT_MCP_URL = "https://oat-blond.vercel.app/api/mcp";
+export const MCP_PROTOCOL_VERSION = "2025-06-18";
+export const DEFAULT_TIMEOUT_MS = 30_000;

--- a/packages/mcp-bridge/src/index.ts
+++ b/packages/mcp-bridge/src/index.ts
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+import { runBridge } from "./bridge.js";
+import { loadConfig } from "./config.js";
+import { PACKAGE_NAME, PACKAGE_VERSION } from "./constants.js";
+import { createLogger } from "./logger.js";
+
+function printHelp() {
+  process.stdout.write(`${PACKAGE_NAME} ${PACKAGE_VERSION}
+
+Usage:
+  npx -y ${PACKAGE_NAME}
+
+Environment:
+  OAT_MCP_TOKEN       Required oat MCP token.
+  OAT_MCP_URL         Optional endpoint override.
+  OAT_MCP_DEBUG       Set to 1 for stderr debug logs.
+  OAT_MCP_TIMEOUT_MS  Optional request timeout in milliseconds.
+`);
+}
+
+async function main() {
+  const [arg] = process.argv.slice(2);
+
+  if (arg === "--help" || arg === "-h") {
+    printHelp();
+    return;
+  }
+
+  if (arg === "--version" || arg === "-v") {
+    process.stdout.write(`${PACKAGE_VERSION}\n`);
+    return;
+  }
+
+  if (arg) {
+    process.stderr.write(`Unknown argument: ${arg}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const config = loadConfig();
+  const logger = createLogger(config.debug);
+  await runBridge(config, logger);
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(
+    `[oat-mcp-bridge] ${error instanceof Error ? error.message : String(error)}\n`,
+  );
+  process.exit(1);
+});

--- a/packages/mcp-bridge/src/json-rpc.ts
+++ b/packages/mcp-bridge/src/json-rpc.ts
@@ -1,0 +1,37 @@
+export type JsonRpcId = string | number | null;
+
+export interface JsonRpcErrorObject {
+  code: number;
+  message: string;
+  data?: unknown;
+}
+
+export interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  id: JsonRpcId;
+  result?: unknown;
+  error?: JsonRpcErrorObject;
+}
+
+export function isJsonRpcResponse(value: unknown): value is JsonRpcResponse {
+  if (!value || typeof value !== "object") return false;
+
+  const candidate = value as Record<string, unknown>;
+  return (
+    candidate.jsonrpc === "2.0" &&
+    ("result" in candidate || "error" in candidate)
+  );
+}
+
+export function jsonRpcError(
+  id: JsonRpcId,
+  code: number,
+  message: string,
+  data?: unknown,
+): JsonRpcResponse {
+  return {
+    jsonrpc: "2.0",
+    id,
+    error: data === undefined ? { code, message } : { code, message, data },
+  };
+}

--- a/packages/mcp-bridge/src/logger.test.ts
+++ b/packages/mcp-bridge/src/logger.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createLogger } from "./logger.js";
+
+describe("createLogger", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("keeps debug logs silent unless enabled", () => {
+    const write = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    const logger = createLogger(false);
+
+    logger.debug("connected", { token: "oat_mcp_secret" });
+
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it("writes debug logs to stderr without token fields", () => {
+    const write = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    const logger = createLogger(true);
+
+    logger.debug("connected", {
+      token: "oat_mcp_secret",
+      url: "https://oat-blond.vercel.app/api/mcp",
+    });
+
+    expect(write).toHaveBeenCalledTimes(1);
+    const output = String(write.mock.calls[0]?.[0]);
+    expect(output).toContain("connected");
+    expect(output).toContain("oat-blond.vercel.app");
+    expect(output).not.toContain("oat_mcp_secret");
+  });
+});

--- a/packages/mcp-bridge/src/logger.ts
+++ b/packages/mcp-bridge/src/logger.ts
@@ -1,0 +1,33 @@
+export interface Logger {
+  debug(message: string, fields?: Record<string, unknown>): void;
+  error(message: string, fields?: Record<string, unknown>): void;
+}
+
+function safeFields(fields: Record<string, unknown> | undefined): string {
+  if (!fields) return "";
+
+  const sanitized = Object.fromEntries(
+    Object.entries(fields).filter(
+      ([key]) => !key.toLowerCase().includes("token"),
+    ),
+  );
+
+  if (Object.keys(sanitized).length === 0) return "";
+  return ` ${JSON.stringify(sanitized)}`;
+}
+
+export function createLogger(debugEnabled: boolean): Logger {
+  return {
+    debug(message, fields) {
+      if (!debugEnabled) return;
+      process.stderr.write(
+        `[oat-mcp-bridge] ${message}${safeFields(fields)}\n`,
+      );
+    },
+    error(message, fields) {
+      process.stderr.write(
+        `[oat-mcp-bridge] ${message}${safeFields(fields)}\n`,
+      );
+    },
+  };
+}

--- a/packages/mcp-bridge/src/remote.ts
+++ b/packages/mcp-bridge/src/remote.ts
@@ -1,0 +1,89 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type {
+  CallToolRequest,
+  ListToolsRequest,
+} from "@modelcontextprotocol/sdk/types.js";
+import type { BridgeConfig } from "./config.js";
+import { PACKAGE_NAME, PACKAGE_VERSION } from "./constants.js";
+import type { Logger } from "./logger.js";
+
+export class RemoteMcpClient {
+  private readonly client: Client;
+  private readonly transport: StreamableHTTPClientTransport;
+
+  constructor(
+    private readonly config: BridgeConfig,
+    private readonly logger: Logger,
+  ) {
+    this.client = new Client({
+      name: PACKAGE_NAME,
+      version: PACKAGE_VERSION,
+    });
+
+    this.transport = new StreamableHTTPClientTransport(config.url, {
+      requestInit: {
+        headers: {
+          Authorization: `Bearer ${config.token}`,
+          "User-Agent": config.userAgent,
+          "X-Oat-Mcp-Bridge": PACKAGE_NAME,
+        },
+      },
+    });
+    this.transport.setProtocolVersion(config.protocolVersion);
+  }
+
+  async connect(): Promise<void> {
+    const startedAt = Date.now();
+    this.logger.debug("connecting remote MCP", {
+      url: this.config.url.toString(),
+      timeoutMs: this.config.timeoutMs,
+    });
+
+    await this.client.connect(this.transport, {
+      timeout: this.config.timeoutMs,
+    });
+
+    this.logger.debug("connected remote MCP", {
+      durationMs: Date.now() - startedAt,
+    });
+  }
+
+  async close(): Promise<void> {
+    try {
+      await this.transport.terminateSession();
+    } catch {
+      // The oat v0 endpoint is stateless and may not support session DELETE.
+    }
+
+    await this.client.close();
+  }
+
+  async listTools(params?: ListToolsRequest["params"]) {
+    const startedAt = Date.now();
+    const result = await this.client.listTools(params, {
+      timeout: this.config.timeoutMs,
+    });
+
+    this.logger.debug("forwarded tools/list", {
+      durationMs: Date.now() - startedAt,
+      toolCount: result.tools.length,
+    });
+
+    return result;
+  }
+
+  async callTool(params: CallToolRequest["params"]) {
+    const startedAt = Date.now();
+    const result = await this.client.callTool(params, undefined, {
+      timeout: this.config.timeoutMs,
+    });
+
+    this.logger.debug("forwarded tools/call", {
+      durationMs: Date.now() - startedAt,
+      toolName: params.name,
+    });
+
+    return result;
+  }
+}

--- a/packages/mcp-bridge/src/response.test.ts
+++ b/packages/mcp-bridge/src/response.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { normalizeRemoteResponse } from "./response.js";
+
+describe("normalizeRemoteResponse", () => {
+  it("passes through valid JSON-RPC results", () => {
+    const response = normalizeRemoteResponse(
+      1,
+      JSON.stringify({ jsonrpc: "2.0", id: 1, result: { ok: true } }),
+    );
+
+    expect(response).toEqual({ jsonrpc: "2.0", id: 1, result: { ok: true } });
+  });
+
+  it("passes through valid JSON-RPC errors", () => {
+    const response = normalizeRemoteResponse(
+      1,
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        error: { code: -32000, message: "Unauthorized" },
+      }),
+    );
+
+    expect(response.error?.message).toBe("Unauthorized");
+  });
+
+  it("wraps non-JSON responses", () => {
+    const response = normalizeRemoteResponse(1, "<html>error</html>");
+
+    expect(response.error?.code).toBe(-32603);
+    expect(response.error?.message).toContain("non-JSON");
+  });
+
+  it("wraps JSON that is not JSON-RPC", () => {
+    const response = normalizeRemoteResponse(1, JSON.stringify({ ok: false }));
+
+    expect(response.error?.code).toBe(-32603);
+    expect(response.error?.message).toContain("invalid JSON-RPC");
+  });
+});

--- a/packages/mcp-bridge/src/response.ts
+++ b/packages/mcp-bridge/src/response.ts
@@ -1,0 +1,33 @@
+import {
+  isJsonRpcResponse,
+  type JsonRpcId,
+  type JsonRpcResponse,
+  jsonRpcError,
+} from "./json-rpc.js";
+
+export function normalizeRemoteResponse(
+  requestId: JsonRpcId,
+  bodyText: string,
+): JsonRpcResponse {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(bodyText);
+  } catch {
+    return jsonRpcError(
+      requestId,
+      -32603,
+      "oat MCP server returned a non-JSON response.",
+    );
+  }
+
+  if (isJsonRpcResponse(parsed)) {
+    return parsed;
+  }
+
+  return jsonRpcError(
+    requestId,
+    -32603,
+    "oat MCP server returned an invalid JSON-RPC response.",
+  );
+}

--- a/packages/mcp-bridge/tsconfig.json
+++ b/packages/mcp-bridge/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "declaration": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/mcp-bridge/vitest.config.ts
+++ b/packages/mcp-bridge/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,6 +184,25 @@ importers:
         specifier: ^4.1.3
         version: 4.1.3(@types/node@20.19.27)(jsdom@29.0.2)(vite@8.0.6(@types/node@20.19.27)(esbuild@0.27.2)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
 
+  packages/mcp-bridge:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.23.3
+        version: 1.29.0(zod@4.2.1)
+    devDependencies:
+      '@types/node':
+        specifier: ^20
+        version: 20.19.27
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.3
+        version: 4.1.3(@types/node@20.19.27)(jsdom@29.0.2)(vite@8.0.6(@types/node@20.19.27)(esbuild@0.27.2)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+
 packages:
 
   '@adobe/css-tools@4.4.4':
@@ -504,6 +523,12 @@ packages:
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@hookform/resolvers@5.2.2':
     resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
     peerDependencies:
@@ -672,6 +697,16 @@ packages:
     peerDependencies:
       '@tanstack/query-core': '>= 4.0.0'
       '@tanstack/react-query': '>= 4.0.0'
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@napi-rs/wasm-runtime@1.1.2':
     resolution: {integrity: sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==}
@@ -1851,9 +1886,24 @@ packages:
   '@vitest/utils@4.1.3':
     resolution: {integrity: sha512-Pc/Oexse/khOWsGB+w3q4yzA4te7W4gpZZAvk+fr8qXfTURZUMj5i7kuxsNK5mP/dEB6ao3jfr0rs17fHhbHdw==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-escapes@7.2.0:
     resolution: {integrity: sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==}
@@ -1901,9 +1951,25 @@ packages:
     resolution: {integrity: sha512-X4CiKlcV2GjnCMwnKAfbVWpHa++65th9TuzAEYtZoATiOE2DQKhSp4CJlyLoTqdhBKlXjpXjCTYPNNFS33Fi6w==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   caniuse-lite@1.0.30001762:
     resolution: {integrity: sha512-PxZwGNvH7Ak8WX5iXzoK1KPZttBXNPuaOvI2ZYU7NrlM+d9Ov+TUvlLOBNGzVXAntMSMMlJPd+jY6ovrVjSmUw==}
@@ -1951,8 +2017,28 @@ packages:
     resolution: {integrity: sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==}
     engines: {node: '>=20'}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
@@ -1960,6 +2046,14 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
@@ -2044,6 +2138,10 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -2068,8 +2166,19 @@ packages:
     resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
     engines: {node: '>=12'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   enhanced-resolve@5.18.4:
     resolution: {integrity: sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==}
@@ -2083,19 +2192,38 @@ packages:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-hangul@2.3.8:
     resolution: {integrity: sha512-VrJuqYBC7W04aKYjCnswomuJNXQRc0q33SG1IltVrRofi2YEE6FwVDPlsEJIdKbHwsOpbBL/mk9sUaBxVpbd+w==}
 
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
+
   esbuild@0.27.2:
     resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
     engines: {node: '>=18'}
     hasBin: true
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
 
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
@@ -2103,13 +2231,37 @@ packages:
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
   fast-equals@5.4.0:
     resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
     engines: {node: '>=6.0.0'}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2128,9 +2280,17 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
 
   framer-motion@12.25.0:
     resolution: {integrity: sha512-mlWqd0rApIjeyhTCSNCqPYsUAEhkcUukZxH3ke6KbstBRPcxhEpuIjmiUQvB+1E9xkEm5SpNHBgHCapH/QHTWg==}
@@ -2146,28 +2306,63 @@ packages:
       react-dom:
         optional: true
 
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   get-east-asian-width@1.4.0:
     resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
     engines: {node: '>=18'}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
 
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
 
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
   get-tsconfig@4.13.0:
     resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  hono@4.12.22:
+    resolution: {integrity: sha512-7fvVPbB92zNRsQke+uiRGwtTuef0tB2Dg4hWxYfFNvkQhIltWoyi0ONReM5LWA+jJWS3nfT5lTq+qbsIpX0IQw==}
+    engines: {node: '>=16.9.0'}
+
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -2210,6 +2405,14 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   is-fullwidth-code-point@5.1.0:
     resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
     engines: {node: '>=18'}
@@ -2221,12 +2424,21 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2239,6 +2451,12 @@ packages:
     peerDependenciesMeta:
       canvas:
         optional: true
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   jszip@3.10.1:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
@@ -2422,12 +2640,32 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
@@ -2462,6 +2700,10 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
 
   next@16.1.1:
     resolution: {integrity: sha512-QI+T7xrxt1pF6SQ/JYFz95ro/mg/1Znk5vBebsWwbpejj1T0A23hO7GYEaVac9QUOT2BIMiuzm0L99ooq7k0/w==}
@@ -2501,8 +2743,19 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
@@ -2513,6 +2766,17 @@ packages:
 
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -2532,6 +2796,10 @@ packages:
     resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
     engines: {node: '>=0.10'}
     hasBin: true
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -2559,9 +2827,17 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+    engines: {node: '>=0.6'}
 
   radix-ui@1.4.3:
     resolution: {integrity: sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==}
@@ -2575,6 +2851,14 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-day-picker@9.14.0:
     resolution: {integrity: sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==}
@@ -2694,6 +2978,10 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
@@ -2712,12 +3000,47 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
   setimmediate@1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -2742,6 +3065,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
@@ -2833,6 +3160,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
@@ -2852,6 +3183,10 @@ packages:
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -2863,6 +3198,10 @@ packages:
   undici@7.24.7:
     resolution: {integrity: sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==}
     engines: {node: '>=20.18.1'}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
 
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
@@ -2891,6 +3230,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vaul@1.1.2:
     resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
@@ -3005,6 +3348,11 @@ packages:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -3013,6 +3361,9 @@ packages:
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   write-file-atomic@7.0.0:
     resolution: {integrity: sha512-YnlPC6JqnZl6aO4uRc+dx5PHguiR9S6WeoLtpxNT9wIG+BDya7ZNE1q7KOjVgaA73hKhKLpVPgJ5QA9THQ5BRg==}
@@ -3045,6 +3396,11 @@ packages:
     resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@4.2.1:
     resolution: {integrity: sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==}
@@ -3282,6 +3638,10 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
+  '@hono/node-server@1.19.14(hono@4.12.22)':
+    dependencies:
+      hono: 4.12.22
+
   '@hookform/resolvers@5.2.2(react-hook-form@7.69.0(react@19.2.3))':
     dependencies:
       '@standard-schema/utils': 0.3.0
@@ -3411,6 +3771,28 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.90.16
       '@tanstack/react-query': 5.90.16(react@19.2.3)
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.2.1)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.22)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.22
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.2.1
+      zod-to-json-schema: 3.25.2(zod@4.2.1)
+    transitivePeerDependencies:
+      - supports-color
 
   '@napi-rs/wasm-runtime@1.1.2(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)':
     dependencies:
@@ -4564,7 +4946,23 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   agent-base@7.1.4: {}
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-escapes@7.2.0:
     dependencies:
@@ -4604,9 +5002,35 @@ snapshots:
       read-cmd-shim: 6.0.0
       write-file-atomic: 7.0.0
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.1
+      on-finished: 2.4.1
+      qs: 6.15.2
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  bytes@3.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   caniuse-lite@1.0.30001762: {}
 
@@ -4649,11 +5073,32 @@ snapshots:
 
   commander@14.0.2: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
 
   cookie@1.1.1: {}
 
   core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
 
   css-tree@3.2.1:
     dependencies:
@@ -4723,6 +5168,8 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  depd@2.0.0: {}
+
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
@@ -4740,7 +5187,17 @@ snapshots:
 
   dotenv@17.2.3: {}
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
   emoji-regex@10.6.0: {}
+
+  encodeurl@2.0.0: {}
 
   enhanced-resolve@5.18.4:
     dependencies:
@@ -4751,9 +5208,17 @@ snapshots:
 
   environment@1.1.0: {}
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-hangul@2.3.8: {}
 
   es-module-lexer@2.0.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
 
   esbuild@0.27.2:
     optionalDependencies:
@@ -4784,17 +5249,69 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.2
       '@esbuild/win32-x64': 0.27.2
 
+  escape-html@1.0.3: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
+
+  etag@1.8.1: {}
 
   eventemitter3@4.0.7: {}
 
   eventemitter3@5.0.1: {}
 
+  eventsource-parser@3.0.8: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.8
+
   expect-type@1.3.0: {}
 
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.2
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  fast-deep-equal@3.1.3: {}
+
   fast-equals@5.4.0: {}
+
+  fast-uri@3.1.2: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -4809,9 +5326,22 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
+
+  forwarded@0.2.0: {}
 
   framer-motion@12.25.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
@@ -4822,24 +5352,64 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
+  fresh@2.0.0: {}
+
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   get-east-asian-width@1.4.0: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
   get-nonce@1.0.1: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
 
   get-tsconfig@4.13.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
+
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  hono@4.12.22: {}
 
   html-encoding-sniffer@6.0.0:
     dependencies:
       '@exodus/bytes': 1.15.0
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -4871,6 +5441,10 @@ snapshots:
 
   internmap@2.0.3: {}
 
+  ip-address@10.2.0: {}
+
+  ipaddr.js@1.9.1: {}
+
   is-fullwidth-code-point@5.1.0:
     dependencies:
       get-east-asian-width: 1.4.0
@@ -4879,9 +5453,15 @@ snapshots:
 
   is-potential-custom-element-name@1.0.1: {}
 
+  is-promise@4.0.0: {}
+
   isarray@1.0.0: {}
 
+  isexe@2.0.0: {}
+
   jiti@2.6.1: {}
+
+  jose@6.2.3: {}
 
   js-tokens@4.0.0: {}
 
@@ -4910,6 +5490,10 @@ snapshots:
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   jszip@3.10.1:
     dependencies:
@@ -5065,12 +5649,24 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  math-intrinsics@1.1.0: {}
+
   mdn-data@2.27.1: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
 
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mimic-function@5.0.1: {}
 
@@ -5093,6 +5689,8 @@ snapshots:
   nano-spawn@2.0.0: {}
 
   nanoid@3.3.11: {}
+
+  negotiator@1.0.0: {}
 
   next@16.1.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
@@ -5130,7 +5728,17 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  object-inspect@1.13.4: {}
+
   obug@2.1.1: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   onetime@7.0.0:
     dependencies:
@@ -5142,6 +5750,12 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parseurl@1.3.3: {}
+
+  path-key@3.1.1: {}
+
+  path-to-regexp@8.4.2: {}
+
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
@@ -5151,6 +5765,8 @@ snapshots:
   picomatch@4.0.4: {}
 
   pidtree@0.6.0: {}
+
+  pkce-challenge@5.0.1: {}
 
   postcss@8.4.31:
     dependencies:
@@ -5186,7 +5802,16 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   punycode@2.3.1: {}
+
+  qs@6.15.2:
+    dependencies:
+      side-channel: 1.1.0
 
   radix-ui@1.4.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
@@ -5250,6 +5875,15 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.1
+      unpipe: 1.0.0
 
   react-day-picker@9.14.0(react@19.2.3):
     dependencies:
@@ -5391,6 +6025,16 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.13
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.13
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   safe-buffer@5.1.2: {}
 
   safer-buffer@2.1.2: {}
@@ -5404,7 +6048,34 @@ snapshots:
   semver@7.7.3:
     optional: true
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
   setimmediate@1.0.5: {}
+
+  setprototypeof@1.2.0: {}
 
   sharp@0.34.5:
     dependencies:
@@ -5438,6 +6109,40 @@ snapshots:
       '@img/sharp-win32-x64': 0.34.5
     optional: true
 
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
@@ -5455,6 +6160,8 @@ snapshots:
   source-map-js@1.2.1: {}
 
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@4.0.0: {}
 
@@ -5536,6 +6243,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toidentifier@1.0.1: {}
+
   tough-cookie@6.0.1:
     dependencies:
       tldts: 7.0.28
@@ -5555,11 +6264,19 @@ snapshots:
 
   tw-animate-css@1.4.0: {}
 
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
 
   undici@7.24.7: {}
+
+  unpipe@1.0.0: {}
 
   use-callback-ref@1.3.3(@types/react@19.2.7)(react@19.2.3):
     dependencies:
@@ -5581,6 +6298,8 @@ snapshots:
       react: 19.2.3
 
   util-deprecate@1.0.2: {}
+
+  vary@1.1.2: {}
 
   vaul@1.1.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
@@ -5669,6 +6388,10 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
@@ -5679,6 +6402,8 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.1.2
+
+  wrappy@1.0.2: {}
 
   write-file-atomic@7.0.0:
     dependencies:
@@ -5694,6 +6419,10 @@ snapshots:
   yallist@5.0.0: {}
 
   yaml@2.8.2: {}
+
+  zod-to-json-schema@3.25.2(zod@4.2.1):
+    dependencies:
+      zod: 4.2.1
 
   zod@4.2.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - .
+  - packages/*
 
 ignoredBuiltDependencies:
   - esbuild


### PR DESCRIPTION
## Summary

- Add packages/mcp-bridge as a lightweight pnpm workspace package published as @oat-app/mcp-bridge.
- Implement a TypeScript SDK based stdio bridge for the hosted oat MCP endpoint with env-only token config, debug logging, timeout config, and response normalization helpers.
- Add package README, smoke test, publish scripts, MCP usage docs, and an ADR for the package/workspace decision.
- Extend /settings/mcp with copyable Claude Code, Codex, and Claude Desktop connection snippets.

## Validation

- pnpm check
- pnpm type-check
- pnpm mcp-bridge:prepublish
- pnpm test components/settings/SettingsMenu.test.tsx
- pnpm build
- node packages/mcp-bridge/dist/index.js --help
- node packages/mcp-bridge/dist/index.js --version

## Notes

- @oat-app/mcp-bridge@0.1.0 was published after the package commit.