### PR TITLE
fix(layout): 모바일 헤더 고정 및 반투명 블러 스타일 적용

### DIFF
--- a/components/layout/ServiceHeader.tsx
+++ b/components/layout/ServiceHeader.tsx
@@ -50,7 +50,7 @@ function MobileServiceHeader({
 
   if (meta.mobileVariant === "topLevel") {
     return (
-      <header className="h-14 px-4 flex items-center lg:hidden">
+      <header className="sticky top-0 z-50 bg-gray-50/80 backdrop-blur-md h-14 px-4 flex items-center lg:hidden">
         <Link href="/home" className="inline-flex items-center">
           <span className="text-xl font-bold text-primary">oat</span>
         </Link>
@@ -59,7 +59,7 @@ function MobileServiceHeader({
   }
 
   return (
-    <header className="relative h-14 px-1 flex items-center lg:hidden">
+    <header className="sticky top-0 z-50 bg-gray-50/80 backdrop-blur-md h-14 px-1 flex items-center lg:hidden">
       <IconLink
         href={parentHref}
         label="이전 화면으로 이동"


### PR DESCRIPTION
모바일 헤더가 스크롤 시 사라지지 않고 상단에 고정되도록 sticky 설정을 추가하였으며, 자연스러운 스크롤 연출을 위해 bg-gray-50/80 backdrop-blur-md 배경 스타일을 부여했습니다.