### PR TITLE
feat: 계좌 및 결제 수단에서 기본값(is_default) 제거 (#292)

### DIFF
--- a/.claude/docs/DATABASE.md
+++ b/.claude/docs/DATABASE.md
@@ -333,7 +333,6 @@ create table public.accounts (
   category account_category,         -- 계좌 범주 (bank/investment)
   balance numeric(18, 2),            -- 현재 잔액 (예수금 포함, 수동 입력)
   balance_updated_at timestamptz,    -- 잔액 마지막 수정일
-  is_default boolean default false,
   memo text,
   created_at timestamptz default now() not null,
   updated_at timestamptz default now() not null,
@@ -357,7 +356,6 @@ create index accounts_owner_id_idx on public.accounts(owner_id);
 | category | enum (nullable) | 계좌 범주 (bank/investment) |
 | balance | numeric (nullable) | 현재 잔액 — 증권 계좌는 예수금, 은행 계좌는 잔액 |
 | balance_updated_at | timestamptz (nullable) | 잔액 마지막 수정일 |
-| is_default | boolean | 기본 계좌 여부 |
 | memo | text (nullable) | 메모 |
 | created_at | timestamptz | 생성일 |
 | updated_at | timestamptz | 수정일 |
@@ -530,7 +528,6 @@ create table public.payment_methods (
   issuer text,
   last_four text,
   payment_day smallint check (payment_day is null or (payment_day between 1 and 31)),
-  is_default boolean default false,
   memo text,
   created_at timestamptz default now() not null,
   updated_at timestamptz default now() not null,
@@ -554,7 +551,6 @@ create index payment_methods_linked_account_id_idx on public.payment_methods(lin
 | issuer | text (nullable) | 카드사/서비스명 (삼성카드, 카카오 등) |
 | last_four | text (nullable) | 카드 끝 4자리 |
 | payment_day | smallint (nullable) | 신용카드 결제일 (1~31) |
-| is_default | boolean | 기본 결제수단 여부 |
 | memo | text (nullable) | 메모 |
 | created_at | timestamptz | 생성일 |
 | updated_at | timestamptz | 수정일 |

--- a/app/api/accounts/[id]/route.ts
+++ b/app/api/accounts/[id]/route.ts
@@ -50,7 +50,6 @@ export async function PATCH(request: Request, { params }: RouteParams) {
       accountType: input.accountType,
       category: input.category,
       balance: input.balance,
-      isDefault: input.isDefault,
       memo: input.memo,
     });
 

--- a/app/api/accounts/route.ts
+++ b/app/api/accounts/route.ts
@@ -112,7 +112,6 @@ export async function POST(request: Request) {
       accountType: input.accountType,
       category: input.category,
       balance: input.balance,
-      isDefault: input.isDefault,
       memo: input.memo,
     });
 

--- a/app/api/payment-methods/[id]/route.ts
+++ b/app/api/payment-methods/[id]/route.ts
@@ -51,7 +51,6 @@ export async function PATCH(request: Request, { params }: RouteParams) {
       lastFour: input.lastFour,
       paymentDay: input.paymentDay,
       balance: input.balance,
-      isDefault: input.isDefault,
       memo: input.memo,
     });
 

--- a/app/api/payment-methods/route.ts
+++ b/app/api/payment-methods/route.ts
@@ -106,7 +106,6 @@ export async function POST(request: Request) {
       lastFour: input.lastFour,
       paymentDay: input.paymentDay,
       balance: input.balance,
-      isDefault: input.isDefault,
       memo: input.memo,
     });
 

