### PR TITLE
[codex] Improve MCP response model

### DIFF
--- a/.claude/docs/MCP.md
+++ b/.claude/docs/MCP.md
@@ -277,13 +277,61 @@ AI가 다른 tool을 호출할 때 필요한 참조 데이터를 반환합니다
 
 ### 8.4 `search_ledger_entries`
 
-기간, 금액, 카테고리, 키워드 등으로 가계부 상세 내역을 조회합니다.
+기간, 타입, 카테고리, Money Endpoint, 사용자, 공유 여부, 키워드 등으로 가계부 상세 내역을 조회합니다.
+
+MCP 응답은 DB의 raw 방향 필드(`from_account_id`, `from_payment_method_id`, `to_account_id`, `to_payment_method_id`)를 직접 노출하지 않습니다. 대신 클라이언트가 바로 이해할 수 있도록 `source`와 `destination` Money Endpoint를 제공합니다.
+
+Money Endpoint:
+
+```json
+{
+  "endpointType": "account",
+  "endpointId": "uuid",
+  "endpointName": "신한 주거래",
+  "ownerName": "이진호"
+}
+```
+
+거래 타입별 endpoint 규칙:
+
+| 타입 | source | destination |
+|------|--------|-------------|
+| expense | 출금 endpoint | null |
+| income | null | 입금 endpoint |
+| transfer | 출금 endpoint | 입금 endpoint |
+
+입력:
+
+```ts
+{
+  from?: string;              // YYYY-MM-DD
+  to?: string;                // YYYY-MM-DD
+  query?: string;
+  types?: ("expense" | "income" | "transfer")[];
+  categoryIds?: string[];
+  endpointIds?: string[];
+  endpointTypes?: ("account" | "paymentMethod")[];
+  ownerIds?: string[];
+  isShared?: boolean;
+  limit?: number;
+}
+```
+
+반환 summary:
+
+```json
+{
+  "count": 100,
+  "limit": 100,
+  "hasMore": true
+}
+```
 
 제한:
 
 - 기본 기간은 이번 달
 - 한 번에 최대 100건
-- cursor 또는 page 기반 pagination
+- v0.1은 `hasMore`만 제공하고 cursor pagination은 보류
 - 파트너 개인 지출 상세 제외
 
 ### 8.5 `get_ledger_stats`
@@ -295,7 +343,25 @@ AI가 다른 tool을 호출할 때 필요한 참조 데이터를 반환합니다
 - 월별 추이
 - 카테고리별
 - 가구원별
-- 결제수단별
+- source Money Endpoint별
+- destination Money Endpoint별
+
+현금흐름 summary 규칙:
+
+- `totalIncome`, `totalExpense`, `balance`, `savingsRate`는 이체를 제외합니다.
+- 파트너 개인 지출은 상세 없이 합계만 포함합니다.
+
+Endpoint flow 규칙:
+
+- `bySource`는 지출 출금과 이체 출금을 포함합니다.
+- `byDestination`은 수입 입금과 이체 입금을 포함합니다.
+- 각 endpoint item은 `breakdownByType`으로 expense, income, transfer 금액과 건수를 분리합니다.
+
+Trend 규칙:
+
+- `trend.dataAvailableFrom`은 MCP 사용자가 관측 가능한 ledger 데이터가 시작되는 월의 1일입니다.
+- `recorded: false`인 월은 아직 기록이 없는 월이므로 금액/비율을 `null`로 반환합니다.
+- `recorded: true`인 월의 `0`은 실제 0원 활동을 의미합니다.
 
 제한:
 
@@ -322,6 +388,27 @@ AI가 다른 tool을 호출할 때 필요한 참조 데이터를 반환합니다
 - 소유자별 배분
 - 주식 보유 현황
 - 수익률 요약
+- valuation metadata
+
+자산 snapshot 규칙:
+
+- `get_asset_snapshot`과 `get_financial_overview`는 같은 portfolio snapshot 계산을 사용합니다.
+- `includeHoldings: false`는 holdings 상세만 숨기며, summary와 allocation은 항상 전체 holdings 기준입니다.
+- allocation은 summary와 같은 가격/환율 snapshot에서 계산합니다.
+- MCP holdings 응답은 오해 가능성이 큰 `firstTransactionAt`을 노출하지 않습니다. `lastTransactionAt`은 유지합니다.
+
+Valuation metadata:
+
+```json
+{
+  "valuationAt": "2026-05-30T00:00:00.000Z",
+  "exchangeRate": 1512.2428,
+  "exchangeRateUpdatedAt": "2026-05-30T00:00:00.000Z",
+  "priceFetchedAt": "2026-05-30T00:00:00.000Z",
+  "hasMissingPrices": false,
+  "hasStalePrices": true
+}
+```
 
 ---
 

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -35,6 +35,12 @@ function summarizeToolInput(
     limit: args.limit,
     includeHoldings: args.includeHoldings,
     includeAllocation: args.includeAllocation,
+    types: args.types,
+    categoryIds: args.categoryIds,
+    endpointIds: args.endpointIds,
+    endpointTypes: args.endpointTypes,
+    ownerIds: args.ownerIds,
+    isShared: args.isShared,
     hasQuery: typeof args.query === "string" && args.query.trim().length > 0,
   };
 }

