### PR TITLE
[버그] 휴장일 기록 workflow 에러 수정 및 Node LTS 버전 업데이트

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
       - name: Install Vercel CLI
         run: npm install -g vercel@latest
 

--- a/.github/workflows/sync-exchange-rates.yml
+++ b/.github/workflows/sync-exchange-rates.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/sync-holiday.yml
+++ b/.github/workflows/sync-holiday.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/sync-stock-master.yml
+++ b/.github/workflows/sync-stock-master.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,6 @@ tmp
 # local settings
 .vscode/
 .claude/settings.local.json
+.antigravitycli/
 
 CONTEXT.md

--- a/lib/supabase/system-config-client.ts
+++ b/lib/supabase/system-config-client.ts
@@ -23,13 +23,14 @@ export function getSystemConfigClient() {
 
   const url =
     process.env.SYSTEM_CONFIG_SUPABASE_URL ||
-    process.env.NEXT_PUBLIC_SUPABASE_URL;
+    process.env.NEXT_PUBLIC_SUPABASE_URL ||
+    process.env.SUPABASE_URL;
   const key =
     process.env.SYSTEM_CONFIG_SECRET_KEY || process.env.SUPABASE_SECRET_KEY;
 
   if (!url || !key) {
     throw new Error(
-      "system_config 클라이언트: SYSTEM_CONFIG_SUPABASE_URL/SECRET_KEY 또는 기본 환경변수 필요",
+      "system_config 클라이언트: SYSTEM_CONFIG_SUPABASE_URL/SECRET_KEY 또는 기본 환경변수(SUPABASE_URL/SECRET_KEY) 필요",
     );
   }
 


### PR DESCRIPTION
Issue #314 에 대응하여 system_config 클라이언트의 환경변수 URL 바인딩 버그를 해결하고 전체 workflow의 Node.js 버전을 v24 Active LTS로 통일해 배포 안정성을 향상했습니다.