--- a/components/accounts/AccountDeleteDialog.tsx
+++ b/components/accounts/AccountDeleteDialog.tsx
@@ -68,11 +68,6 @@ export function AccountDeleteDialog({
         <div className="rounded-md border p-4 space-y-2">
           <div className="flex items-center justify-between">
             <span className="font-medium">{account.name}</span>
-            {account.isDefault && (
-              <span className="text-xs bg-secondary text-secondary-foreground px-2 py-0.5 rounded">
-                기본
-              </span>
-            )}
           </div>
           <div className="text-sm text-muted-foreground space-y-1">
             {account.broker && (

--- a/components/accounts/AccountFormDialog.tsx
+++ b/components/accounts/AccountFormDialog.tsx
@@ -6,7 +6,6 @@ import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
 import { Button } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -53,7 +52,6 @@ const bankAccountFormSchema = z.object({
   accountType: z.enum(BANK_ACCOUNT_TYPES, {
     message: "계좌 유형을 선택해주세요.",
   }),
-  isDefault: z.boolean(),
   memo: z.string().max(500, "메모는 500자 이내여야 합니다."),
 });
 
@@ -67,7 +65,6 @@ const investmentAccountFormSchema = z.object({
   accountType: z.enum(INVESTMENT_ACCOUNT_TYPES, {
     message: "계좌 유형을 선택해주세요.",
   }),
-  isDefault: z.boolean(),
   memo: z.string().max(500, "메모는 500자 이내여야 합니다."),
 });
 
@@ -133,12 +130,9 @@ export function AccountFormDialog({
       accountNumber: "",
       accountType: defaultAccountType as BankAccountType &
         InvestmentAccountType,
-      isDefault: false,
       memo: "",
     },
   });
-
-  const watchIsDefault = watch("isDefault");
 
   useEffect(() => {
     if (open) {
@@ -155,7 +149,6 @@ export function AccountFormDialog({
           broker: account.broker || "",
           accountNumber: account.accountNumber || "",
           accountType: resolvedType as BankAccountType & InvestmentAccountType,
-          isDefault: account.isDefault,
           memo: account.memo || "",
         });
       } else {
@@ -165,7 +158,6 @@ export function AccountFormDialog({
           accountNumber: "",
           accountType: defaultAccountType as BankAccountType &
             InvestmentAccountType,
-          isDefault: false,
           memo: "",
         });
       }
@@ -183,7 +175,6 @@ export function AccountFormDialog({
             accountNumber: data.accountNumber || null,
             accountType: data.accountType,
             category: isBank ? "bank" : "investment",
-            isDefault: data.isDefault,
             memo: data.memo || null,
           },
         });
@@ -202,7 +193,6 @@ export function AccountFormDialog({
             broker: data.broker,
             accountNumber: "",
             accountType: data.accountType,
-            isDefault: false,
             memo: "",
           });
         } else {
@@ -304,17 +294,6 @@ export function AccountFormDialog({
             {errors.accountNumber.message}
           </p>
         )}
-      </div>
-
-      <div className="flex items-center space-x-2">
-        <Checkbox
-          id="isDefault"
-          checked={watchIsDefault}
-          onCheckedChange={(checked) => setValue("isDefault", checked === true)}
-        />
-        <Label htmlFor="isDefault" className="font-normal cursor-pointer">
-          기본 계좌로 설정
-        </Label>
       </div>
 
       <div className="space-y-2">

--- a/components/accounts/AccountList.tsx
+++ b/components/accounts/AccountList.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { MoreHorizontal, Pencil, Star, Trash2 } from "lucide-react";
+import { MoreHorizontal, Pencil, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -19,7 +18,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { useAccounts, useUpdateAccount } from "@/hooks/use-accounts";
+import { useAccounts } from "@/hooks/use-accounts";
 import { useCurrentUserId } from "@/hooks/use-current-user";
 import type { AccountWithOwner } from "@/lib/api/account";
 import { AccountDeleteDialog } from "./AccountDeleteDialog";
@@ -61,7 +60,6 @@ interface AccountTableProps {
   category?: "bank" | "investment";
   onEdit: (account: AccountWithOwner, category?: "bank" | "investment") => void;
   onDelete: (account: AccountWithOwner) => void;
-  onSetDefault: (account: AccountWithOwner) => void;
 }
 
 function AccountTable({
@@ -70,7 +68,6 @@ function AccountTable({
   category,
   onEdit,
   onDelete,
-  onSetDefault,
 }: AccountTableProps) {
   return (
     <Table>
@@ -89,16 +86,7 @@ function AccountTable({
           const isOwner = currentUserId === account.ownerId;
           return (
             <TableRow key={account.id}>
-              <TableCell className="font-medium pl-5">
-                <div className="flex items-center gap-2">
-                  {account.name}
-                  {account.isDefault && (
-                    <Badge variant="secondary" className="text-xs">
-                      기본
-                    </Badge>
-                  )}
-                </div>
-              </TableCell>
+              <TableCell className="font-medium pl-5">{account.name}</TableCell>
               <TableCell className="text-gray-600">
                 {account.ownerName}
               </TableCell>
@@ -130,12 +118,6 @@ function AccountTable({
                         <Pencil className="h-4 w-4 mr-2" />
                         수정
                       </DropdownMenuItem>
-                      {!account.isDefault && (
-                        <DropdownMenuItem onClick={() => onSetDefault(account)}>
-                          <Star className="h-4 w-4 mr-2" />
-                          기본 계좌로 설정
-                        </DropdownMenuItem>
-                      )}
                       <DropdownMenuItem
                         className="text-destructive focus:text-destructive"
                         onClick={() => onDelete(account)}
@@ -158,7 +140,6 @@ function AccountTable({
 export function AccountList({ filter }: AccountListProps) {
   const { data: accounts, isLoading, error } = useAccounts();
   const { userId: currentUserId } = useCurrentUserId();
-  const updateAccount = useUpdateAccount();
 
   const [editingAccount, setEditingAccount] = useState<AccountWithOwner | null>(
     null,
@@ -169,22 +150,6 @@ export function AccountList({ filter }: AccountListProps) {
   const [deletingAccount, setDeletingAccount] =
     useState<AccountWithOwner | null>(null);
   const [isFormOpen, setIsFormOpen] = useState(false);
-
-  const handleSetDefault = async (account: AccountWithOwner) => {
-    try {
-      await updateAccount.mutateAsync({
-        id: account.id,
-        data: { isDefault: true },
-      });
-      toast.success(`${account.name}을(를) 기본 계좌로 설정했습니다.`);
-    } catch (error) {
-      if (error instanceof Error) {
-        toast.error(error.message);
-      } else {
-        toast.error("기본 계좌 설정에 실패했습니다.");
-      }
-    }
-  };
 
   const handleEdit = (
     account: AccountWithOwner,
@@ -256,7 +221,6 @@ export function AccountList({ filter }: AccountListProps) {
             currentUserId={currentUserId}
             onEdit={handleEdit}
             onDelete={handleDelete}
-            onSetDefault={handleSetDefault}
           />
         </div>
 
@@ -311,7 +275,6 @@ export function AccountList({ filter }: AccountListProps) {
                 category="bank"
                 onEdit={handleEdit}
                 onDelete={handleDelete}
-                onSetDefault={handleSetDefault}
               />
             </div>
           </div>
@@ -329,7 +292,6 @@ export function AccountList({ filter }: AccountListProps) {
                 category="investment"
                 onEdit={handleEdit}
                 onDelete={handleDelete}
-                onSetDefault={handleSetDefault}
               />
             </div>
           </div>

--- a/components/accounts/AccountNewForm.tsx
+++ b/components/accounts/AccountNewForm.tsx
@@ -8,7 +8,6 @@ import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
 import { Button } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -43,7 +42,6 @@ const detailFormSchema = z.object({
     message: "계좌 유형을 선택해주세요.",
   }),
   balanceStr: z.string(),
-  isDefault: z.boolean(),
   memo: z.string().max(500, "메모는 500자 이내여야 합니다."),
 });
 
@@ -120,12 +118,9 @@ function DetailForm({ category, onBack }: DetailFormProps) {
       accountNumber: "",
       accountType: defaultAccountType,
       balanceStr: "",
-      isDefault: false,
       memo: "",
     },
   });
-
-  const watchIsDefault = watch("isDefault");
 
   const onSubmit = async (data: DetailFormData) => {
     const balance =
@@ -143,7 +138,6 @@ function DetailForm({ category, onBack }: DetailFormProps) {
         accountType: data.accountType,
         category,
         balance,
-        isDefault: data.isDefault,
         memo: data.memo || undefined,
       });
       toast.success(`${data.name} 계좌가 추가되었습니다.`);
@@ -253,17 +247,6 @@ function DetailForm({ category, onBack }: DetailFormProps) {
             {errors.balanceStr.message}
           </p>
         )}
-      </div>
-
-      <div className="flex items-center space-x-2">
-        <Checkbox
-          id="isDefault"
-          checked={watchIsDefault}
-          onCheckedChange={(checked) => setValue("isDefault", checked === true)}
-        />
-        <Label htmlFor="isDefault" className="font-normal cursor-pointer">
-          기본 계좌로 설정
-        </Label>
       </div>
 
       <div className="space-y-2">

--- a/components/accounts/PaymentMethodDeleteDialog.tsx
+++ b/components/accounts/PaymentMethodDeleteDialog.tsx
@@ -69,11 +69,6 @@ export function PaymentMethodDeleteDialog({
         <div className="rounded-md border p-4 space-y-2">
           <div className="flex items-center justify-between">
             <span className="font-medium">{paymentMethod.name}</span>
-            {paymentMethod.isDefault && (
-              <span className="text-xs bg-secondary text-secondary-foreground px-2 py-0.5 rounded">
-                기본
-              </span>
-            )}
           </div>
           <div className="text-sm text-muted-foreground space-y-1">
             <div className="flex justify-between">

--- a/components/accounts/PaymentMethodFormDialog.tsx
+++ b/components/accounts/PaymentMethodFormDialog.tsx
@@ -6,7 +6,6 @@ import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
 import { Button } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -101,7 +100,6 @@ const paymentMethodFormSchema = z.object({
   balanceStr: z.string().refine((value) => value === "" || Number(value) >= 0, {
     message: "잔액은 0 이상이어야 합니다.",
   }),
-  isDefault: z.boolean(),
   memo: z.string().max(500, "메모는 500자 이내여야 합니다.").optional(),
 });
 
@@ -140,12 +138,10 @@ export function PaymentMethodFormDialog({
       lastFour: "",
       paymentDay: undefined,
       balanceStr: "",
-      isDefault: false,
       memo: "",
     },
   });
 
-  const watchIsDefault = watch("isDefault");
   const watchType = watch("type");
 
   const showCardFields =
@@ -165,7 +161,6 @@ export function PaymentMethodFormDialog({
           paymentDay: paymentMethod.paymentDay ?? undefined,
           balanceStr:
             paymentMethod.balance !== null ? String(paymentMethod.balance) : "",
-          isDefault: paymentMethod.isDefault,
           memo: paymentMethod.memo ?? "",
         });
       } else {
@@ -177,7 +172,6 @@ export function PaymentMethodFormDialog({
           lastFour: "",
           paymentDay: undefined,
           balanceStr: "",
-          isDefault: false,
           memo: "",
         });
       }
@@ -199,7 +193,6 @@ export function PaymentMethodFormDialog({
       paymentDay: Number.isNaN(data.paymentDay)
         ? undefined
         : (data.paymentDay as number | undefined),
-      isDefault: data.isDefault,
       memo: data.memo || undefined,
       ...(shouldSubmitBalance && { balance }),
     };
@@ -374,17 +367,6 @@ export function PaymentMethodFormDialog({
             ))}
           </SelectContent>
         </Select>
-      </div>
-
-      <div className="flex items-center space-x-2">
-        <Checkbox
-          id="pm-is-default"
-          checked={watchIsDefault}
-          onCheckedChange={(checked) => setValue("isDefault", checked === true)}
-        />
-        <Label htmlFor="pm-is-default" className="font-normal cursor-pointer">
-          기본 결제수단으로 설정
-        </Label>
       </div>
 
       <div className="space-y-2">

--- a/components/accounts/PaymentMethodList.tsx
+++ b/components/accounts/PaymentMethodList.tsx
@@ -2,7 +2,6 @@
 
 import { MoreHorizontal, Pencil, Trash2 } from "lucide-react";
 import { useState } from "react";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -111,11 +110,6 @@ export function PaymentMethodList() {
                   <TableCell className="font-medium pl-5">
                     <div className="flex items-center gap-2">
                       {method.name}
-                      {method.isDefault && (
-                        <Badge variant="secondary" className="text-xs">
-                          기본
-                        </Badge>
-                      )}
                       {method.lastFour && (
                         <span className="text-xs text-gray-400">
                           ···· {method.lastFour}

--- a/components/accounts/PaymentMethodNewForm.tsx
+++ b/components/accounts/PaymentMethodNewForm.tsx
@@ -8,7 +8,6 @@ import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
 import { Button } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -74,7 +73,6 @@ const paymentMethodFormSchema = z.object({
   balanceStr: z.string().refine((value) => value === "" || Number(value) >= 0, {
     message: "잔액은 0 이상이어야 합니다.",
   }),
-  isDefault: z.boolean(),
   memo: z.string().max(500, "메모는 500자 이내여야 합니다.").optional(),
 });
 
@@ -139,12 +137,10 @@ function DetailForm({ type, onBack }: DetailFormProps) {
       lastFour: "",
       paymentDay: undefined,
       balanceStr: "",
-      isDefault: false,
       memo: "",
     },
   });
 
-  const watchIsDefault = watch("isDefault");
   const watchType = watch("type");
 
   const showCardFields =
@@ -166,7 +162,6 @@ function DetailForm({ type, onBack }: DetailFormProps) {
       paymentDay: Number.isNaN(data.paymentDay)
         ? undefined
         : (data.paymentDay as number | undefined),
-      isDefault: data.isDefault,
       memo: data.memo || undefined,
       ...(showAuxiliaryBalance && { balance }),
     };
@@ -303,17 +298,6 @@ function DetailForm({ type, onBack }: DetailFormProps) {
             ))}
           </SelectContent>
         </Select>
-      </div>
-
-      <div className="flex items-center space-x-2">
-        <Checkbox
-          id="pm-is-default"
-          checked={watchIsDefault}
-          onCheckedChange={(checked) => setValue("isDefault", checked === true)}
-        />
-        <Label htmlFor="pm-is-default" className="font-normal cursor-pointer">
-          기본 결제수단으로 설정
-        </Label>
       </div>
 
       <div className="space-y-2">

--- a/components/transactions/AccountSelector.tsx
+++ b/components/transactions/AccountSelector.tsx
@@ -75,11 +75,6 @@ export function AccountSelector<T extends FieldValues & { accountId: string }>({
                     ({account.broker})
                   </span>
                 )}
-                {account.isDefault && (
-                  <span className="text-xs px-1.5 py-0.5 bg-blue-100 text-blue-600 rounded">
-                    기본
-                  </span>
-                )}
               </span>
             </SelectItem>
           ))}

--- a/components/transactions/MultiTransactionFormWrapper.tsx
+++ b/components/transactions/MultiTransactionFormWrapper.tsx
@@ -51,9 +51,8 @@ export function MultiTransactionFormWrapper({
     );
   }
 
-  // 기본 계좌 또는 첫 번째 계좌 (본인 계좌 중에서만)
-  const defaultAccount = myAccounts.find((a) => a.isDefault);
-  const defaultAccountId = defaultAccount?.id ?? myAccounts[0].id;
+  // 첫 번째 계좌 (본인 계좌 중에서만)
+  const defaultAccountId = myAccounts[0].id;
 
   return (
     <MultiTransactionForm

--- a/components/transactions/funnel/SelectMetaStep.tsx
+++ b/components/transactions/funnel/SelectMetaStep.tsx
@@ -3,7 +3,6 @@
 import { ChevronRightIcon, PlusCircle } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { DatePickerInput } from "@/components/ui/date-picker";
 import { Label } from "@/components/ui/label";
@@ -34,11 +33,8 @@ export function SelectMetaStep({
   isLoadingAccounts,
   onNext,
 }: SelectMetaStepProps) {
-  // 기본 계좌 찾기: defaultAccountId > isDefault=true > 첫 번째 계좌
   const getDefaultAccountId = () => {
     if (defaultAccountId) return defaultAccountId;
-    const defaultAccount = accounts.find((a) => a.isDefault);
-    if (defaultAccount) return defaultAccount.id;
     if (accounts.length > 0) return accounts[0].id;
     return "";
   };
@@ -88,14 +84,6 @@ export function SelectMetaStep({
                   <span className="flex items-center gap-2">
                     {account.name}
                     {account.broker && ` (${account.broker})`}
-                    {account.isDefault && (
-                      <Badge
-                        variant="secondary"
-                        className="text-xs px-1.5 py-0"
-                      >
-                        기본
-                      </Badge>
-                    )}
                   </span>
                 </SelectItem>
               ))}

--- a/components/transactions/funnel/TransactionFunnel.tsx
+++ b/components/transactions/funnel/TransactionFunnel.tsx
@@ -97,7 +97,7 @@ export function TransactionFunnel({ defaultDate }: TransactionFunnelProps) {
 
   // 기본 계좌 찾기 (본인 계좌 중에서만)
   const myAccounts = accounts.filter((a) => a.ownerId === currentUserId);
-  const defaultAccount = myAccounts.find((a) => a.isDefault) ?? myAccounts[0];
+  const defaultAccount = myAccounts[0];
   const defaultAccountId = defaultAccount?.id;
 
   return (

--- a/lib/api/account.ts
+++ b/lib/api/account.ts
@@ -11,7 +11,6 @@ export interface CreateAccountParams {
   accountType: AccountType;
   category?: AccountCategory;
   balance?: number;
-  isDefault?: boolean;
   memo?: string;
 }
 
@@ -22,7 +21,6 @@ export interface UpdateAccountParams {
   accountType?: AccountType;
   category?: AccountCategory | null;
   balance?: number | null;
-  isDefault?: boolean;
   memo?: string | null;
 }
 
@@ -38,7 +36,6 @@ export interface AccountWithOwner {
   category: AccountCategory | null;
   balance: number | null;
   balanceUpdatedAt: string | null;
-  isDefault: boolean;
   memo: string | null;
   createdAt: string;
   updatedAt: string;
@@ -83,7 +80,6 @@ export async function getAccounts(
     category: account.category,
     balance: account.balance,
     balanceUpdatedAt: account.balance_updated_at,
-    isDefault: account.is_default ?? false,
     memo: account.memo,
     createdAt: account.created_at,
     updatedAt: account.updated_at,
@@ -92,7 +88,6 @@ export async function getAccounts(
 
 /**
  * 계좌 생성
- * - is_default가 true이면 동일 소유자의 다른 계좌 is_default를 false로 변경
  */
 export async function createAccount(
   supabase: SupabaseClient<Database>,
@@ -107,7 +102,6 @@ export async function createAccount(
     accountType,
     category,
     balance,
-    isDefault,
     memo,
   } = params;
 
@@ -128,15 +122,6 @@ export async function createAccount(
     );
   }
 
-  // is_default가 true이면 동일 소유자의 다른 계좌 is_default를 false로
-  if (isDefault) {
-    await supabase
-      .from("accounts")
-      .update({ is_default: false })
-      .eq("household_id", householdId)
-      .eq("owner_id", ownerId);
-  }
-
   const { data, error } = await supabase
     .from("accounts")
     .insert({
@@ -149,7 +134,6 @@ export async function createAccount(
       category: category ?? null,
       balance: balance ?? null,
       balance_updated_at: balance != null ? new Date().toISOString() : null,
-      is_default: isDefault ?? false,
       memo: memo || null,
     })
     .select()
@@ -166,7 +150,6 @@ export async function createAccount(
 /**
  * 계좌 수정
  * - 소유권 확인 필수
- * - is_default가 true이면 동일 소유자의 다른 계좌 is_default를 false로 변경
  */
 export async function updateAccount(
   supabase: SupabaseClient<Database>,
@@ -212,16 +195,6 @@ export async function updateAccount(
     }
   }
 
-  // is_default가 true이면 동일 소유자의 다른 계좌 is_default를 false로
-  if (params.isDefault === true) {
-    await supabase
-      .from("accounts")
-      .update({ is_default: false })
-      .eq("household_id", existingAccount.household_id)
-      .eq("owner_id", ownerId)
-      .neq("id", accountId);
-  }
-
   const { data, error } = await supabase
     .from("accounts")
     .update({
@@ -238,7 +211,6 @@ export async function updateAccount(
         balance: params.balance,
         balance_updated_at: new Date().toISOString(),
       }),
-      ...(params.isDefault !== undefined && { is_default: params.isDefault }),
       ...(params.memo !== undefined && { memo: params.memo }),
       updated_at: new Date().toISOString(),
     })

--- a/lib/api/payment-method.ts
+++ b/lib/api/payment-method.ts
@@ -25,7 +25,6 @@ export interface CreatePaymentMethodParams {
   lastFour?: string;
   paymentDay?: number;
   balance?: number | null;
-  isDefault?: boolean;
   memo?: string;
 }
 
@@ -37,7 +36,6 @@ export interface UpdatePaymentMethodParams {
   lastFour?: string | null;
   paymentDay?: number | null;
   balance?: number | null;
-  isDefault?: boolean;
   memo?: string | null;
 }
 
@@ -55,7 +53,6 @@ export interface PaymentMethodWithDetails {
   paymentDay: number | null;
   balance: number | null;
   balanceUpdatedAt: string | null;
-  isDefault: boolean;
   memo: string | null;
   createdAt: string;
   updatedAt: string;
@@ -117,7 +114,6 @@ export async function getPaymentMethods(
     paymentDay: pm.payment_day,
     balance: pm.balance,
     balanceUpdatedAt: pm.balance_updated_at,
-    isDefault: pm.is_default ?? false,
     memo: pm.memo,
     createdAt: pm.created_at,
     updatedAt: pm.updated_at,
@@ -138,7 +134,6 @@ export async function createPaymentMethod(
     lastFour,
     paymentDay,
     balance,
-    isDefault,
     memo,
   } = params;
 
@@ -177,15 +172,6 @@ export async function createPaymentMethod(
     }
   }
 
-  // isDefault가 true이면 동일 소유자의 다른 결제수단 is_default를 false로
-  if (isDefault) {
-    await supabase
-      .from("payment_methods")
-      .update({ is_default: false })
-      .eq("household_id", householdId)
-      .eq("owner_id", ownerId);
-  }
-
   const normalizedBalance = normalizePaymentMethodBalance(type, balance);
   const now = new Date().toISOString();
 
@@ -202,7 +188,6 @@ export async function createPaymentMethod(
       payment_day: paymentDay ?? null,
       balance: normalizedBalance,
       balance_updated_at: normalizedBalance !== null ? now : null,
-      is_default: isDefault ?? false,
       memo: memo || null,
     })
     .select()
@@ -286,16 +271,6 @@ export async function updatePaymentMethod(
     }
   }
 
-  // isDefault가 true이면 동일 소유자의 다른 결제수단 is_default를 false로
-  if (params.isDefault === true) {
-    await supabase
-      .from("payment_methods")
-      .update({ is_default: false })
-      .eq("household_id", existing.household_id)
-      .eq("owner_id", ownerId)
-      .neq("id", paymentMethodId);
-  }
-
   const nextType = params.type ?? existing.type;
   const nextBalance =
     params.balance !== undefined ? params.balance : existing.balance;
@@ -328,7 +303,6 @@ export async function updatePaymentMethod(
       ...(balanceUpdatedAt !== undefined && {
         balance_updated_at: balanceUpdatedAt,
       }),
-      ...(params.isDefault !== undefined && { is_default: params.isDefault }),
       ...(params.memo !== undefined && { memo: params.memo }),
       updated_at: new Date().toISOString(),
     })

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -298,7 +298,7 @@ async function listReferences(
       supabase
         .from("accounts")
         .select(
-          "id, owner_id, name, broker, account_type, category, balance, balance_updated_at, is_default",
+          "id, owner_id, name, broker, account_type, category, balance, balance_updated_at",
         )
         .eq("household_id", auth.householdId)
         .order("created_at", { ascending: false }),

--- a/schemas/account.ts
+++ b/schemas/account.ts
@@ -31,7 +31,6 @@ export const createAccountSchema = z.object({
   }),
   category: z.enum(accountCategoryValues).optional(),
   balance: z.number().min(0, "잔액은 0 이상이어야 합니다.").optional(),
-  isDefault: z.boolean().optional().default(false),
   memo: z.string().max(500, "메모는 500자 이내여야 합니다.").optional(),
 });
 
@@ -64,7 +63,6 @@ export const updateAccountSchema = z.object({
     .min(0, "잔액은 0 이상이어야 합니다.")
     .nullable()
     .optional(),
-  isDefault: z.boolean().optional(),
   memo: z
     .string()
     .max(500, "메모는 500자 이내여야 합니다.")

--- a/schemas/payment-method.test.ts
+++ b/schemas/payment-method.test.ts
@@ -92,17 +92,6 @@ describe("createPaymentMethodSchema", () => {
     });
     expect(result.success).toBe(false);
   });
-
-  it("isDefault 기본값은 false다", () => {
-    const result = createPaymentMethodSchema.safeParse({
-      name: "카드",
-      type: "debit_card",
-    });
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data.isDefault).toBe(false);
-    }
-  });
 });
 
 describe("updatePaymentMethodSchema", () => {

--- a/schemas/payment-method.ts
+++ b/schemas/payment-method.ts
@@ -33,7 +33,6 @@ export const createPaymentMethodSchema = z.object({
     .max(31, "결제일은 31일 이하여야 합니다.")
     .optional(),
   balance: z.number().min(0, "잔액은 0 이상이어야 합니다.").optional(),
-  isDefault: z.boolean().optional().default(false),
   memo: z.string().max(500, "메모는 500자 이내여야 합니다.").optional(),
 });
 
@@ -76,7 +75,6 @@ export const updatePaymentMethodSchema = z.object({
     .min(0, "잔액은 0 이상이어야 합니다.")
     .nullable()
     .optional(),
-  isDefault: z.boolean().optional(),
   memo: z
     .string()
     .max(500, "메모는 500자 이내여야 합니다.")

--- a/supabase/migrations/20260528000000_remove_is_default.sql
+++ b/supabase/migrations/20260528000000_remove_is_default.sql
@@ -1,0 +1,3 @@
+-- Remove is_default column from accounts and payment_methods
+alter table public.accounts drop column if exists is_default;
+alter table public.payment_methods drop column if exists is_default;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -45,7 +45,6 @@ export type Database = {
           created_at: string;
           household_id: string;
           id: string;
-          is_default: boolean | null;
           memo: string | null;
           name: string;
           owner_id: string;
@@ -61,7 +60,6 @@ export type Database = {
           created_at?: string;
           household_id: string;
           id?: string;
-          is_default?: boolean | null;
           memo?: string | null;
           name: string;
           owner_id: string;
@@ -77,7 +75,6 @@ export type Database = {
           created_at?: string;
           household_id?: string;
           id?: string;
-          is_default?: boolean | null;
           memo?: string | null;
           name?: string;
           owner_id?: string;
@@ -578,7 +575,6 @@ export type Database = {
           created_at: string;
           household_id: string;
           id: string;
-          is_default: boolean | null;
           issuer: string | null;
           last_four: string | null;
           linked_account_id: string | null;
@@ -595,7 +591,6 @@ export type Database = {
           created_at?: string;
           household_id: string;
           id?: string;
-          is_default?: boolean | null;
           issuer?: string | null;
           last_four?: string | null;
           linked_account_id?: string | null;
@@ -612,7 +607,6 @@ export type Database = {
           created_at?: string;
           household_id?: string;
           id?: string;
-          is_default?: boolean | null;
           issuer?: string | null;
           last_four?: string | null;
           linked_account_id?: string | null;


### PR DESCRIPTION
### 개요
- 계좌(accounts) 및 결제 수단(payment_methods)에서 `is_default` / `isDefault` 속성을 완전히 제거하였습니다. (이슈 #292)

### 변경 사항
1. **DB 마이그레이션**: `accounts`, `payment_methods`에서 `is_default` 컬럼을 삭제하는 마이그레이션 추가
2. **API & Schema**: Zod 스키마, API 엔드포인트 및 관련 테스트에서 `isDefault` 관련 파라미터와 로직 제거
3. **UI 컴포넌트**: 계좌/결제 수단 등록/수정 다이얼로그의 기본값 체크박스 및 목록/거래 선택창의 기본값 배지 제거
4. **기타**: MCP 도구 및 `DATABASE.md` 내 `is_default` 관련 참조 제거

### 테스트 결과
- TypeScript 빌드 성공 (`tsc --noEmit`)
- Vitest 테스트 전체 통과