### PR TITLE
[codex] Add SSGOI page transitions

### DIFF
--- a/.claude/docs/CONVENTIONS_FE.md
+++ b/.claude/docs/CONVENTIONS_FE.md
@@ -10,6 +10,7 @@
 - **react-hook-form + zod** - 폼 상태 및 검증
 - **react-error-boundary** - 선언적 에러 처리
 - **shadcn/ui + Tailwind** - UI 컴포넌트
+- **SSGOI** - 페이지/화면 단위 전환 기준 (`TRANSITIONS.md` 참고)
 
 ---
 
@@ -98,6 +99,8 @@ lib/queries/index.ts  # 모든 쿼리 정의
 ---
 
 ## 5. 라우팅 패턴
+
+페이지 전환, funnel step 전환, 모바일 full-screen selector는 `.claude/docs/TRANSITIONS.md`의 SSGOI 기준을 따릅니다.
 
 ### 자산 유형별 계층 구조
 

--- a/.claude/docs/TRANSITIONS.md
+++ b/.claude/docs/TRANSITIONS.md
@@ -1,0 +1,210 @@
+# TRANSITIONS.md
+
+> 화면 전환 UX와 SSGOI 사용 기준
+
+## TL;DR
+
+- **표준 라이브러리**: `ssgoi`를 페이지/화면 단위 전환의 기준으로 사용
+- **보조 라이브러리**: `framer-motion`은 카드, 리스트, 차트 등 컴포넌트 내부 미세 애니메이션에 한정
+- **라우팅 유지**: Next.js App Router와 `@use-funnel/browser`를 유지하고, 전환만 `ssgoi`로 얹음
+- **모바일 우선**: 선택지가 많거나 입력 맥락이 넓은 UI는 bottom sheet보다 full-screen transition을 우선 검토
+- **접근성**: `prefers-reduced-motion` 사용자를 고려해 과한 이동 전환을 줄이거나 비활성화
+
+---
+
+## 1. 역할 구분
+
+### SSGOI
+
+페이지와 화면 단위의 큰 전환을 담당합니다.
+
+사용 대상:
+- 주요 페이지 이동
+- form/funnel step 전환
+- 모바일 full-screen selector
+- 목록에서 상세 화면으로 들어가는 drill-down
+- 카드나 row가 상세 화면으로 확장되는 hero/zoom 전환
+
+### framer-motion
+
+현재 프로젝트에 이미 포함되어 있으며, 작은 UI 반응에만 사용합니다.
+
+사용 대상:
+- 리스트 item 등장
+- 차트/숫자 영역의 가벼운 상태 변화
+- 버튼, 카드, 탭 내부의 micro interaction
+
+페이지 전환, 화면 stack, full-screen selector의 표준으로 사용하지 않습니다.
+
+### stackflow
+
+현 시점에서는 도입하지 않습니다.
+
+이유:
+- Next.js App Router와 별도의 navigation model을 만들 가능성이 큼
+- 이미 `@use-funnel/browser`로 step flow를 표현하고 있음
+- oat는 라우터를 교체하기보다 기존 라우팅 위에 전환 계층을 얹는 편이 적합
+
+---
+
+## 2. SSGOI 기본 설정 원칙
+
+SSGOI는 route 변경 시 나가는 화면을 clone해서 `position: absolute`로 다시 배치한 뒤, 들어오는 화면과 동시에 애니메이션합니다. 따라서 wrapper CSS 계약이 중요합니다.
+
+전환 wrapper는 다음 조건을 만족해야 합니다.
+
+| 조건 | 이유 |
+|------|------|
+| `relative` | 나가는 화면 clone의 위치 기준이 필요 |
+| `z-0` | stacking context를 만들어 배경 뒤로 사라지는 문제 방지 |
+| `overflow-x-clip` | slide/drill 전환 중 가로 overflow 깜박임 방지 |
+| 명확한 scroll element | scroll 위치 보존과 transition 위치 계산의 기준 |
+
+현재 `app/(main)/layout.tsx`는 내부 scroll container를 사용합니다. `Ssgoi`를 실제로 도입할 때는 이 scroll container와 `{children}` wrapper의 관계를 먼저 정리해야 합니다.
+
+권장 형태:
+
+```tsx
+<div className="size-full overflow-y-auto overflow-x-clip relative z-0">
+  <PageTransitionProvider>
+    <PageTransition className="p-4">{children}</PageTransition>
+  </PageTransitionProvider>
+</div>
+```
+
+실제 코드는 현재 레이아웃의 `Header`, `Sidebar`, `BottomNav` 고정 영역과 충돌하지 않도록 조정합니다. padding, background, width 같은 page layout class는 `PageTransition` boundary에 둡니다. boundary 안쪽에 별도 `main`을 두면 OUT page clone이 absolute로 되살아날 때 padding 좌표를 잃어 레이아웃이 흔들릴 수 있습니다.
+
+---
+
+## 3. 페이지 래핑 원칙
+
+기본 페이지 전환은 개별 page 파일에서 직접 감싸지 않습니다. `app/(main)/layout.tsx`의 내부 content 영역에서 `PageTransitionProvider`와 `PageTransition`을 한 번만 적용합니다.
+
+```tsx
+<PageTransitionProvider>
+  <PageTransition>{children}</PageTransition>
+</PageTransitionProvider>
+```
+
+`PageTransition`은 `usePathname()`으로 현재 route path를 읽어 `data-ssgoi-transition` 값으로 사용합니다. route 변경 시 같은 DOM 노드의 속성만 바꾸지 않고, `key={pathname}`으로 transition boundary DOM을 새로 만들어야 합니다. 동적 route는 config의 path pattern과 매칭될 수 있도록 일관된 id 정책을 둡니다.
+
+예:
+- `/ledger`
+- `/ledger/new`
+- `/ledger/records`
+- `/assets/stock/holdings`
+- `/assets/stock/holdings/[ticker]`
+
+---
+
+## 4. 전환 패턴 선택 기준
+
+### `fade`
+
+관계가 약한 페이지 전환의 기본값입니다.
+
+사용:
+- 설정 하위 페이지
+- 데이터 로딩이 중심인 화면
+- 정보 구조상 방향성이 약한 화면
+
+### `drill`
+
+계층형 navigation에 사용합니다.
+
+사용:
+- 목록 -> 상세
+- 자산 유형 -> 자산 상세
+- 테이블 row -> 상세 분석
+
+### `slide` 또는 `axis`
+
+동일한 depth의 sibling 화면 전환에 사용합니다.
+
+사용:
+- 탭처럼 나란한 화면
+- 분석 유형 간 이동
+- funnel step이 순차적일 때
+
+### `sheet`
+
+새 화면이 아래에서 올라와 modal-like하게 열릴 때 사용합니다.
+
+사용:
+- FAB -> 기록 작성
+- 짧은 작성 화면
+- 현재 맥락 위에 임시 작업 화면을 쌓는 경우
+
+bottom sheet 컴포넌트를 무조건 대체하는 것이 아니라, 화면 전체를 쓰는 편이 더 나은 경우에 사용합니다.
+
+### `hero` 또는 `zoom`
+
+같은 논리 객체가 목록에서 상세로 확장될 때 사용합니다.
+
+사용:
+- 카드 -> 상세
+- 종목 row -> 종목 상세
+- 카테고리 카드 -> 카테고리 분석
+
+필수:
+- `hero`는 list/detail 양쪽에 matching key가 필요
+- `zoom`도 outgoing/incoming key가 필요
+- key 값은 데이터 id 기반으로 안정적으로 만든다
+
+---
+
+## 5. Bottom Sheet 대체 기준
+
+모바일에서 다음 조건이면 bottom sheet보다 full-screen transition을 우선합니다.
+
+- 선택지가 많아 검색, 필터, 그룹핑이 필요한 경우
+- 키보드가 올라올 가능성이 높은 경우
+- 선택 중에 설명, 잔액, 최근 사용 정보 등 부가 정보가 필요한 경우
+- 선택 후 다시 form으로 돌아왔을 때 이전 입력 상태가 유지되어야 하는 경우
+- sheet 높이 제한 때문에 내용이 답답해지는 경우
+
+bottom sheet를 유지해도 되는 경우:
+- 선택지가 3-5개 정도로 적음
+- 확인/삭제 같은 짧은 보조 액션
+- 현재 화면을 떠나는 느낌을 주면 안 되는 가벼운 작업
+
+---
+
+## 6. Form/Funnel 적용 기준
+
+`@use-funnel/browser`는 step 상태를 담당하고, `ssgoi`는 step 사이 화면 전환을 담당합니다.
+
+적용 대상:
+- `components/ledger/funnel/*`
+- `components/transactions/funnel/*`
+- 계좌/결제수단 생성 flow
+- 카테고리/결제수단/종목 선택 화면
+
+권장 UX:
+- 각 step은 하나의 full-screen panel처럼 구성
+- 뒤로가기는 이전 step으로 돌아감
+- 모바일에서는 step header와 back affordance를 명확히 표시
+- PC에서는 필요하면 Dialog/Popover를 유지하고 모바일만 full-screen selector로 전환
+
+---
+
+## 7. 구현 체크리스트
+
+SSGOI 도입 PR은 최소한 다음을 포함해야 합니다.
+
+- `@ssgoi/react` 설치
+- 전역 transition config 추가
+- main layout의 scroll/wrapper CSS 계약 정리
+- `prefers-reduced-motion` 정책 추가
+- route id 정책 문서화
+- 샘플 route 또는 funnel step 1개에만 우선 적용
+- 모바일 Safari/PWA에서 화면 밀림, scroll 보존, back 동작 확인
+
+---
+
+## 8. 참고
+
+- SSGOI llms guide: https://ssgoi.dev/llms.txt
+- SSGOI docs: https://ssgoi.dev
+- SSGOI mobile transitions: https://ssgoi.dev/en/docs/mobile-transitions
+- SSGOI transition references: https://ssgoi.dev/llms/.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@
 | **DATABASE.md** | `.claude/docs/` | Supabase 스키마, RLS 정책 |
 | **CONVENTIONS.md** | `.claude/docs/` | 공통 컨벤션 |
 | **CONVENTIONS_FE.md** | `.claude/docs/` | 프론트엔드 패턴 |
