### PR TITLE
fix: 숫자 입력 필드에 inputMode 추가하여 모바일 숫자 키패드 노출

### DIFF
--- a/components/accounts/AccountNewForm.tsx
+++ b/components/accounts/AccountNewForm.tsx
@@ -225,6 +225,7 @@ function DetailForm({ category, onBack }: DetailFormProps) {
         <Label htmlFor="accountNumber">계좌번호</Label>
         <Input
           id="accountNumber"
+          inputMode="numeric"
           placeholder="예: 123-456-78901234"
           {...register("accountNumber")}
           aria-invalid={!!errors.accountNumber}
@@ -241,6 +242,7 @@ function DetailForm({ category, onBack }: DetailFormProps) {
         <Input
           id="balanceStr"
           type="number"
+          inputMode="numeric"
           min="0"
           placeholder="예: 1000000"
           {...register("balanceStr")}

--- a/components/accounts/PaymentMethodFormDialog.tsx
+++ b/components/accounts/PaymentMethodFormDialog.tsx
@@ -297,6 +297,7 @@ export function PaymentMethodFormDialog({
           <Label htmlFor="pm-last-four">카드번호 끝 4자리</Label>
           <Input
             id="pm-last-four"
+            inputMode="numeric"
             placeholder="예: 1234"
             maxLength={4}
             {...register("lastFour")}
@@ -316,6 +317,7 @@ export function PaymentMethodFormDialog({
           <Input
             id="pm-payment-day"
             type="number"
+            inputMode="numeric"
             min={1}
             max={31}
             placeholder="예: 15"
@@ -336,6 +338,7 @@ export function PaymentMethodFormDialog({
           <Input
             id="pm-balance"
             type="number"
+            inputMode="numeric"
             min="0"
             placeholder="예: 30000"
             {...register("balanceStr")}

--- a/components/accounts/PaymentMethodNewForm.tsx
+++ b/components/accounts/PaymentMethodNewForm.tsx
@@ -226,6 +226,7 @@ function DetailForm({ type, onBack }: DetailFormProps) {
           <Label htmlFor="pm-last-four">카드번호 끝 4자리</Label>
           <Input
             id="pm-last-four"
+            inputMode="numeric"
             placeholder="예: 1234"
             maxLength={4}
             {...register("lastFour")}
@@ -245,6 +246,7 @@ function DetailForm({ type, onBack }: DetailFormProps) {
           <Input
             id="pm-payment-day"
             type="number"
+            inputMode="numeric"
             min={1}
             max={31}
             placeholder="예: 15"
@@ -265,6 +267,7 @@ function DetailForm({ type, onBack }: DetailFormProps) {
           <Input
             id="pm-balance"
             type="number"
+            inputMode="numeric"
             min="0"
             placeholder="예: 30000"
             {...register("balanceStr")}

--- a/components/transactions/TransactionEditDialog.tsx
+++ b/components/transactions/TransactionEditDialog.tsx
@@ -167,6 +167,7 @@ export function TransactionEditDialog({
         <Input
           id="quantity"
           type="number"
+          inputMode="numeric"
           step="any"
           min="0"
           {...register("quantity")}
@@ -184,6 +185,7 @@ export function TransactionEditDialog({
         <Input
           id="price"
           type="number"
+          inputMode="decimal"
           step="any"
           min="0"
           {...register("price")}


### PR DESCRIPTION
## 변경 사항

모바일에서 금액, 수량, 카드번호 등 숫자 입력 필드에 숫자 키패드가 노출되도록 `inputMode` 속성을 추가합니다.

### 수정 파일

| 파일 | 필드 | inputMode |
|------|------|-----------|
| `PaymentMethodFormDialog.tsx` | 결제일, 보조잔액, 카드번호 끝 4자리 | `numeric` |
| `PaymentMethodNewForm.tsx` | 결제일, 보조잔액, 카드번호 끝 4자리 | `numeric` |
| `TransactionEditDialog.tsx` | 수량 | `numeric` |
| `TransactionEditDialog.tsx` | 단가 | `decimal` |
| `AccountNewForm.tsx` | 잔액, 계좌번호 | `numeric` |

### 참고
- 정수 필드: `inputMode="numeric"` (숫자 키패드, 소수점 없음)
- 소수점 허용 필드: `inputMode="decimal"` (소수점 포함 숫자 키패드)
- 기존에 이미 적용된 파일 (TransactionItemRow, LedgerEntryEditDialog, AddTransferStep, AddItemsStep)과 동일한 패턴