--- a/lib/mcp/tools.test.ts
+++ b/lib/mcp/tools.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildEndpointStats,
   buildMcpMeta,
+  buildMoneyEndpoint,
   clampLedgerLimit,
   isLedgerEntryVisibleToMcp,
   MCP_TOOL_DEFINITIONS,
@@ -17,6 +19,21 @@ describe("MCP tool helpers", () => {
       "get_ledger_stats",
       "get_asset_snapshot",
     ]);
+  });
+
+  it("exposes ledger filters using the Money Endpoint model", () => {
+    const searchTool = MCP_TOOL_DEFINITIONS.find(
+      (tool) => tool.name === "search_ledger_entries",
+    );
+
+    expect(searchTool?.inputSchema.properties).toMatchObject({
+      types: { type: "array" },
+      categoryIds: { type: "array" },
+      endpointIds: { type: "array" },
+      endpointTypes: { type: "array" },
+      ownerIds: { type: "array" },
+      isShared: { type: "boolean" },
+    });
   });
 
   it("defaults the period to the current month and caps explicit ranges", () => {
@@ -84,5 +101,97 @@ describe("MCP tool helpers", () => {
         currentUserId: "me",
       }),
     ).toBe(true);
+  });
+
+  it("normalizes ledger source and destination to Money Endpoints", () => {
+    const maps = {
+      accounts: new Map([
+        ["account-1", { name: "신한 주거래", ownerName: "이진호" }],
+      ]),
+      paymentMethods: new Map([
+        ["pm-1", { name: "온누리", ownerName: "우니" }],
+      ]),
+    };
+
+    expect(
+      buildMoneyEndpoint(
+        {
+          type: "transfer",
+          from_account_id: "account-1",
+          from_payment_method_id: null,
+          to_account_id: null,
+          to_payment_method_id: "pm-1",
+        },
+        maps,
+        "source",
+      ),
+    ).toEqual({
+      endpointType: "account",
+      endpointId: "account-1",
+      endpointName: "신한 주거래",
+      ownerName: "이진호",
+    });
+
+    expect(
+      buildMoneyEndpoint(
+        {
+          type: "income",
+          from_account_id: null,
+          from_payment_method_id: null,
+          to_account_id: null,
+          to_payment_method_id: "pm-1",
+        },
+        maps,
+        "destination",
+      ),
+    ).toEqual({
+      endpointType: "paymentMethod",
+      endpointId: "pm-1",
+      endpointName: "온누리",
+      ownerName: "우니",
+    });
+  });
+
+  it("keeps endpoint flow totals split by ledger entry type", () => {
+    const aggregate = new Map([
+      [
+        "account:account-1",
+        {
+          amount: 1_500,
+          count: 2,
+          endpoint: {
+            endpointType: "account",
+            endpointId: "account-1",
+            endpointName: "신한 주거래",
+            ownerName: "이진호",
+          },
+          breakdownByType: {
+            expense: { amount: 1_000, entryCount: 1 },
+            income: { amount: 0, entryCount: 0 },
+            transfer: { amount: 500, entryCount: 1 },
+          },
+        },
+      ],
+    ]);
+
+    expect(buildEndpointStats(aggregate as never)).toEqual({
+      total: 1_500,
+      items: [
+        {
+          endpointType: "account",
+          endpointId: "account-1",
+          endpointName: "신한 주거래",
+          ownerName: "이진호",
+          amount: 1_500,
+          percentage: 100,
+          entryCount: 2,
+          breakdownByType: {
+            expense: { amount: 1_000, entryCount: 1 },
+            income: { amount: 0, entryCount: 0 },
+            transfer: { amount: 500, entryCount: 1 },
+          },
+        },
+      ],
+    });
   });
 });

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -3,7 +3,8 @@ import { APIError } from "@/lib/api/error";
 import { getExchangeRateSafe } from "@/lib/api/exchange";
 import { getHoldings } from "@/lib/api/holdings";
 import { getPaymentMethods } from "@/lib/api/payment-method";
-import { getPortfolioSummary } from "@/lib/api/portfolio";
+import { getStockPrices } from "@/lib/api/stock-price";
+import { calculateHoldingValuation } from "@/lib/api/valuation";
 import type { Database } from "@/types";
 import type { McpAuthContext } from "./auth";
 
