### PR TITLE
feat: 계좌번호를 뒤 4자리만 저장하도록 정리 (issue #308)

### DIFF
--- a/.claude/docs/DATABASE.md
+++ b/.claude/docs/DATABASE.md
@@ -328,7 +328,7 @@ create table public.accounts (
   owner_id uuid not null references public.profiles(id) on delete cascade,
   name text not null,
   broker text,
-  account_number text,
+  last_four text check (last_four is null or last_four ~ '^\d{4}$'),
   account_type account_type,
   category account_category,         -- 계좌 범주 (bank/investment)
   balance numeric(18, 2),            -- 현재 잔액 (예수금 포함, 수동 입력)
@@ -351,7 +351,7 @@ create index accounts_owner_id_idx on public.accounts(owner_id);
 | owner_id | uuid (FK) | 계좌 소유자 |
 | name | text | 계좌명 |
 | broker | text (nullable) | 증권사/은행명 |
-| account_number | text (nullable) | 계좌번호 |
+| last_four | text (nullable) | 계좌번호 뒤 4자리 |
 | account_type | enum (nullable) | 계좌 유형 |
 | category | enum (nullable) | 계좌 범주 (bank/investment) |
 | balance | numeric (nullable) | 현재 잔액 — 증권 계좌는 예수금, 은행 계좌는 잔액 |

--- a/app/api/accounts/[id]/route.ts
+++ b/app/api/accounts/[id]/route.ts
@@ -46,7 +46,7 @@ export async function PATCH(request: Request, { params }: RouteParams) {
     const account = await updateAccount(supabase, id, user.id, {
       name: input.name,
       broker: input.broker,
-      accountNumber: input.accountNumber,
+      lastFour: input.lastFour,
       accountType: input.accountType,
       category: input.category,
       balance: input.balance,

--- a/app/api/accounts/route.ts
+++ b/app/api/accounts/route.ts
@@ -108,7 +108,7 @@ export async function POST(request: Request) {
       ownerId: user.id,
       name: input.name,
       broker: input.broker,
-      accountNumber: input.accountNumber,
+      lastFour: input.lastFour,
       accountType: input.accountType,
       category: input.category,
       balance: input.balance,

--- a/components/accounts/AccountDeleteDialog.tsx
+++ b/components/accounts/AccountDeleteDialog.tsx
@@ -85,10 +85,10 @@ export function AccountDeleteDialog({
                 </span>
               </div>
             )}
-            {account.accountNumber && (
+            {account.lastFour && (
               <div className="flex justify-between">
-                <span>계좌번호</span>
-                <span>{account.accountNumber}</span>
+                <span>계좌번호 뒤 4자리</span>
+                <span>{account.lastFour}</span>
               </div>
             )}
           </div>

--- a/components/accounts/AccountFormDialog.tsx
+++ b/components/accounts/AccountFormDialog.tsx
@@ -48,7 +48,7 @@ const bankAccountFormSchema = z.object({
     .min(1, "계좌명은 필수입니다.")
     .max(50, "계좌명은 50자 이내여야 합니다."),
   broker: z.string().max(50, "증권사/은행명은 50자 이내여야 합니다."),
-  accountNumber: z.string().max(50, "계좌번호는 50자 이내여야 합니다."),
+  lastFour: z.string().regex(/^\d{0,4}$/, "숫자 4자리만 입력해주세요."),
   accountType: z.enum(BANK_ACCOUNT_TYPES, {
     message: "계좌 유형을 선택해주세요.",
   }),
@@ -61,7 +61,7 @@ const investmentAccountFormSchema = z.object({
     .min(1, "계좌명은 필수입니다.")
     .max(50, "계좌명은 50자 이내여야 합니다."),
   broker: z.string().max(50, "증권사/은행명은 50자 이내여야 합니다."),
-  accountNumber: z.string().max(50, "계좌번호는 50자 이내여야 합니다."),
+  lastFour: z.string().regex(/^\d{0,4}$/, "숫자 4자리만 입력해주세요."),
   accountType: z.enum(INVESTMENT_ACCOUNT_TYPES, {
     message: "계좌 유형을 선택해주세요.",
   }),
@@ -127,7 +127,7 @@ export function AccountFormDialog({
     defaultValues: {
       name: "",
       broker: "",
-      accountNumber: "",
+      lastFour: "",
       accountType: defaultAccountType as BankAccountType &
         InvestmentAccountType,
       memo: "",
@@ -147,7 +147,7 @@ export function AccountFormDialog({
         reset({
           name: account.name,
           broker: account.broker || "",
-          accountNumber: account.accountNumber || "",
+          lastFour: account.lastFour || "",
           accountType: resolvedType as BankAccountType & InvestmentAccountType,
           memo: account.memo || "",
         });
@@ -155,7 +155,7 @@ export function AccountFormDialog({
         reset({
           name: "",
           broker: "",
-          accountNumber: "",
+          lastFour: "",
           accountType: defaultAccountType as BankAccountType &
             InvestmentAccountType,
           memo: "",
@@ -172,7 +172,7 @@ export function AccountFormDialog({
           data: {
             name: data.name,
             broker: data.broker || null,
-            accountNumber: data.accountNumber || null,
+            lastFour: data.lastFour || null,
             accountType: data.accountType,
             category: isBank ? "bank" : "investment",
             memo: data.memo || null,
@@ -191,7 +191,7 @@ export function AccountFormDialog({
           reset({
             name: "",
             broker: data.broker,
-            accountNumber: "",
+            lastFour: "",
             accountType: data.accountType,
             memo: "",
           });
@@ -282,17 +282,17 @@ export function AccountFormDialog({
       </div>
 
       <div className="space-y-2">
-        <Label htmlFor="accountNumber">계좌번호</Label>
+        <Label htmlFor="lastFour">계좌번호 뒤 4자리</Label>
         <Input
-          id="accountNumber"
-          placeholder="예: 123-456-78901234"
-          {...register("accountNumber")}
-          aria-invalid={!!errors.accountNumber}
+          id="lastFour"
+          inputMode="numeric"
+          maxLength={4}
+          placeholder="예: 1234"
+          {...register("lastFour")}
+          aria-invalid={!!errors.lastFour}
         />
-        {errors.accountNumber && (
-          <p className="text-sm text-destructive">
-            {errors.accountNumber.message}
-          </p>
+        {errors.lastFour && (
+          <p className="text-sm text-destructive">{errors.lastFour.message}</p>
         )}
       </div>
 

--- a/components/accounts/AccountList.test.tsx
+++ b/components/accounts/AccountList.test.tsx
@@ -30,7 +30,7 @@ const account: AccountWithOwner = {
   ownerName: "진호",
   name: "NH ISA",
   broker: "NH투자증권",
-  accountNumber: "123-456",
+  lastFour: "1234",
   accountType: "isa",
   category: "investment",
   balance: null,
@@ -51,6 +51,6 @@ describe("AccountList", () => {
     expect(screen.getByText("NH ISA")).toBeInTheDocument();
     expect(screen.getByText("NH투자증권")).toBeInTheDocument();
     expect(screen.getByText("ISA")).toBeInTheDocument();
-    expect(screen.getByText("123-456")).toBeInTheDocument();
+    expect(screen.getByText("끝 1234")).toBeInTheDocument();
   });
 });

--- a/components/accounts/AccountList.tsx
+++ b/components/accounts/AccountList.tsx
@@ -101,8 +101,8 @@ function AccountCollection({
                   <Building2 className="size-4" />
                   {account.broker || "기관 미입력"}
                 </span>
-                {account.accountNumber && (
-                  <span className="text-gray-400">{account.accountNumber}</span>
+                {account.lastFour && (
+                  <span className="text-gray-400">끝 {account.lastFour}</span>
                 )}
               </div>
             </div>

--- a/components/accounts/AccountNewForm.tsx
+++ b/components/accounts/AccountNewForm.tsx
@@ -37,7 +37,7 @@ const detailFormSchema = z.object({
     .min(1, "계좌명은 필수입니다.")
     .max(50, "계좌명은 50자 이내여야 합니다."),
   broker: z.string().max(50, "증권사/은행명은 50자 이내여야 합니다."),
-  accountNumber: z.string().max(50, "계좌번호는 50자 이내여야 합니다."),
+  lastFour: z.string().regex(/^\d{0,4}$/, "숫자 4자리만 입력해주세요."),
   accountType: z.enum(ALL_ACCOUNT_TYPES, {
     message: "계좌 유형을 선택해주세요.",
   }),
@@ -115,7 +115,7 @@ function DetailForm({ category, onBack }: DetailFormProps) {
     defaultValues: {
       name: "",
       broker: "",
-      accountNumber: "",
+      lastFour: "",
       accountType: defaultAccountType,
       balanceStr: "",
       memo: "",
@@ -134,7 +134,7 @@ function DetailForm({ category, onBack }: DetailFormProps) {
       await createAccount.mutateAsync({
         name: data.name,
         broker: data.broker || undefined,
-        accountNumber: data.accountNumber || undefined,
+        lastFour: data.lastFour || undefined,
         accountType: data.accountType,
         category,
         balance,
@@ -216,18 +216,17 @@ function DetailForm({ category, onBack }: DetailFormProps) {
       </div>
 
       <div className="space-y-2">
-        <Label htmlFor="accountNumber">계좌번호</Label>
+        <Label htmlFor="lastFour">계좌번호 뒤 4자리</Label>
         <Input
-          id="accountNumber"
+          id="lastFour"
           inputMode="numeric"
-          placeholder="예: 123-456-78901234"
-          {...register("accountNumber")}
-          aria-invalid={!!errors.accountNumber}
+          maxLength={4}
+          placeholder="예: 1234"
+          {...register("lastFour")}
+          aria-invalid={!!errors.lastFour}
         />
-        {errors.accountNumber && (
-          <p className="text-sm text-destructive">
-            {errors.accountNumber.message}
-          </p>
+        {errors.lastFour && (
+          <p className="text-sm text-destructive">{errors.lastFour.message}</p>
         )}
       </div>
 

--- a/lib/api/account.ts
+++ b/lib/api/account.ts
@@ -7,7 +7,7 @@ export interface CreateAccountParams {
   ownerId: string;
   name: string;
   broker?: string;
-  accountNumber?: string;
+  lastFour?: string;
   accountType: AccountType;
   category?: AccountCategory;
   balance?: number;
@@ -17,7 +17,7 @@ export interface CreateAccountParams {
 export interface UpdateAccountParams {
   name?: string;
   broker?: string | null;
-  accountNumber?: string | null;
+  lastFour?: string | null;
   accountType?: AccountType;
   category?: AccountCategory | null;
   balance?: number | null;
@@ -31,7 +31,7 @@ export interface AccountWithOwner {
   ownerName: string;
   name: string;
   broker: string | null;
-  accountNumber: string | null;
+  lastFour: string | null;
   accountType: AccountType | null;
   category: AccountCategory | null;
   balance: number | null;
@@ -75,7 +75,7 @@ export async function getAccounts(
     ownerName: ownerMap.get(account.owner_id) ?? "알 수 없음",
     name: account.name,
     broker: account.broker,
-    accountNumber: account.account_number,
+    lastFour: account.last_four,
     accountType: account.account_type,
     category: account.category,
     balance: account.balance,
@@ -98,7 +98,7 @@ export async function createAccount(
     ownerId,
     name,
     broker,
-    accountNumber,
+    lastFour,
     accountType,
     category,
     balance,
@@ -129,7 +129,7 @@ export async function createAccount(
       owner_id: ownerId,
       name,
       broker: broker || null,
-      account_number: accountNumber || null,
+      last_four: lastFour || null,
       account_type: accountType,
       category: category ?? null,
       balance: balance ?? null,
@@ -200,8 +200,8 @@ export async function updateAccount(
     .update({
       ...(params.name !== undefined && { name: params.name }),
       ...(params.broker !== undefined && { broker: params.broker }),
-      ...(params.accountNumber !== undefined && {
-        account_number: params.accountNumber,
+      ...(params.lastFour !== undefined && {
+        last_four: params.lastFour,
       }),
       ...(params.accountType !== undefined && {
         account_type: params.accountType,

--- a/lib/ledger/money-source-options.test.ts
+++ b/lib/ledger/money-source-options.test.ts
@@ -11,7 +11,7 @@ const bankAccount: LedgerMoneySourceAccount = {
   name: "국민은행 생활비",
   ownerName: "진호",
   broker: "국민은행",
-  accountNumber: "111-222",
+  lastFour: "1222",
   accountType: "checking",
   category: "bank",
 };
@@ -21,7 +21,7 @@ const legacyBankAccount: LedgerMoneySourceAccount = {
   name: "신한 적금",
   ownerName: "진호",
   broker: "신한은행",
-  accountNumber: null,
+  lastFour: null,
   accountType: "savings",
   category: null,
 };
@@ -31,7 +31,7 @@ const investmentAccount: LedgerMoneySourceAccount = {
   name: "토스증권",
   ownerName: "수진",
   broker: "토스증권",
-  accountNumber: "333-444",
+  lastFour: "3444",
   accountType: "stock",
   category: "investment",
 };
@@ -41,7 +41,7 @@ const legacyInvestmentAccount: LedgerMoneySourceAccount = {
   name: "ISA 계좌",
   ownerName: "수진",
   broker: "미래에셋",
-  accountNumber: null,
+  lastFour: null,
   accountType: "isa",
   category: null,
 };

--- a/lib/ledger/money-source-options.ts
+++ b/lib/ledger/money-source-options.ts
@@ -17,7 +17,7 @@ export interface LedgerMoneySourceAccount {
   name: string;
   ownerName: string;
   broker: string | null;
-  accountNumber: string | null;
+  lastFour: string | null;
   accountType: AccountType | null;
   category: AccountCategory | null;
 }
@@ -119,7 +119,7 @@ function toAccountOption(
   const description = compactSearchText([
     account.broker,
     account.ownerName,
-    account.accountNumber,
+    account.lastFour ? `끝 ${account.lastFour}` : null,
   ]);
 
   return {
@@ -132,7 +132,7 @@ function toAccountOption(
       account.name,
       account.broker,
       account.ownerName,
-      account.accountNumber,
+      account.lastFour,
       groupLabel,
     ]),
   };

--- a/schemas/account.ts
+++ b/schemas/account.ts
@@ -22,9 +22,10 @@ export const createAccountSchema = z.object({
     .string()
     .max(50, "증권사/은행명은 50자 이내여야 합니다.")
     .optional(),
-  accountNumber: z
+  lastFour: z
     .string()
-    .max(50, "계좌번호는 50자 이내여야 합니다.")
+    .length(4, "계좌번호 뒤 4자리를 입력해주세요.")
+    .regex(/^\d{4}$/, "숫자 4자리만 입력해주세요.")
     .optional(),
   accountType: z.enum(accountTypeValues, {
     message: "계좌 유형을 선택해주세요.",
@@ -47,9 +48,10 @@ export const updateAccountSchema = z.object({
     .max(50, "증권사/은행명은 50자 이내여야 합니다.")
     .nullable()
     .optional(),
-  accountNumber: z
+  lastFour: z
     .string()
-    .max(50, "계좌번호는 50자 이내여야 합니다.")
+    .length(4, "계좌번호 뒤 4자리를 입력해주세요.")
+    .regex(/^\d{4}$/, "숫자 4자리만 입력해주세요.")
     .nullable()
     .optional(),
   accountType: z

--- a/supabase/migrations/20260529000000_rename_account_number_to_last_four.sql
+++ b/supabase/migrations/20260529000000_rename_account_number_to_last_four.sql
@@ -1,0 +1,16 @@
+-- 계좌번호 민감정보 정리 (Issue #308)
+-- 기존 account_number(전체 계좌번호)를 last_four(뒤 4자리)로 변환
+
+-- 1. 기존 데이터를 뒤 4자리로 변환
+UPDATE public.accounts
+SET account_number = RIGHT(account_number, 4)
+WHERE account_number IS NOT NULL
+  AND length(account_number) > 4;
+
+-- 2. 컬럼명 변경: account_number → last_four
+ALTER TABLE public.accounts RENAME COLUMN account_number TO last_four;
+
+-- 3. 길이 제약 추가: 숫자 4자리만 허용 (NULL 허용)
+ALTER TABLE public.accounts
+  ADD CONSTRAINT accounts_last_four_check
+  CHECK (last_four IS NULL OR last_four ~ '^\d{4}$');

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -36,7 +36,6 @@ export type Database = {
     Tables: {
       accounts: {
         Row: {
-          account_number: string | null;
           account_type: Database["public"]["Enums"]["account_type"] | null;
           balance: number | null;
           balance_updated_at: string | null;
@@ -45,13 +44,13 @@ export type Database = {
           created_at: string;
           household_id: string;
           id: string;
+          last_four: string | null;
           memo: string | null;
           name: string;
           owner_id: string;
           updated_at: string;
         };
         Insert: {
-          account_number?: string | null;
           account_type?: Database["public"]["Enums"]["account_type"] | null;
           balance?: number | null;
           balance_updated_at?: string | null;
@@ -60,13 +59,13 @@ export type Database = {
           created_at?: string;
           household_id: string;
           id?: string;
+          last_four?: string | null;
           memo?: string | null;
           name: string;
           owner_id: string;
           updated_at?: string;
         };
         Update: {
-          account_number?: string | null;
           account_type?: Database["public"]["Enums"]["account_type"] | null;
           balance?: number | null;
           balance_updated_at?: string | null;
@@ -75,6 +74,7 @@ export type Database = {
           created_at?: string;
           household_id?: string;
           id?: string;
+          last_four?: string | null;
           memo?: string | null;
           name?: string;
           owner_id?: string;


### PR DESCRIPTION
## 📋 작업 요약
현재 카드번호는 뒤 4자리만 받지만 계좌는 계좌번호 전체를 받음 -> 민감정보의 일부분만 사용하도록 제어하기 위해 계좌번호 뒤 4자리만 입력받아 저장하도록 수정하였습니다.

## 🔧 변경 사항
- **DB 마이그레이션**: 기존 `account_number` 컬럼 데이터를 뒤 4자리로 파싱하여 `last_four`로 이름을 변경하고, 정규식 검증 CHECK 제약조건을 추가하는 마이그레이션 생성 (`20260529000000_rename_account_number_to_last_four.sql`).
- **Zod 스키마**: `accountNumber` -> `lastFour`로 이름을 변경하고 숫자 4자리 검증 정규식 추가.
- **API 레이어**: `lib/api/account.ts` 및 API 라우트에서 변경된 필드명에 맞추어 DB 컬럼과 매핑하도록 수정.
- **UI 컴포넌트**: 계좌 생성/수정/삭제 폼 및 목록 UI에서 계좌번호를 '끝 XXXX' 형태로 노출하고 숫자 4자리만 입력받도록 수정.
- **테스트 코드 & 명세**: 관련 유닛 테스트 데이터 및 `DATABASE.md` 설계를 동기화.

## ✅ 테스트 결과
- `pnpm run type-check` 및 `pnpm test` 성공