+| **TRANSITIONS.md** | `.claude/docs/` | 화면 전환 UX, SSGOI 사용 기준 |
 | **CONVENTIONS_BE.md** | `.claude/docs/` | 백엔드/API 패턴 |
 | **API.md** | `.claude/docs/` | API 설계 원칙 |
 | **MCP.md** | `.claude/docs/` | MCP 서버 설계, 인증, tool 범위 |

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -1,4 +1,10 @@
-import { BottomNav, Header, Sidebar } from "@/components/layout";
+import {
+  BottomNav,
+  Header,
+  PageTransition,
+  PageTransitionProvider,
+  Sidebar,
+} from "@/components/layout";
 
 export default function MainLayout({
   children,
@@ -10,10 +16,12 @@ export default function MainLayout({
       <Header />
       <div className="flex flex-1 overflow-hidden">
         <Sidebar />
-        <div className="size-full overflow-y-scroll">
-          <main className="flex-1 p-4 pb-[calc(6rem+env(safe-area-inset-bottom))] lg:pb-4">
-            <div className="max-w-4xl mx-auto space-y-6">{children}</div>
-          </main>
+        <div className="size-full overflow-y-scroll overflow-x-clip relative z-0">
+          <PageTransitionProvider>
+            <PageTransition className="flex-1 p-4 pb-[calc(6rem+env(safe-area-inset-bottom))] lg:pb-4">
+              <div className="max-w-4xl mx-auto space-y-6">{children}</div>
+            </PageTransition>
+          </PageTransitionProvider>
         </div>
       </div>
       <BottomNav />

--- a/app/(main)/loading.tsx
+++ b/app/(main)/loading.tsx
@@ -2,7 +2,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 
 export default function MainLoading() {
   return (
-    <div className="space-y-6">
+    <div className="min-h-full w-full bg-gray-50 space-y-6">
       <div className="space-y-2">
         <Skeleton className="h-7 w-32 bg-gray-200" />
         <Skeleton className="h-4 w-48 bg-gray-200" />

--- a/components/layout/BottomNav.test.tsx
+++ b/components/layout/BottomNav.test.tsx
@@ -24,6 +24,10 @@ vi.mock("next/link", () => ({
   useLinkStatus: vi.fn(() => ({ pending: false })),
 }));
 
+vi.mock("./NavPendingIndicator", () => ({
+  NavPendingIndicator: () => <span data-testid="nav-pending-indicator" />,
+}));
+
 import { usePathname } from "next/navigation";
 
 describe("BottomNav", () => {
@@ -93,5 +97,13 @@ describe("BottomNav", () => {
 
     const settingsLink = screen.getByText("설정").closest("a");
     expect(settingsLink?.className).toContain("text-primary");
+  });
+
+  it("페이지 전환 피드백과 중복되는 pending spinner를 렌더링하지 않는다", () => {
+    render(<BottomNav />);
+
+    expect(
+      screen.queryByTestId("nav-pending-indicator"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/components/layout/BottomNav.tsx
+++ b/components/layout/BottomNav.tsx
@@ -4,7 +4,6 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { isNavItemActive, NAV_ITEMS } from "@/constants/nav-items";
 import { cn } from "@/lib/utils/cn";
-import { NavPendingIndicator } from "./NavPendingIndicator";
 
 export function BottomNav() {
   const pathname = usePathname();
@@ -25,9 +24,8 @@ export function BottomNav() {
                 active ? "text-primary" : "text-gray-500 hover:text-gray-700",
               )}
             >
-              <div className="relative">
+              <div>
                 <Icon className="size-5" />
-                <NavPendingIndicator className="absolute -right-3 -top-1" />
               </div>
               <span className="text-xs font-medium">{item.label}</span>
             </Link>

--- a/components/layout/PageTransition.test.tsx
+++ b/components/layout/PageTransition.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { usePathname } from "next/navigation";
+import { describe, expect, it, vi } from "vitest";
+import { PageTransition } from "./PageTransition";
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(() => "/ledger"),
+}));
+
+describe("PageTransition", () => {
+  it("현재 pathname을 SSGOI transition boundary id로 사용한다", () => {
+    vi.mocked(usePathname).mockReturnValue("/ledger");
+
+    render(
+      <PageTransition>
+        <div>가계부</div>
+      </PageTransition>,
+    );
+
+    expect(screen.getByText("가계부").parentElement).toHaveAttribute(
+      "data-ssgoi-transition",
+      "/ledger",
+    );
+  });
+
+  it("pathname이 바뀌면 transition boundary DOM을 새로 만든다", () => {
+    vi.mocked(usePathname).mockReturnValue("/ledger");
+    const { rerender } = render(
+      <PageTransition>
+        <div>가계부</div>
+      </PageTransition>,
+    );
+    const ledgerBoundary = screen.getByText("가계부").parentElement;
+
+    vi.mocked(usePathname).mockReturnValue("/ledger/new");
+    rerender(
+      <PageTransition>
+        <div>기록 추가</div>
+      </PageTransition>,
+    );
+
+    const newBoundary = screen.getByText("기록 추가").parentElement;
+    expect(newBoundary).toHaveAttribute("data-ssgoi-transition", "/ledger/new");
+    expect(newBoundary).not.toBe(ledgerBoundary);
+  });
+});

--- a/components/layout/PageTransition.tsx
+++ b/components/layout/PageTransition.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils/cn";
+
+interface PageTransitionProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function PageTransition({ children, className }: PageTransitionProps) {
+  const pathname = usePathname();
+
+  return (
+    <main
+      key={pathname}
+      data-ssgoi-transition={pathname}
+      className={cn("min-h-full w-full bg-gray-50 overflow-x-clip", className)}
+    >
+      {children}
+    </main>
+  );
+}

--- a/components/layout/PageTransitionProvider.tsx
+++ b/components/layout/PageTransitionProvider.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Ssgoi } from "@ssgoi/react";
+import { useEffect, useMemo, useState } from "react";
+import { useMediaQuery } from "@/hooks/use-media-query";
+import { createPageTransitionConfig } from "@/lib/transitions/create-page-transition-config";
+import { getPageTransitionMode } from "@/lib/transitions/page-transition-rules";
+
+interface PageTransitionProviderProps {
+  children: React.ReactNode;
+}
+
+export function PageTransitionProvider({
+  children,
+}: PageTransitionProviderProps) {
+  const [hasMounted, setHasMounted] = useState(false);
+  const isDesktop = useMediaQuery("(min-width: 1024px)");
+  const prefersReducedMotion = useMediaQuery(
+    "(prefers-reduced-motion: reduce)",
+  );
+
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
+
+  const mode = getPageTransitionMode({
+    hasMounted,
+    isDesktop,
+    prefersReducedMotion,
+  });
+
+  const config = useMemo(() => createPageTransitionConfig(mode), [mode]);
+
+  return <Ssgoi config={config}>{children}</Ssgoi>;
+}

--- a/components/layout/Sidebar.test.tsx
+++ b/components/layout/Sidebar.test.tsx
@@ -22,6 +22,10 @@ vi.mock("next/link", () => ({
   useLinkStatus: vi.fn(() => ({ pending: false })),
 }));
 
+vi.mock("./NavPendingIndicator", () => ({
+  NavPendingIndicator: () => <span data-testid="nav-pending-indicator" />,
+}));
+
 import { usePathname } from "next/navigation";
 
 describe("Sidebar", () => {
@@ -72,5 +76,13 @@ describe("Sidebar", () => {
 
     const settingsLink = screen.getByText("설정").closest("a");
     expect(settingsLink?.className).toContain("bg-primary/10");
+  });
+
+  it("페이지 전환 피드백과 중복되는 pending spinner를 렌더링하지 않는다", () => {
+    render(<Sidebar />);
+
+    expect(
+      screen.queryByTestId("nav-pending-indicator"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -4,7 +4,6 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { isNavItemActive, NAV_ITEMS } from "@/constants/nav-items";
 import { cn } from "@/lib/utils/cn";
-import { NavPendingIndicator } from "./NavPendingIndicator";
 
 export function Sidebar() {
   const pathname = usePathname();
@@ -29,7 +28,6 @@ export function Sidebar() {
             >
               <Icon className="size-5" />
               <span>{item.label}</span>
-              <NavPendingIndicator className="ml-auto" />
             </Link>
           );
         })}

--- a/components/layout/index.ts
+++ b/components/layout/index.ts
@@ -3,4 +3,6 @@ export { Header } from "./Header";
 export { NavPendingIndicator } from "./NavPendingIndicator";
 export { PageContainer } from "./PageContainer";
 export { PageHeader } from "./PageHeader";
+export { PageTransition } from "./PageTransition";
+export { PageTransitionProvider } from "./PageTransitionProvider";
 export { Sidebar } from "./Sidebar";

--- a/lib/transitions/create-page-transition-config.test.ts
+++ b/lib/transitions/create-page-transition-config.test.ts
@@ -1,0 +1,36 @@
+import { fade } from "@ssgoi/react/view-transitions";
+import { describe, expect, it, vi } from "vitest";
+import { createPageTransitionConfig } from "./create-page-transition-config";
+
+vi.mock("@ssgoi/react/view-transitions", () => ({
+  axis: vi.fn(() => []),
+  drill: vi.fn(() => []),
+  fade: vi.fn(() => []),
+  sheet: vi.fn(() => []),
+}));
+
+describe("createPageTransitionConfig", () => {
+  it("desktop fade에는 빠른 spring physics를 사용한다", () => {
+    createPageTransitionConfig("desktop");
+
+    expect(fade).toHaveBeenCalledWith({
+      paths: [
+        "/home",
+        "/ledger",
+        "/assets",
+        "/dashboard",
+        "/settings",
+        "/household",
+      ],
+      options: {
+        physics: {
+          spring: {
+            stiffness: 260,
+            damping: 28,
+            doubleSpring: true,
+          },
+        },
+      },
+    });
+  });
+});

--- a/lib/transitions/create-page-transition-config.ts
+++ b/lib/transitions/create-page-transition-config.ts
@@ -1,0 +1,67 @@
+import type { SsgoiConfig } from "@ssgoi/react/types";
+import { axis, drill, fade, sheet } from "@ssgoi/react/view-transitions";
+import type {
+  PageTransitionMode,
+  PageTransitionRule,
+} from "./page-transition-rules";
+import { getPageTransitionRules } from "./page-transition-rules";
+
+const FAST_FADE_OPTIONS = {
+  physics: {
+    spring: {
+      stiffness: 260,
+      damping: 28,
+      doubleSpring: true,
+    },
+  },
+};
+
+function createTransition(rule: PageTransitionRule) {
+  switch (rule.kind) {
+    case "fade":
+      return fade({
+        paths: rule.paths,
+        options: rule.speed === "fast" ? FAST_FADE_OPTIONS : {},
+      } as Parameters<typeof fade>[0]);
+    case "axis":
+      if (rule.type === "x") {
+        return axis({
+          paths: rule.paths,
+          type: "x",
+          variant: rule.variant,
+        });
+      }
+      if (rule.type === "y") {
+        return axis({
+          paths: rule.paths,
+          type: "y",
+          variant: rule.variant,
+        });
+      }
+      return axis({
+        paths: rule.paths,
+        type: "z",
+        variant: rule.variant,
+      });
+    case "sheet":
+      return sheet({
+        enter: rule.enter,
+        exit: rule.exit,
+        type: rule.type === "scale" ? "scale" : "static",
+      });
+    case "drill":
+      return drill({
+        enter: rule.enter,
+        exit: rule.exit,
+        type: rule.type === "slide" ? "slide" : "parallax",
+      });
+  }
+}
+
+export function createPageTransitionConfig(
+  mode: PageTransitionMode,
+): SsgoiConfig {
+  return {
+    transitions: getPageTransitionRules(mode).map(createTransition),
+  };
+}

--- a/lib/transitions/page-transition-rules.test.ts
+++ b/lib/transitions/page-transition-rules.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  getPageTransitionMode,
+  getPageTransitionRules,
+} from "./page-transition-rules";
+
+describe("page transition rules", () => {
+  it("첫 렌더에서는 viewport와 무관하게 initial 모드를 사용한다", () => {
+    expect(
+      getPageTransitionMode({
+        hasMounted: false,
+        isDesktop: true,
+        prefersReducedMotion: false,
+      }),
+    ).toBe("initial");
+
+    expect(
+      getPageTransitionMode({
+        hasMounted: false,
+        isDesktop: false,
+        prefersReducedMotion: false,
+      }),
+    ).toBe("initial");
+  });
+
+  it("reduced motion 사용자는 reduced 모드를 사용한다", () => {
+    expect(
+      getPageTransitionMode({
+        hasMounted: true,
+        isDesktop: false,
+        prefersReducedMotion: true,
+      }),
+    ).toBe("reduced");
+  });
+
+  it("mount 이후 viewport에 따라 mobile과 desktop 모드를 구분한다", () => {
+    expect(
+      getPageTransitionMode({
+        hasMounted: true,
+        isDesktop: false,
+        prefersReducedMotion: false,
+      }),
+    ).toBe("mobile");
+
+    expect(
+      getPageTransitionMode({
+        hasMounted: true,
+        isDesktop: true,
+        prefersReducedMotion: false,
+      }),
+    ).toBe("desktop");
+  });
+
+  it("mobile 모드는 parent to child 이동에 명시적인 drill 전환을 적용한다", () => {
+    expect(getPageTransitionRules("mobile")).toContainEqual({
+      kind: "drill",
+      enter: "/ledger/*",
+      exit: "/ledger",
+      type: "parallax",
+    });
+    expect(getPageTransitionRules("mobile")).not.toContainEqual({
+      kind: "drill",
+      enter: "*",
+      exit: "*",
+      type: "parallax",
+    });
+  });
+
+  it("desktop 모드는 강한 화면 이동 대신 fade 전환만 사용한다", () => {
+    const rules = getPageTransitionRules("desktop");
+
+    expect(rules.every((rule) => rule.kind === "fade")).toBe(true);
+    expect(rules).toContainEqual({
+      kind: "fade",
+      paths: ["/ledger", "/ledger/new"],
+      speed: "fast",
+    });
+  });
+});

--- a/lib/transitions/page-transition-rules.ts
+++ b/lib/transitions/page-transition-rules.ts
@@ -1,0 +1,111 @@
+export type PageTransitionMode = "initial" | "mobile" | "desktop" | "reduced";
+
+export type PageTransitionRule =
+  | {
+      kind: "fade";
+      paths: readonly string[];
+      speed?: "default" | "fast";
+    }
+  | {
+      kind: "axis";
+      paths: readonly string[];
+      type: "x";
+      variant?: "default" | "snappy";
+    }
+  | {
+      kind: "axis";
+      paths: readonly string[];
+      type: "y";
+      variant?: "default" | "non-directional";
+    }
+  | {
+      kind: "axis";
+      paths: readonly string[];
+      type: "z";
+      variant?: "default";
+    }
+  | {
+      kind: "sheet" | "drill";
+      enter: string;
+      exit: string;
+      type?: "static" | "scale" | "parallax" | "slide";
+    };
+
+const TOP_LEVEL_ROUTES = [
+  "/home",
+  "/ledger",
+  "/assets",
+  "/dashboard",
+  "/settings",
+  "/household",
+] as const;
+
+export function getPageTransitionMode({
+  hasMounted,
+  isDesktop,
+  prefersReducedMotion,
+}: {
+  hasMounted: boolean;
+  isDesktop: boolean;
+  prefersReducedMotion: boolean;
+}): PageTransitionMode {
+  if (!hasMounted) {
+    return "initial";
+  }
+  if (prefersReducedMotion) {
+    return "reduced";
+  }
+  return isDesktop ? "desktop" : "mobile";
+}
+
+export function getPageTransitionRules(
+  mode: PageTransitionMode,
+): PageTransitionRule[] {
+  switch (mode) {
+    case "mobile":
+      return [
+        { kind: "fade", paths: TOP_LEVEL_ROUTES },
+        {
+          kind: "drill",
+          enter: "/ledger/*",
+          exit: "/ledger",
+          type: "parallax",
+        },
+        {
+          kind: "drill",
+          enter: "/assets/*",
+          exit: "/assets",
+          type: "parallax",
+        },
+        {
+          kind: "drill",
+          enter: "/dashboard/*",
+          exit: "/dashboard",
+          type: "parallax",
+        },
+        {
+          kind: "drill",
+          enter: "/settings/*",
+          exit: "/settings",
+          type: "parallax",
+        },
+        {
+          kind: "drill",
+          enter: "/household/*",
+          exit: "/household",
+          type: "parallax",
+        },
+      ];
+    case "desktop":
+      return [
+        { kind: "fade", paths: TOP_LEVEL_ROUTES, speed: "fast" },
+        { kind: "fade", paths: ["/ledger", "/ledger/new"], speed: "fast" },
+      ];
+    case "reduced":
+    case "initial":
+      return [
+        { kind: "fade", paths: TOP_LEVEL_ROUTES },
+        { kind: "fade", paths: ["/ledger", "/ledger/new"] },
+      ];
+  }
+}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@ssgoi/react": "^6.4.0",
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.89.0",
     "@tanstack/react-query": "^5.90.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@ssgoi/react':
+        specifier: ^6.4.0
+        version: 6.4.0
       '@supabase/ssr':
         specifier: ^0.8.0
         version: 0.8.0(@supabase/supabase-js@2.89.0)
@@ -76,7 +79,7 @@ importers:
         version: 0.562.0(react@19.2.3)
       next:
         specifier: 16.1.1
-        version: 16.1.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.1(@babel/core@7.29.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       radix-ui:
         specifier: ^1.4.3
         version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -227,12 +230,79 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/runtime@7.28.4':
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@biomejs/biome@2.2.0':
@@ -1588,6 +1658,14 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
 
+  '@ssgoi/core@6.4.0':
+    resolution: {integrity: sha512-R0vwkdpJtywKJfRK5yx9aug7uSIw9JI2Ufpyyblo5vrT9PfN8xvZtfBpfFzKQQA050VH+pwBZLEwtjw/kBRO7w==}
+    engines: {node: '>=18.0.0'}
+
+  '@ssgoi/react@6.4.0':
+    resolution: {integrity: sha512-wjwMFK5KSiSjB1/qLNT0DJZM522zJTe6IK0GlbIWoMd8Y8m65DQ85TsOERgbOqHxxY8Eo2vQBJvuM9yTXEhTVA==}
+    engines: {node: '>=18.0.0'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1890,6 +1968,11 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -1940,6 +2023,11 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  baseline-browser-mapping@2.10.32:
+    resolution: {integrity: sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   baseline-browser-mapping@2.9.11:
     resolution: {integrity: sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==}
     hasBin: true
@@ -1959,6 +2047,11 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -1973,6 +2066,9 @@ packages:
 
   caniuse-lite@1.0.30001762:
     resolution: {integrity: sha512-PxZwGNvH7Ak8WX5iXzoK1KPZttBXNPuaOvI2ZYU7NrlM+d9Ov+TUvlLOBNGzVXAntMSMMlJPd+jY6ovrVjSmUw==}
+
+  caniuse-lite@1.0.30001793:
+    resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -2173,6 +2269,9 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
+  electron-to-chromium@1.5.362:
+    resolution: {integrity: sha512-PUY2DrLvkjkUuWqq+KPL2iWshrJsZOcIojzRQ7eXFacc9dWga7MGMJAa15VbiejSZB1PAXaRLAiKgruHP8LB1w==}
+
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
@@ -2214,6 +2313,10 @@ packages:
     resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -2317,6 +2420,10 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
 
   get-east-asian-width@1.4.0:
     resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
@@ -2452,11 +2559,21 @@ packages:
       canvas:
         optional: true
 
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   jszip@3.10.1:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
@@ -2628,6 +2745,9 @@ packages:
     resolution: {integrity: sha512-wgWa6FWQ3QRRJbIjbsldRJZxdxYngT/dO0I5Ynmlnin8qy7tC6xYzbcJjtN4wHLXtkbVwHzk0C+OejVw1XM+DQ==}
     engines: {node: 20 || >=22}
 
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
   lucide-react@0.562.0:
     resolution: {integrity: sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw==}
     peerDependencies:
@@ -2734,6 +2854,10 @@ packages:
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  node-releases@2.0.46:
+    resolution: {integrity: sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==}
+    engines: {node: '>=18'}
 
   npm-normalize-package-bin@5.0.0:
     resolution: {integrity: sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==}
@@ -2951,6 +3075,7 @@ packages:
   recharts@2.15.4:
     resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
     engines: {node: '>=14'}
+    deprecated: 1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -2994,6 +3119,10 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
 
   semver@7.7.3:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
@@ -3130,6 +3259,7 @@ packages:
   tar@7.5.2:
     resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
@@ -3202,6 +3332,16 @@ packages:
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+
+  unplugin@2.3.11:
+    resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
+    engines: {node: '>=18.12.0'}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
 
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
@@ -3340,6 +3480,9 @@ packages:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
 
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
   whatwg-mimetype@5.0.0:
     resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
     engines: {node: '>=20'}
@@ -3387,6 +3530,9 @@ packages:
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
@@ -3451,9 +3597,109 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
 
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
   '@babel/runtime@7.28.4': {}
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@biomejs/biome@2.2.0':
     optionalDependencies:
@@ -4654,6 +4900,16 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
+  '@ssgoi/core@6.4.0': {}
+
+  '@ssgoi/react@6.4.0':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@ssgoi/core': 6.4.0
+      unplugin: 2.3.11
+    transitivePeerDependencies:
+      - supports-color
+
   '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
@@ -4951,6 +5207,8 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
+  acorn@8.16.0: {}
+
   agent-base@7.1.4: {}
 
   ajv-formats@3.0.1(ajv@8.20.0):
@@ -4988,6 +5246,8 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  baseline-browser-mapping@2.10.32: {}
+
   baseline-browser-mapping@2.9.11: {}
 
   bidi-js@1.0.3:
@@ -5020,6 +5280,14 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.32
+      caniuse-lite: 1.0.30001793
+      electron-to-chromium: 1.5.362
+      node-releases: 2.0.46
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
   bytes@3.1.2: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -5033,6 +5301,8 @@ snapshots:
       get-intrinsic: 1.3.0
 
   caniuse-lite@1.0.30001762: {}
+
+  caniuse-lite@1.0.30001793: {}
 
   chai@6.2.2: {}
 
@@ -5195,6 +5465,8 @@ snapshots:
 
   ee-first@1.1.1: {}
 
+  electron-to-chromium@1.5.362: {}
+
   emoji-regex@10.6.0: {}
 
   encodeurl@2.0.0: {}
@@ -5248,6 +5520,8 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.2
       '@esbuild/win32-ia32': 0.27.2
       '@esbuild/win32-x64': 0.27.2
+
+  escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
 
@@ -5358,6 +5632,8 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  gensync@1.0.0-beta.2: {}
 
   get-east-asian-width@1.4.0: {}
 
@@ -5491,9 +5767,13 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  jsesc@3.1.0: {}
+
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@8.0.2: {}
+
+  json5@2.2.3: {}
 
   jszip@3.10.1:
     dependencies:
@@ -5639,6 +5919,10 @@ snapshots:
 
   lru-cache@11.3.2: {}
 
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
   lucide-react@0.562.0(react@19.2.3):
     dependencies:
       react: 19.2.3
@@ -5692,7 +5976,7 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  next@16.1.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.1(@babel/core@7.29.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.1.1
       '@swc/helpers': 0.5.15
@@ -5701,7 +5985,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      styled-jsx: 5.1.6(react@19.2.3)
+      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.3)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.1.1
       '@next/swc-darwin-x64': 16.1.1
@@ -5723,6 +6007,8 @@ snapshots:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
+
+  node-releases@2.0.46: {}
 
   npm-normalize-package-bin@5.0.0: {}
 
@@ -6045,6 +6331,8 @@ snapshots:
 
   scheduler@0.27.0: {}
 
+  semver@6.3.1: {}
+
   semver@7.7.3:
     optional: true
 
@@ -6190,10 +6478,12 @@ snapshots:
     dependencies:
       min-indent: 1.0.1
 
-  styled-jsx@5.1.6(react@19.2.3):
+  styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.3):
     dependencies:
       client-only: 0.0.1
       react: 19.2.3
+    optionalDependencies:
+      '@babel/core': 7.29.7
 
   supabase@2.70.5:
     dependencies:
@@ -6277,6 +6567,19 @@ snapshots:
   undici@7.24.7: {}
 
   unpipe@1.0.0: {}
+
+  unplugin@2.3.11:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      acorn: 8.16.0
+      picomatch: 4.0.4
+      webpack-virtual-modules: 0.6.2
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
 
   use-callback-ref@1.3.3(@types/react@19.2.7)(react@19.2.3):
     dependencies:
@@ -6378,6 +6681,8 @@ snapshots:
 
   webidl-conversions@8.0.1: {}
 
+  webpack-virtual-modules@0.6.2: {}
+
   whatwg-mimetype@5.0.0: {}
 
   whatwg-url@16.0.1:
@@ -6415,6 +6720,8 @@ snapshots:
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
+
+  yallist@3.1.1: {}
 
   yallist@5.0.0: {}
 


### PR DESCRIPTION
## Summary

- Add SSGOI as the page/screen transition foundation for the main app shell.
- Wrap main content with a shared transition provider and pathname-based data-ssgoi-transition boundary.
- Use mobile parent-to-child drill transitions, fast desktop fade, and fade for initial/reduced-motion states.
- Remove duplicated pending spinners from bottom navigation and desktop sidebar.
- Document transition usage in .claude/docs/TRANSITIONS.md and link it from project docs.

## Validation

- pnpm test components/layout/PageTransition.test.tsx lib/transitions/page-transition-rules.test.ts lib/transitions/create-page-transition-config.test.ts components/layout/BottomNav.test.tsx
- pnpm test components/layout/Sidebar.test.tsx components/layout/BottomNav.test.tsx
- pnpm type-check
- pnpm check
- pnpm build