@@ -46,13 +47,25 @@ export const MCP_TOOL_DEFINITIONS = [
   {
     name: "search_ledger_entries",
     description:
-      "가계부 상세 내역을 조회합니다. 파트너 개인 지출 상세는 제외됩니다.",
+      "가계부 상세 내역을 조회합니다. source/destination은 account 또는 paymentMethod 기반 Money Endpoint이며, 파트너 개인 지출 상세는 제외됩니다.",
     inputSchema: {
       type: "object",
       properties: {
         from: { type: "string", description: "YYYY-MM-DD" },
         to: { type: "string", description: "YYYY-MM-DD" },
         query: { type: "string" },
+        types: {
+          type: "array",
+          items: { type: "string", enum: ["expense", "income", "transfer"] },
+        },
+        categoryIds: { type: "array", items: { type: "string" } },
+        endpointIds: { type: "array", items: { type: "string" } },
+        endpointTypes: {
+          type: "array",
+          items: { type: "string", enum: ["account", "paymentMethod"] },
+        },
+        ownerIds: { type: "array", items: { type: "string" } },
+        isShared: { type: "boolean" },
         limit: { type: "number", minimum: 1, maximum: MAX_LEDGER_ENTRIES },
       },
       additionalProperties: false,
@@ -61,7 +74,7 @@ export const MCP_TOOL_DEFINITIONS = [
   {
     name: "get_ledger_stats",
     description:
-      "가계부 요약, 멤버별, 카테고리별, 결제수단별 집계를 조회합니다.",
+      "가계부 요약, 멤버별, 카테고리별, Money Endpoint별 집계를 조회합니다. 현금흐름 summary는 이체를 제외하고, endpoint flow는 이체를 포함합니다.",
     inputSchema: {
       type: "object",
       properties: {
@@ -94,6 +107,40 @@ export interface McpPeriod {
 }
 
 type LooseSupabaseClient = SupabaseClient<Database>;
+type LedgerEntryType = "expense" | "income" | "transfer";
+type MoneyEndpointType = "account" | "paymentMethod" | "unknown";
+
+interface MoneyEndpoint {
+  endpointType: MoneyEndpointType;
+  endpointId: string | null;
+  endpointName: string;
+  ownerName: string | null;
+}
+
+interface EndpointMaps {
+  accounts: Map<string, { name: string; ownerName: string | null }>;
+  paymentMethods: Map<string, { name: string; ownerName: string | null }>;
+}
+
+type EndpointDirection = "source" | "destination";
+
+interface LedgerEndpointRow {
+  type: LedgerEntryType;
+  from_account_id: string | null;
+  from_payment_method_id: string | null;
+  to_account_id: string | null;
+  to_payment_method_id: string | null;
+}
+
+interface EndpointAggregate {
+  amount: number;
+  count: number;
+  breakdownByType: Record<
+    LedgerEntryType,
+    { amount: number; entryCount: number }
+  >;
+  endpoint: MoneyEndpoint;
+}
 
 function toDateOnly(date: Date): string {
   return date.toISOString().slice(0, 10);
@@ -114,6 +161,28 @@ function endOfUtcMonth(date: Date): Date {
 function addUtcMonths(date: Date, months: number): Date {
   return new Date(
     Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + months, 1),
+  );
+}
+
+function isLedgerEntryType(value: string): value is LedgerEntryType {
+  return value === "expense" || value === "income" || value === "transfer";
+}
+
+function parseStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function parseLedgerEntryTypes(value: unknown): LedgerEntryType[] {
+  return parseStringArray(value).filter(isLedgerEntryType);
+}
+
+function parseEndpointTypes(
+  value: unknown,
+): Exclude<MoneyEndpointType, "unknown">[] {
+  return parseStringArray(value).filter(
+    (item): item is Exclude<MoneyEndpointType, "unknown"> =>
+      item === "account" || item === "paymentMethod",
   );
 }
 
@@ -247,6 +316,145 @@ async function fetchMembers(
   });
 }
 
+async function fetchEndpointMaps(
+  supabase: LooseSupabaseClient,
+  householdId: string,
+): Promise<EndpointMaps> {
+  const [members, { data: accounts }, paymentMethods] = await Promise.all([
+    fetchMembers(supabase, householdId),
+    supabase
+      .from("accounts")
+      .select("id, owner_id, name")
+      .eq("household_id", householdId),
+    getPaymentMethods(supabase as SupabaseClient<Database>, householdId),
+  ]);
+  const memberMap = new Map(members.map((member) => [member.id, member.name]));
+
+  return {
+    accounts: new Map(
+      (accounts ?? []).map((account) => [
+        account.id,
+        {
+          name: account.name,
+          ownerName: memberMap.get(account.owner_id) ?? null,
+        },
+      ]),
+    ),
+    paymentMethods: new Map(
+      paymentMethods.map((method) => [
+        method.id,
+        {
+          name: method.name,
+          ownerName: method.ownerName,
+        },
+      ]),
+    ),
+  };
+}
+
+function createUnknownEndpoint(direction: EndpointDirection): MoneyEndpoint {
+  return {
+    endpointType: "unknown",
+    endpointId: null,
+    endpointName: direction === "source" ? "출처 없음" : "도착지 없음",
+    ownerName: null,
+  };
+}
+
+export function buildMoneyEndpoint(
+  row: LedgerEndpointRow,
+  maps: EndpointMaps,
+  direction: EndpointDirection,
+): MoneyEndpoint | null {
+  const accountId =
+    direction === "source" ? row.from_account_id : row.to_account_id;
+  const paymentMethodId =
+    direction === "source"
+      ? row.from_payment_method_id
+      : row.to_payment_method_id;
+
+  if (accountId) {
+    const account = maps.accounts.get(accountId);
+    return {
+      endpointType: "account",
+      endpointId: accountId,
+      endpointName: account?.name ?? "알 수 없음",
+      ownerName: account?.ownerName ?? null,
+    };
+  }
+
+  if (paymentMethodId) {
+    const paymentMethod = maps.paymentMethods.get(paymentMethodId);
+    return {
+      endpointType: "paymentMethod",
+      endpointId: paymentMethodId,
+      endpointName: paymentMethod?.name ?? "알 수 없음",
+      ownerName: paymentMethod?.ownerName ?? null,
+    };
+  }
+
+  if (
+    (direction === "source" &&
+      (row.type === "expense" || row.type === "transfer")) ||
+    (direction === "destination" &&
+      (row.type === "income" || row.type === "transfer"))
+  ) {
+    return createUnknownEndpoint(direction);
+  }
+
+  return null;
+}
+
+function endpointKey(endpoint: MoneyEndpoint): string {
+  return `${endpoint.endpointType}:${endpoint.endpointId ?? "unknown"}`;
+}
+
+function incrementEndpointAggregate(
+  map: Map<string, EndpointAggregate>,
+  endpoint: MoneyEndpoint | null,
+  type: LedgerEntryType,
+  amount: number,
+) {
+  if (!endpoint) return;
+
+  const key = endpointKey(endpoint);
+  const existing = map.get(key) ?? {
+    amount: 0,
+    count: 0,
+    endpoint,
+    breakdownByType: {
+      expense: { amount: 0, entryCount: 0 },
+      income: { amount: 0, entryCount: 0 },
+      transfer: { amount: 0, entryCount: 0 },
+    },
+  };
+  existing.amount += amount;
+  existing.count += 1;
+  existing.breakdownByType[type].amount += amount;
+  existing.breakdownByType[type].entryCount += 1;
+  map.set(key, existing);
+}
+
+export function buildEndpointStats(
+  aggregateMap: Map<string, EndpointAggregate>,
+) {
+  const total = [...aggregateMap.values()].reduce(
+    (sum, item) => sum + item.amount,
+    0,
+  );
+  const items = [...aggregateMap.values()]
+    .map(({ endpoint, amount, count, breakdownByType }) => ({
+      ...endpoint,
+      amount,
+      percentage: total > 0 ? Math.round((amount / total) * 10000) / 100 : 0,
+      entryCount: count,
+      breakdownByType,
+    }))
+    .sort((a, b) => b.amount - a.amount);
+
+  return { total, items };
+}
+
 async function getContext(supabase: LooseSupabaseClient, auth: McpAuthContext) {
   requireScope(auth, ["read:overview"]);
 
@@ -340,8 +548,13 @@ async function searchLedgerEntries(
   });
   const { from, to } = periodToIsoRange(period);
   const limit = clampLedgerLimit(args.limit);
+  const types = parseLedgerEntryTypes(args.types);
+  const categoryIds = parseStringArray(args.categoryIds);
+  const endpointIds = parseStringArray(args.endpointIds);
+  const endpointTypes = parseEndpointTypes(args.endpointTypes);
+  const ownerIds = parseStringArray(args.ownerIds);
 
-  const query = supabase
+  let query = supabase
     .from("ledger_entries")
     .select(
       "id, owner_id, type, amount, title, category_id, from_account_id, from_payment_method_id, to_account_id, to_payment_method_id, is_shared, memo, transacted_at, created_at, updated_at",
@@ -351,7 +564,14 @@ async function searchLedgerEntries(
     .lt("transacted_at", to)
     .or(`is_shared.eq.true,owner_id.eq.${auth.userId}`)
     .order("transacted_at", { ascending: false })
-    .limit(limit);
+    .limit(limit + 1);
+
+  if (types.length > 0) query = query.in("type", types);
+  if (categoryIds.length > 0) query = query.in("category_id", categoryIds);
+  if (ownerIds.length > 0) query = query.in("owner_id", ownerIds);
+  if (typeof args.isShared === "boolean") {
+    query = query.eq("is_shared", args.isShared);
+  }
 
   const { data, error } = await query;
 
@@ -364,6 +584,10 @@ async function searchLedgerEntries(
   }
 
   const keyword = typeof args.query === "string" ? args.query.trim() : "";
+  const endpointTypeSet = new Set<string>(endpointTypes);
+  const endpointIdSet = new Set(endpointIds);
+  const shouldFilterEndpoint =
+    endpointTypeSet.size > 0 || endpointIdSet.size > 0;
   const rows = (data ?? [])
     .filter((row) =>
       isLedgerEntryVisibleToMcp({
@@ -373,19 +597,59 @@ async function searchLedgerEntries(
       }),
     )
     .filter((row) => {
+      if (!shouldFilterEndpoint) return true;
+      const candidates = [
+        { type: "account", id: row.from_account_id },
+        { type: "paymentMethod", id: row.from_payment_method_id },
+        { type: "account", id: row.to_account_id },
+        { type: "paymentMethod", id: row.to_payment_method_id },
+      ];
+      return candidates.some(
+        (candidate) =>
+          candidate.id &&
+          (endpointTypeSet.size === 0 || endpointTypeSet.has(candidate.type)) &&
+          (endpointIdSet.size === 0 || endpointIdSet.has(candidate.id)),
+      );
+    })
+    .filter((row) => {
       if (!keyword) return true;
       const haystack = `${row.title ?? ""} ${row.memo ?? ""}`.toLowerCase();
       return haystack.includes(keyword.toLowerCase());
     });
+  const pageRows = rows.slice(0, limit);
+  const endpointMaps = await fetchEndpointMaps(supabase, auth.householdId);
 
   return {
     meta: buildMcpMeta({ period, scopes: auth.scopes }),
     summary: {
-      count: rows.length,
+      count: pageRows.length,
       limit,
+      hasMore: rows.length > limit,
     },
     data: {
-      entries: rows,
+      entries: pageRows.map((row) => ({
+        id: row.id,
+        ownerId: row.owner_id,
+        type: row.type,
+        amount: row.amount,
+        title: row.title,
+        categoryId: row.category_id,
+        source: buildMoneyEndpoint(
+          row as LedgerEndpointRow,
+          endpointMaps,
+          "source",
+        ),
+        destination: buildMoneyEndpoint(
+          row as LedgerEndpointRow,
+          endpointMaps,
+          "destination",
+        ),
+        isShared: row.is_shared,
+        memo: row.memo,
+        transactedAt: row.transacted_at,
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
+      })),
     },
   };
 }
@@ -405,6 +669,26 @@ function incrementAggregate(
 function calcSavingsRate(income: number, expense: number): number {
   if (income === 0) return 0;
   return Math.round(((income - expense) / income) * 10000) / 100;
+}
+
+function monthKey(date: Date): string {
+  return `${date.getUTCFullYear()}-${date.getUTCMonth() + 1}`;
+}
+
+function monthStartDateOnly(value: string): string {
+  const date = new Date(value);
+  return toDateOnly(startOfUtcMonth(date));
+}
+
+function isSameOrAfterMonth(
+  year: number,
+  month: number,
+  dataAvailableFrom: string | null,
+): boolean {
+  if (!dataAvailableFrom) return false;
+  const current = new Date(Date.UTC(year, month - 1, 1));
+  const available = new Date(`${dataAvailableFrom}T00:00:00.000Z`);
+  return current >= available;
 }
 
 async function fetchCategoryMap(
@@ -451,64 +735,16 @@ function buildCategoryStats(
   return { type, scope: "all", total, items };
 }
 
-async function fetchPaymentMethodMap(
-  supabase: LooseSupabaseClient,
-  aggregateMap: Map<string | null, { amount: number; count: number }>,
-) {
-  const ids = [...aggregateMap.keys()].filter(Boolean) as string[];
-  const { data } =
-    ids.length > 0
-      ? await supabase
-          .from("payment_methods")
-          .select("id, name, type")
-          .in("id", ids)
-      : { data: [] };
-
-  return new Map(
-    (data ?? []).map((method) => [
-      method.id,
-      { name: method.name, type: method.type },
-    ]),
-  );
-}
-
-function buildPaymentMethodStats(
-  paymentMethodMap: Map<string, { name: string; type: string | null }>,
-  aggregateMap: Map<string | null, { amount: number; count: number }>,
-) {
-  const total = [...aggregateMap.values()].reduce(
-    (sum, item) => sum + item.amount,
-    0,
-  );
-  const items = [...aggregateMap.entries()]
-    .map(([paymentMethodId, { amount, count }]) => {
-      const paymentMethod = paymentMethodId
-        ? paymentMethodMap.get(paymentMethodId)
-        : undefined;
-      return {
-        paymentMethodId,
-        paymentMethodName: paymentMethod?.name ?? "현금/기타",
-        paymentMethodType: paymentMethod?.type ?? null,
-        amount,
-        percentage: total > 0 ? Math.round((amount / total) * 10000) / 100 : 0,
-        entryCount: count,
-      };
-    })
-    .sort((a, b) => b.amount - a.amount);
-
-  return { scope: "all", total, items };
-}
-
 async function buildTrendStats(
   supabase: LooseSupabaseClient,
   auth: McpAuthContext,
   months: number,
+  endMonth: Date,
 ) {
-  const now = new Date();
   const monthList: { year: number; month: number }[] = [];
   for (let i = months - 1; i >= 0; i--) {
     const cursor = new Date(
-      Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - i, 1),
+      Date.UTC(endMonth.getUTCFullYear(), endMonth.getUTCMonth() - i, 1),
     );
     monthList.push({
       year: cursor.getUTCFullYear(),
@@ -527,6 +763,37 @@ async function buildTrendStats(
     .gte("transacted_at", from)
     .lt("transacted_at", to)
     .or(`is_shared.eq.true,owner_id.eq.${auth.userId}`);
+  const [{ data: earliestVisibleRows }, { data: earliestPartnerPrivateRows }] =
+    await Promise.all([
+      supabase
+        .from("ledger_entries")
+        .select("transacted_at")
+        .eq("household_id", auth.householdId)
+        .or(`is_shared.eq.true,owner_id.eq.${auth.userId}`)
+        .order("transacted_at", { ascending: true })
+        .limit(1),
+      supabase
+        .from("ledger_entries")
+        .select("transacted_at")
+        .eq("household_id", auth.householdId)
+        .eq("type", "expense")
+        .eq("is_shared", false)
+        .neq("owner_id", auth.userId)
+        .order("transacted_at", { ascending: true })
+        .limit(1),
+    ]);
+  const earliestCandidates = [
+    earliestVisibleRows?.[0]?.transacted_at,
+    earliestPartnerPrivateRows?.[0]?.transacted_at,
+  ].filter((value): value is string => typeof value === "string");
+  const dataAvailableFrom =
+    earliestCandidates.length > 0
+      ? monthStartDateOnly(
+          earliestCandidates.sort(
+            (a, b) => new Date(a).getTime() - new Date(b).getTime(),
+          )[0],
+        )
+      : null;
 
   const monthMap = new Map<string, { income: number; expense: number }>();
   for (const { year, month } of monthList) {
@@ -545,7 +812,7 @@ async function buildTrendStats(
     }
 
     const date = new Date(row.transacted_at);
-    const key = `${date.getUTCFullYear()}-${date.getUTCMonth() + 1}`;
+    const key = monthKey(date);
     const existing = monthMap.get(key);
     if (!existing) continue;
     if (row.type === "income") existing.income += row.amount;
@@ -569,18 +836,23 @@ async function buildTrendStats(
   }
 
   return {
+    dataAvailableFrom,
     items: monthList.map(({ year, month }) => {
       const item = monthMap.get(`${year}-${month}`) ?? {
         income: 0,
         expense: 0,
       };
+      const recorded = isSameOrAfterMonth(year, month, dataAvailableFrom);
       return {
         year,
         month,
-        totalIncome: item.income,
-        totalExpense: item.expense,
-        balance: item.income - item.expense,
-        savingsRate: calcSavingsRate(item.income, item.expense),
+        recorded,
+        totalIncome: recorded ? item.income : null,
+        totalExpense: recorded ? item.expense : null,
+        balance: recorded ? item.income - item.expense : null,
+        savingsRate: recorded
+          ? calcSavingsRate(item.income, item.expense)
+          : null,
       };
     }),
   };
@@ -609,7 +881,7 @@ async function getLedgerStats(
     supabase
       .from("ledger_entries")
       .select(
-        "owner_id, type, amount, category_id, from_payment_method_id, is_shared, transacted_at",
+        "owner_id, type, amount, category_id, from_account_id, from_payment_method_id, to_account_id, to_payment_method_id, is_shared, transacted_at",
       )
       .eq("household_id", auth.householdId)
       .gte("transacted_at", from)
@@ -652,10 +924,9 @@ async function getLedgerStats(
     string | null,
     { amount: number; count: number }
   >();
-  const paymentMethodMap = new Map<
-    string | null,
-    { amount: number; count: number }
-  >();
+  const sourceMap = new Map<string, EndpointAggregate>();
+  const destinationMap = new Map<string, EndpointAggregate>();
+  const endpointMaps = await fetchEndpointMaps(supabase, auth.householdId);
 
   for (const member of members) {
     byMemberMap.set(member.id, {
@@ -667,6 +938,7 @@ async function getLedgerStats(
 
   for (const row of visibleRows) {
     const memberStats = byMemberMap.get(row.owner_id);
+    const type = row.type as LedgerEntryType;
 
     if (row.type === "income") {
       totalIncome += row.amount;
@@ -682,11 +954,27 @@ async function getLedgerStats(
         myPersonalExpense += row.amount;
         if (memberStats) memberStats.personalExpense += row.amount;
       }
-
       incrementAggregate(expenseCategoryMap, row.category_id, row.amount);
-      incrementAggregate(
-        paymentMethodMap,
-        row.from_payment_method_id,
+    }
+
+    if (row.type === "expense" || row.type === "transfer") {
+      incrementEndpointAggregate(
+        sourceMap,
+        buildMoneyEndpoint(row as LedgerEndpointRow, endpointMaps, "source"),
+        type,
+        row.amount,
+      );
+    }
+
+    if (row.type === "income" || row.type === "transfer") {
+      incrementEndpointAggregate(
+        destinationMap,
+        buildMoneyEndpoint(
+          row as LedgerEndpointRow,
+          endpointMaps,
+          "destination",
+        ),
+        type,
         row.amount,
       );
     }
@@ -742,11 +1030,7 @@ async function getLedgerStats(
     incomeCategoryMap,
     "income",
   );
-  const byPaymentMethod = buildPaymentMethodStats(
-    await fetchPaymentMethodMap(supabase, paymentMethodMap),
-    paymentMethodMap,
-  );
-  const trend = await buildTrendStats(supabase, auth, months);
+  const trend = await buildTrendStats(supabase, auth, months, monthCursor);
 
   return {
     meta: buildMcpMeta({ period, scopes: auth.scopes }),
@@ -757,9 +1041,145 @@ async function getLedgerStats(
         expense: byExpenseCategory,
         income: byIncomeCategory,
       },
-      byPaymentMethod,
+      bySource: buildEndpointStats(sourceMap),
+      byDestination: buildEndpointStats(destinationMap),
       trend,
     },
+  };
+}
+
+async function getPortfolioSnapshot(
+  supabase: SupabaseClient<Database>,
+  householdId: string,
+) {
+  const [holdingsResult, exchangeRateResult] = await Promise.all([
+    getHoldings(supabase, householdId, {
+      pagination: { page: 1, pageSize: 1000 },
+    }),
+    getExchangeRateSafe(supabase, "USD", "KRW"),
+  ]);
+  const holdings = holdingsResult.data;
+  const exchangeRate = exchangeRateResult?.rate ?? 1300;
+  const stockQueries = holdings
+    .filter((holding) => holding.market === "KR" || holding.market === "US")
+    .map((holding) => ({
+      market: holding.market as "KR" | "US",
+      code: holding.ticker,
+    }));
+  const stockPrices = await getStockPrices(supabase, stockQueries);
+  const valuationAt = new Date().toISOString();
+  let totalValue = 0;
+  let totalInvested = 0;
+  let hasMissingPrices = false;
+  let hasStalePrices = false;
+  let priceFetchedAt: string | null = null;
+  const allocationByAssetType = new Map<
+    string,
+    { totalValue: number; totalInvested: number }
+  >();
+  const allocationByOwner = new Map<
+    string,
+    { totalValue: number; totalInvested: number }
+  >();
+
+  const valuedHoldings = holdings.map((holding) => {
+    const priceKey = `${holding.market}:${holding.ticker}`;
+    const price = stockPrices[priceKey];
+    const valuation = calculateHoldingValuation(
+      {
+        quantity: holding.quantity,
+        avgPrice: holding.avgPrice,
+        totalInvested: holding.totalInvested,
+        currency: holding.currency,
+      },
+      price,
+      exchangeRate,
+    );
+    totalValue += valuation.currentValue;
+    totalInvested += valuation.investedAmount;
+    hasMissingPrices = hasMissingPrices || valuation.isMissingPrice;
+    hasStalePrices = hasStalePrices || valuation.isStalePrice;
+    if (price?.fetchedAt) {
+      const fetchedAt = price.fetchedAt.toISOString();
+      priceFetchedAt =
+        !priceFetchedAt || fetchedAt > priceFetchedAt
+          ? fetchedAt
+          : priceFetchedAt;
+    }
+
+    const assetTypeAllocation = allocationByAssetType.get(
+      holding.assetType,
+    ) ?? {
+      totalValue: 0,
+      totalInvested: 0,
+    };
+    assetTypeAllocation.totalValue += valuation.currentValue;
+    assetTypeAllocation.totalInvested += valuation.investedAmount;
+    allocationByAssetType.set(holding.assetType, assetTypeAllocation);
+
+    const ownerAllocation = allocationByOwner.get(holding.owner.name) ?? {
+      totalValue: 0,
+      totalInvested: 0,
+    };
+    ownerAllocation.totalValue += valuation.currentValue;
+    ownerAllocation.totalInvested += valuation.investedAmount;
+    allocationByOwner.set(holding.owner.name, ownerAllocation);
+
+    return {
+      ticker: holding.ticker,
+      name: holding.name,
+      quantity: holding.quantity,
+      avgPrice: holding.avgPrice,
+      totalInvested: valuation.investedAmount,
+      currentPrice: valuation.currentPrice,
+      currentValue: valuation.currentValue,
+      returnRate:
+        valuation.investedAmount > 0
+          ? ((valuation.currentValue - valuation.investedAmount) /
+              valuation.investedAmount) *
+            100
+          : 0,
+      market: holding.market,
+      currency: holding.currency,
+      assetType: holding.assetType,
+      riskLevel: holding.riskLevel,
+      lastTransactionAt: holding.lastTransactionAt,
+      owner: holding.owner,
+      account: holding.account,
+      priceFetchedAt: price?.fetchedAt.toISOString() ?? null,
+      priceStatus: price?.status ?? "missing",
+    };
+  });
+  const returnRate =
+    totalInvested > 0
+      ? ((totalValue - totalInvested) / totalInvested) * 100
+      : 0;
+
+  return {
+    summary: {
+      holdingCount: holdings.length,
+      totalValue,
+      totalInvested,
+      returnRate,
+      valuationAt,
+    },
+    valuation: {
+      valuationAt,
+      exchangeRate: exchangeRateResult?.rate ?? null,
+      exchangeRateUpdatedAt: exchangeRateResult?.updatedAt ?? null,
+      priceFetchedAt,
+      hasMissingPrices,
+      hasStalePrices,
+    },
+    allocation: {
+      byAssetType: [...allocationByAssetType.entries()].map(
+        ([assetType, allocation]) => ({ assetType, ...allocation }),
+      ),
+      byOwner: [...allocationByOwner.entries()].map(
+        ([ownerName, allocation]) => ({ ownerName, ...allocation }),
+      ),
+    },
+    holdings: valuedHoldings,
   };
 }
 
@@ -772,47 +1192,18 @@ async function getAssetSnapshot(
 
   const includeHoldings = args.includeHoldings !== false;
   const includeAllocation = args.includeAllocation !== false;
-  const typed = supabase as SupabaseClient<Database>;
-  const [portfolio, holdingsResult, exchangeRateResult] = await Promise.all([
-    getPortfolioSummary(typed, auth.householdId),
-    getHoldings(typed, auth.householdId, {
-      pagination: { page: 1, pageSize: includeHoldings ? 1000 : 1 },
-    }),
-    getExchangeRateSafe(typed, "USD", "KRW"),
-  ]);
-
-  const holdings = holdingsResult.data;
-  const allocationByAssetType = new Map<string, number>();
-  const allocationByOwner = new Map<string, number>();
-
-  for (const holding of holdings) {
-    allocationByAssetType.set(
-      holding.assetType,
-      (allocationByAssetType.get(holding.assetType) ?? 0) +
-        holding.totalInvested,
-    );
-    allocationByOwner.set(
-      holding.owner.name,
-      (allocationByOwner.get(holding.owner.name) ?? 0) + holding.totalInvested,
-    );
-  }
+  const snapshot = await getPortfolioSnapshot(
+    supabase as SupabaseClient<Database>,
+    auth.householdId,
+  );
 
   return {
     meta: buildMcpMeta({ period: null, scopes: auth.scopes }),
-    summary: portfolio,
+    summary: snapshot.summary,
     data: {
-      exchangeRate: exchangeRateResult?.rate ?? null,
-      holdings: includeHoldings ? holdings : undefined,
-      allocation: includeAllocation
-        ? {
-            byAssetType: [...allocationByAssetType.entries()].map(
-              ([assetType, totalInvested]) => ({ assetType, totalInvested }),
-            ),
-            byOwner: [...allocationByOwner.entries()].map(
-              ([ownerName, totalInvested]) => ({ ownerName, totalInvested }),
-            ),
-          }
-        : undefined,
+      valuation: snapshot.valuation,
+      holdings: includeHoldings ? snapshot.holdings : undefined,
+      allocation: includeAllocation ? snapshot.allocation : undefined,
     },
   };
 }


### PR DESCRIPTION
## Summary

- Replace MCP ledger raw from/to fields with client-facing source and destination Money Endpoint objects.
- Replace byPaymentMethod stats with endpoint-oriented bySource and byDestination, including type breakdowns for expense, income, and transfer flows.
- Add ledger search filters, hasMore, trend dataAvailableFrom/recorded, and unified asset valuation metadata.
- Update MCP docs and tests for the new response model.

## Why

Issue #309 found that the MCP v0 responses could push clients toward wrong conclusions: payment-method stats hid account withdrawals, trend zeros conflated missing data with real zero activity, and asset overview/allocation could be inconsistent. This change makes the server response model closer to the domain language and easier for MCP clients to interpret safely.

## Validation

- pnpm type-check
- pnpm test
- pnpm build