### PR TITLE
[feat] #323 폼 스타일링 및 사용성 개선 (주식/가계부)

### DIFF
--- a/app/api/transactions/batch/route.ts
+++ b/app/api/transactions/batch/route.ts
@@ -61,6 +61,8 @@ export async function POST(request: Request) {
         quantity: item.quantity,
         price: item.price,
         memo: item.memo,
+        transactedAt: item.transactedAt,
+        accountId: item.accountId,
         stock: {
           name: item.stock.name,
           market: item.stock.market,

--- a/components/ledger/LedgerCategoryCombobox.tsx
+++ b/components/ledger/LedgerCategoryCombobox.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { ArrowLeftIcon, CheckIcon, ChevronsUpDownIcon } from "lucide-react";
+import type { ComponentPropsWithoutRef } from "react";
+import { forwardRef, useState } from "react";
+import { CategoryIcon } from "@/components/ledger/CategoryIcon";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils/cn";
+import type { Category } from "@/types";
+
+interface LedgerCategoryBaseProps {
+  value: string;
+  categories: Category[];
+}
+
+interface LedgerCategoryComboboxProps extends LedgerCategoryBaseProps {
+  placeholder: string;
+  onValueChange: (value: string) => void;
+}
+
+interface LedgerCategoryPickerPanelProps extends LedgerCategoryBaseProps {
+  title: string;
+  searchPlaceholder: string;
+  onBack?: () => void;
+  onValueChange: (value: string) => void;
+}
+
+interface LedgerCategoryTriggerProps
+  extends ComponentPropsWithoutRef<typeof Button> {
+  label: string;
+  placeholder: string;
+  open?: boolean;
+}
+
+export const LedgerCategoryTrigger = forwardRef<
+  HTMLButtonElement,
+  LedgerCategoryTriggerProps
+>(function LedgerCategoryTrigger(
+  { label, placeholder, open, className, ...props },
+  ref,
+) {
+  return (
+    <Button
+      ref={ref}
+      type="button"
+      variant="outline"
+      role="combobox"
+      aria-expanded={open}
+      className={cn(
+        "h-10 w-full justify-between px-3 font-normal rounded-xl",
+        className,
+      )}
+      {...props}
+    >
+      <span
+        className={cn(
+          "truncate",
+          label === placeholder && "text-muted-foreground",
+        )}
+      >
+        {label}
+      </span>
+      <ChevronsUpDownIcon className="ml-2 size-4 shrink-0 opacity-50" />
+    </Button>
+  );
+});
+
+function CategoryCommandList({
+  categories,
+  value,
+  onValueChange,
+}: {
+  categories: Category[];
+  value: string;
+  onValueChange: (value: string) => void;
+}) {
+  return (
+    <CommandList className="max-h-[320px]">
+      <CommandEmpty>검색 결과가 없습니다.</CommandEmpty>
+      <CommandGroup heading="카테고리 선택">
+        {categories.map((category) => (
+          <CommandItem
+            key={category.id}
+            value={category.name}
+            onSelect={() => onValueChange(category.id)}
+            className="cursor-pointer py-2.5"
+          >
+            <CheckIcon
+              className={cn(
+                "size-4 mr-2",
+                value === category.id ? "opacity-100" : "opacity-0",
+              )}
+            />
+            <div className="flex items-center gap-2 min-w-0 flex-1">
+              <CategoryIcon
+                iconName={category.icon}
+                className="size-4 text-gray-500 shrink-0"
+              />
+              <span className="truncate font-medium">{category.name}</span>
+            </div>
+          </CommandItem>
+        ))}
+      </CommandGroup>
+    </CommandList>
+  );
+}
+
+export function LedgerCategoryCombobox({
+  value,
+  categories,
+  placeholder,
+  onValueChange,
+}: LedgerCategoryComboboxProps) {
+  const [open, setOpen] = useState(false);
+  const selectedCategory = categories.find((cat) => cat.id === value);
+  const selectedLabel = selectedCategory ? selectedCategory.name : placeholder;
+
+  const handleValueChange = (nextValue: string) => {
+    onValueChange(nextValue);
+    setOpen(false);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <LedgerCategoryTrigger
+          label={selectedLabel}
+          placeholder={placeholder}
+          open={open}
+        />
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-[var(--radix-popover-trigger-width)] p-0"
+        align="start"
+      >
+        <Command>
+          <CommandInput placeholder="카테고리 이름 검색" />
+          <CategoryCommandList
+            categories={categories}
+            value={value}
+            onValueChange={handleValueChange}
+          />
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export function LedgerCategoryPickerPanel({
+  value,
+  categories,
+  title,
+  searchPlaceholder,
+  onBack,
+  onValueChange,
+}: LedgerCategoryPickerPanelProps) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex items-center gap-2 px-4 pb-3">
+        {onBack && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-9 shrink-0"
+            onClick={onBack}
+          >
+            <ArrowLeftIcon className="size-5" />
+            <span className="sr-only">돌아가기</span>
+          </Button>
+        )}
+        <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
+      </div>
+      <div className="min-h-0 flex-1 px-4">
+        <Command className="h-full rounded-xl border">
+          <CommandInput placeholder={searchPlaceholder} className="h-11" />
+          <CategoryCommandList
+            categories={categories}
+            value={value}
+            onValueChange={onValueChange}
+          />
+        </Command>
+      </div>
+    </div>
+  );
+}

--- a/components/ledger/LedgerEntryEditDialog.tsx
+++ b/components/ledger/LedgerEntryEditDialog.tsx
@@ -7,6 +7,11 @@ import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
 import {
+  LedgerCategoryCombobox,
+  LedgerCategoryPickerPanel,
+  LedgerCategoryTrigger,
+} from "@/components/ledger/LedgerCategoryCombobox";
+import {
   getLedgerMoneySourceLabel,
   LedgerMoneySourceCombobox,
   LedgerMoneySourcePickerPanel,
@@ -33,13 +38,6 @@ import {
 } from "@/components/ui/drawer";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { useAccounts } from "@/hooks/use-accounts";
 import { useCategories } from "@/hooks/use-categories";
@@ -75,7 +73,7 @@ const editFormSchema = z.object({
 });
 
 type EditFormValues = z.infer<typeof editFormSchema>;
-type MobileEditView = "form" | "moneySourcePicker";
+type MobileEditView = "form" | "moneySourcePicker" | "categoryPicker";
 
 export function LedgerEntryEditDialog({
   entry,
@@ -330,23 +328,25 @@ export function LedgerEntryEditDialog({
       <div className="grid grid-cols-2 gap-3">
         <div className="space-y-2">
           <Label>카테고리 *</Label>
-          <Select
-            value={watchCategoryId ?? ""}
-            onValueChange={(v) =>
-              setValue("categoryId", v, { shouldValidate: true })
-            }
-          >
-            <SelectTrigger>
-              <SelectValue placeholder="선택" />
-            </SelectTrigger>
-            <SelectContent>
-              {categories.map((cat) => (
-                <SelectItem key={cat.id} value={cat.id}>
-                  {cat.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          {isDesktop ? (
+            <LedgerCategoryCombobox
+              value={watchCategoryId ?? ""}
+              categories={categories}
+              placeholder="선택"
+              onValueChange={(v) =>
+                setValue("categoryId", v, { shouldValidate: true })
+              }
+            />
+          ) : (
+            <LedgerCategoryTrigger
+              label={
+                categories.find((cat) => cat.id === watchCategoryId)?.name ??
+                "선택"
+              }
+              placeholder="선택"
+              onClick={() => setMobileView("categoryPicker")}
+            />
+          )}
           {errors.categoryId && (
             <p className="text-sm text-destructive">
               {errors.categoryId.message}
@@ -465,6 +465,20 @@ export function LedgerEntryEditDialog({
               onValueChange={handleMobileMoneySourceChange}
             />
           </div>
+        ) : mobileView === "categoryPicker" ? (
+          <div className="flex min-h-[70vh] flex-col pb-4">
+            <LedgerCategoryPickerPanel
+              value={watchCategoryId ?? ""}
+              categories={categories}
+              title="카테고리 선택"
+              searchPlaceholder="카테고리 이름 검색"
+              onBack={() => setMobileView("form")}
+              onValueChange={(v) => {
+                setValue("categoryId", v, { shouldValidate: true });
+                setMobileView("form");
+              }}
+            />
+          </div>
         ) : (
           <>
             <DrawerHeader>
@@ -485,7 +499,7 @@ export function LedgerEntryEditDialog({
               </form>
             </div>
 
-            <DrawerFooter>
+            <DrawerFooter className="pb-[calc(1rem+env(safe-area-inset-bottom))]">
               <div className="flex gap-2">
                 <Button
                   type="button"

--- a/components/ledger/entry-composer/ComposerFormStep.tsx
+++ b/components/ledger/entry-composer/ComposerFormStep.tsx
@@ -3,7 +3,17 @@
 import { XIcon } from "lucide-react";
 import { useState } from "react";
 import { useFormContext } from "react-hook-form";
-import { LedgerMoneySourceCombobox } from "@/components/ledger/LedgerMoneySourceCombobox";
+import {
+  LedgerCategoryCombobox,
+  LedgerCategoryPickerPanel,
+  LedgerCategoryTrigger,
+} from "@/components/ledger/LedgerCategoryCombobox";
+import {
+  getLedgerMoneySourceLabel,
+  LedgerMoneySourceCombobox,
+  LedgerMoneySourcePickerPanel,
+  LedgerMoneySourceTrigger,
+} from "@/components/ledger/LedgerMoneySourceCombobox";
 import { Button } from "@/components/ui/button";
 import { DatePickerInput } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
@@ -18,6 +28,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { useAccounts } from "@/hooks/use-accounts";
 import { useCategories } from "@/hooks/use-categories";
+import { useMediaQuery } from "@/hooks/use-media-query";
 import { usePaymentMethods } from "@/hooks/use-payment-methods";
 import { getLedgerMoneySourceValue } from "@/lib/ledger/money-source-options";
 import type { LedgerComposerFormValues } from "./LedgerEntryComposer";
@@ -35,6 +46,10 @@ export function ComposerFormStep({
 }: ComposerFormStepProps) {
   const form = useFormContext<LedgerComposerFormValues>();
   const [snapshot] = useState(() => form.getValues(`items.${index}`));
+  const isDesktop = useMediaQuery("(min-width: 768px)");
+  const [mobileView, setMobileView] = useState<
+    "form" | "moneySourcePicker" | "categoryPicker"
+  >("form");
 
   const handleCancel = () => {
     form.setValue(`items.${index}`, snapshot);
@@ -79,6 +94,46 @@ export function ComposerFormStep({
     form.setValue(`items.${index}.accountId`, undefined);
   };
 
+  if (!isDesktop && mobileView === "moneySourcePicker") {
+    return (
+      <div className="flex min-h-[70vh] flex-col pb-4 pt-16 bg-white h-full">
+        <LedgerMoneySourcePickerPanel
+          mode={itemType}
+          value={moneySourceValue}
+          paymentMethods={paymentMethods}
+          accounts={accounts}
+          title={itemType === "expense" ? "결제 방법 선택" : "입금 계좌 선택"}
+          searchPlaceholder="이름, 기관, 소유자 검색"
+          onBack={() => setMobileView("form")}
+          onValueChange={(v) => {
+            handleMoneySourceChange(v);
+            setMobileView("form");
+          }}
+        />
+      </div>
+    );
+  }
+
+  if (!isDesktop && mobileView === "categoryPicker") {
+    return (
+      <div className="flex min-h-[70vh] flex-col pb-4 pt-16 bg-white h-full">
+        <LedgerCategoryPickerPanel
+          value={form.watch(`items.${index}.categoryId`)}
+          categories={categories}
+          title="카테고리 선택"
+          searchPlaceholder="카테고리 이름 검색"
+          onBack={() => setMobileView("form")}
+          onValueChange={(v) => {
+            form.setValue(`items.${index}.categoryId`, v, {
+              shouldValidate: true,
+            });
+            setMobileView("form");
+          }}
+        />
+      </div>
+    );
+  }
+
   return (
     <>
       <Button
@@ -90,111 +145,112 @@ export function ComposerFormStep({
       </Button>
 
       {/* Form Content */}
-      <div className="flex-1 overflow-y-auto p-4 pt-16">
-        <div className="rounded-2xl border border-gray-100 bg-white p-4 shadow-sm space-y-4">
-          <div className="grid grid-cols-2 gap-2">
-            <div className="min-w-0 space-y-1">
-              <Label className="text-sm text-gray-700">유형</Label>
-              <Select
-                value={itemType}
-                onValueChange={(value) => {
-                  form.setValue(
-                    `items.${index}.type`,
-                    value as "expense" | "income",
-                  );
-                  form.setValue(`items.${index}.categoryId`, "");
-                  form.setValue(`items.${index}.paymentMethodId`, undefined);
-                  form.setValue(`items.${index}.accountId`, undefined);
-                }}
-              >
-                <SelectTrigger className="h-10 w-full">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="expense">지출</SelectItem>
-                  <SelectItem value="income">수입</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div className="min-w-0 space-y-1">
-              <Label className="text-sm text-gray-700">공개범위</Label>
-              <Select
-                value={itemIsShared ? "shared" : "private"}
-                onValueChange={(value) =>
-                  form.setValue(`items.${index}.isShared`, value === "shared")
-                }
-              >
-                <SelectTrigger className="h-10 w-full">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="shared">공용</SelectItem>
-                  <SelectItem value="private">개인</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-          <div className="space-y-1">
-            <Label className="text-sm text-gray-700">카테고리 *</Label>
+      <div className="flex-1 overflow-y-auto px-4 pt-16 pb-4 space-y-4">
+        <div className="grid grid-cols-2 gap-2">
+          <div className="min-w-0 space-y-1">
+            <Label className="text-sm text-gray-700">유형</Label>
             <Select
+              value={itemType}
+              onValueChange={(value) => {
+                form.setValue(
+                  `items.${index}.type`,
+                  value as "expense" | "income",
+                );
+                form.setValue(`items.${index}.categoryId`, "");
+                form.setValue(`items.${index}.paymentMethodId`, undefined);
+                form.setValue(`items.${index}.accountId`, undefined);
+              }}
+            >
+              <SelectTrigger className="h-10 w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="expense">지출</SelectItem>
+                <SelectItem value="income">수입</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="min-w-0 space-y-1">
+            <Label className="text-sm text-gray-700">공개범위</Label>
+            <Select
+              value={itemIsShared ? "shared" : "private"}
+              onValueChange={(value) =>
+                form.setValue(`items.${index}.isShared`, value === "shared")
+              }
+            >
+              <SelectTrigger className="h-10 w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="shared">공용</SelectItem>
+                <SelectItem value="private">개인</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+        <div className="space-y-1">
+          <Label className="text-sm text-gray-700">카테고리 *</Label>
+          {isDesktop ? (
+            <LedgerCategoryCombobox
               value={form.watch(`items.${index}.categoryId`)}
+              categories={categories}
+              placeholder="선택"
               onValueChange={(value) =>
                 form.setValue(`items.${index}.categoryId`, value, {
                   shouldValidate: true,
                 })
               }
-            >
-              <SelectTrigger className="h-10 w-full">
-                <SelectValue placeholder="선택" />
-              </SelectTrigger>
-              <SelectContent>
-                {categories.map((category) => (
-                  <SelectItem key={category.id} value={category.id}>
-                    {category.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            {errors?.categoryId && (
-              <p className="text-xs text-red-500">
-                {errors.categoryId.message}
-              </p>
+            />
+          ) : (
+            <LedgerCategoryTrigger
+              label={
+                categories.find(
+                  (cat) => cat.id === form.watch(`items.${index}.categoryId`),
+                )?.name ?? "선택"
+              }
+              placeholder="선택"
+              onClick={() => setMobileView("categoryPicker")}
+            />
+          )}
+          {errors?.categoryId && (
+            <p className="text-xs text-red-500">{errors.categoryId.message}</p>
+          )}
+        </div>
+
+        <div className="grid grid-cols-[1fr_112px] gap-2">
+          <div className="space-y-1">
+            <Label className="text-sm text-gray-700">내용 *</Label>
+            <Input
+              placeholder="예: 점심, 커피"
+              {...form.register(`items.${index}.title`)}
+            />
+            {errors?.title && (
+              <p className="text-xs text-red-500">{errors.title.message}</p>
             )}
           </div>
 
-          <div className="grid grid-cols-[1fr_112px] gap-2">
-            <div className="space-y-1">
-              <Label className="text-sm text-gray-700">내용 *</Label>
-              <Input
-                placeholder="예: 점심, 커피"
-                {...form.register(`items.${index}.title`)}
-              />
-              {errors?.title && (
-                <p className="text-xs text-red-500">{errors.title.message}</p>
-              )}
-            </div>
-
-            <div className="space-y-1">
-              <Label className="text-sm text-gray-700">금액 *</Label>
-              <Input
-                type="number"
-                inputMode="numeric"
-                placeholder="0"
-                className="text-right"
-                {...form.register(`items.${index}.amount`)}
-              />
-              {errors?.amount && (
-                <p className="text-xs text-red-500">{errors.amount.message}</p>
-              )}
-            </div>
+          <div className="space-y-1">
+            <Label className="text-sm text-gray-700">금액 *</Label>
+            <Input
+              type="number"
+              inputMode="numeric"
+              placeholder="0"
+              className="text-right"
+              {...form.register(`items.${index}.amount`)}
+            />
+            {errors?.amount && (
+              <p className="text-xs text-red-500">{errors.amount.message}</p>
+            )}
           </div>
+        </div>
 
-          <div className="grid grid-cols-1 gap-2">
-            <div className="space-y-1">
-              <Label className="text-sm text-gray-700">
-                {itemType === "expense" ? "결제 방법" : "입금 계좌"}
-              </Label>
+        <div className="grid grid-cols-1 gap-2">
+          <div className="space-y-1">
+            <Label className="text-sm text-gray-700">
+              {itemType === "expense" ? "결제 방법" : "입금 계좌"}
+            </Label>
+            {isDesktop ? (
               <LedgerMoneySourceCombobox
                 mode={itemType}
                 value={moneySourceValue}
@@ -203,37 +259,49 @@ export function ComposerFormStep({
                 placeholder="선택 안함"
                 onValueChange={handleMoneySourceChange}
               />
-            </div>
-          </div>
-
-          {mode === "full" && (
-            <div className="space-y-1">
-              <Label className="text-sm text-gray-700">날짜</Label>
-              <DatePickerInput
-                value={form.watch(`items.${index}.transactedAt`)}
-                onChange={(value) =>
-                  form.setValue(`items.${index}.transactedAt`, value, {
-                    shouldValidate: true,
-                  })
-                }
+            ) : (
+              <LedgerMoneySourceTrigger
+                label={getLedgerMoneySourceLabel({
+                  mode: itemType,
+                  value: moneySourceValue,
+                  paymentMethods,
+                  accounts,
+                  placeholder: "선택 안함",
+                })}
+                placeholder="선택 안함"
+                onClick={() => setMobileView("moneySourcePicker")}
               />
-            </div>
-          )}
+            )}
+          </div>
+        </div>
 
+        {mode === "full" && (
           <div className="space-y-1">
-            <Label className="text-sm text-gray-700">메모</Label>
-            <Textarea
-              placeholder="추가로 남기고 싶은 내용을 입력하세요"
-              rows={2}
-              className="resize-none"
-              {...form.register(`items.${index}.memo`)}
+            <Label className="text-sm text-gray-700">날짜</Label>
+            <DatePickerInput
+              value={form.watch(`items.${index}.transactedAt`)}
+              onChange={(value) =>
+                form.setValue(`items.${index}.transactedAt`, value, {
+                  shouldValidate: true,
+                })
+              }
             />
           </div>
+        )}
+
+        <div className="space-y-1">
+          <Label className="text-sm text-gray-700">메모</Label>
+          <Textarea
+            placeholder="추가로 남기고 싶은 내용을 입력하세요"
+            rows={2}
+            className="resize-none"
+            {...form.register(`items.${index}.memo`)}
+          />
         </div>
       </div>
 
       {/* Action Button */}
-      <div className="p-4 border-t border-gray-100 bg-white shrink-0">
+      <div className="p-4 border-t border-gray-100 bg-white shrink-0 pb-[calc(1rem+env(safe-area-inset-bottom))]">
         <Button
           type="button"
           onClick={handleConfirm}

--- a/components/ledger/entry-composer/ComposerListStep.tsx
+++ b/components/ledger/entry-composer/ComposerListStep.tsx
@@ -75,13 +75,6 @@ export function ComposerListStep({
 
   const handleDefaultDateChange = (value: string) => {
     form.setValue("defaultDate", value, { shouldValidate: true });
-    if (mode === "daily") {
-      fields.forEach((_, index) => {
-        form.setValue(`items.${index}.transactedAt`, value, {
-          shouldValidate: true,
-        });
-      });
-    }
   };
 
   const getCategoryName = (type: "expense" | "income", categoryId: string) => {
@@ -96,8 +89,8 @@ export function ComposerListStep({
   };
 
   return (
-    <div className="space-y-5">
-      <div className="rounded-2xl bg-white p-4 shadow-sm">
+    <div className="space-y-5 pb-[calc(1rem+env(safe-area-inset-bottom))]">
+      <div className="rounded-2xl bg-white p-4 shadow-sm space-y-4">
         <div className="space-y-4">
           <div className="grid grid-cols-2 gap-2">
             <div className="min-w-0 space-y-1">
@@ -151,6 +144,20 @@ export function ComposerListStep({
             />
           </div>
         </div>
+
+        {defaultType !== "transfer" && (
+          <div className="pt-2 border-t border-gray-50 flex justify-end">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleAddItem}
+              className="w-full sm:w-auto rounded-xl border-dashed h-11 px-6"
+            >
+              <PlusIcon className="size-4 mr-2" />
+              내역 추가
+            </Button>
+          </div>
+        )}
       </div>
 
       {defaultType === "transfer" ? (
@@ -239,16 +246,6 @@ export function ComposerListStep({
               );
             })}
           </div>
-
-          <Button
-            type="button"
-            variant="outline"
-            onClick={handleAddItem}
-            className="h-12 w-full rounded-xl border-dashed"
-          >
-            <PlusIcon className="size-4" />
-            내역 추가
-          </Button>
 
           <Button
             type="button"

--- a/components/ledger/entry-composer/LedgerEntryComposer.tsx
+++ b/components/ledger/entry-composer/LedgerEntryComposer.tsx
@@ -13,7 +13,6 @@ import {
   useCreateBatchLedgerEntries,
   useCreateLedgerEntry,
 } from "@/hooks/use-ledger-entries";
-import { useMediaQuery } from "@/hooks/use-media-query";
 import {
   buildLedgerEntryPayload,
   buildTransferLedgerEntryPayload,
@@ -157,7 +156,7 @@ export function LedgerEntryComposer({
                 animate={{ y: 0 }}
                 exit={{ y: "100%" }}
                 transition={{ type: "spring", damping: 25, stiffness: 200 }}
-                className="fixed inset-0 z-50 bg-white flex flex-col lg:left-56 lg:top-14 lg:right-0 lg:bottom-0"
+                className="fixed inset-0 z-50 bg-background flex flex-col lg:left-56 lg:top-14 lg:right-0 lg:bottom-0"
               >
                 <ComposerFormStep
                   key={editIndex}

--- a/components/stocks/StockSearchDialog.tsx
+++ b/components/stocks/StockSearchDialog.tsx
@@ -179,17 +179,19 @@ export function StockSearchDialog({
       variant="outline"
       disabled={disabled}
       onClick={() => setOpen(true)}
-      className="w-full justify-start font-normal"
+      className="w-full justify-start font-normal min-w-0"
     >
       {value ? (
-        <span className="flex items-center gap-2">
-          <span className="font-medium">{value.code}</span>
-          <span className="text-muted-foreground">{value.name}</span>
+        <span className="flex items-center gap-2 w-full min-w-0 text-left">
+          <span className="font-medium shrink-0">{value.code}</span>
+          <span className="text-muted-foreground truncate flex-1 min-w-0">
+            {value.name}
+          </span>
         </span>
       ) : (
-        <span className="flex items-center gap-2 text-muted-foreground">
-          <SearchIcon className="size-4" />
-          {placeholder}
+        <span className="flex items-center gap-2 text-muted-foreground w-full min-w-0 text-left">
+          <SearchIcon className="size-4 shrink-0" />
+          <span className="truncate flex-1 min-w-0">{placeholder}</span>
         </span>
       )}
     </Button>

--- a/components/transactions/AccountSelector.tsx
+++ b/components/transactions/AccountSelector.tsx
@@ -1,39 +1,164 @@
 "use client";
 
-import { PlusCircle } from "lucide-react";
+import { CheckIcon, ChevronsUpDownIcon, PlusCircle } from "lucide-react";
 import Link from "next/link";
-import type { ReactNode } from "react";
+import type { ComponentPropsWithoutRef } from "react";
+import { forwardRef, useState } from "react";
 import type { Control, FieldValues, Path } from "react-hook-form";
 import { useController } from "react-hook-form";
 import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
 import { Label } from "@/components/ui/label";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { useAccounts } from "@/hooks/use-accounts";
+import { useMediaQuery } from "@/hooks/use-media-query";
+import { cn } from "@/lib/utils/cn";
 
 interface AccountSelectorProps<T extends FieldValues> {
   control: Control<T>;
   name?: Path<T>;
   variant?: "card" | "inline";
+  placeholder?: string;
+  allowClear?: boolean;
+  onChange?: (value: string) => void;
 }
 
-export function AccountSelector<T extends FieldValues & { accountId: string }>({
+interface AccountSelectorTriggerProps
+  extends ComponentPropsWithoutRef<typeof Button> {
+  label: string;
+  placeholder: string;
+  open?: boolean;
+}
+
+export const AccountSelectorTrigger = forwardRef<
+  HTMLButtonElement,
+  AccountSelectorTriggerProps
+>(function AccountSelectorTrigger(
+  { label, placeholder, open, className, ...props },
+  ref,
+) {
+  return (
+    <Button
+      ref={ref}
+      type="button"
+      variant="outline"
+      role="combobox"
+      aria-expanded={open}
+      className={cn(
+        "h-11 w-full justify-between px-3 font-normal rounded-xl",
+        className,
+      )}
+      {...props}
+    >
+      <span
+        className={cn(
+          "truncate",
+          label === placeholder && "text-muted-foreground",
+        )}
+      >
+        {label}
+      </span>
+      <ChevronsUpDownIcon className="ml-2 size-4 shrink-0 opacity-50" />
+    </Button>
+  );
+});
+
+function AccountCommandList({
+  accounts,
+  value,
+  allowClear,
+  onValueChange,
+}: {
+  // biome-ignore lint/suspicious/noExplicitAny: accounts type from useAccounts
+  accounts: any[];
+  value: string;
+  allowClear: boolean;
+  onValueChange: (value: string) => void;
+}) {
+  return (
+    <CommandList className="max-h-[320px]">
+      <CommandEmpty>검색 결과가 없습니다.</CommandEmpty>
+      <CommandGroup heading="계좌 선택">
+        {allowClear && (
+          <CommandItem
+            value="DEFAULT"
+            onSelect={() => onValueChange("DEFAULT")}
+            className="cursor-pointer py-2.5"
+          >
+            <CheckIcon
+              className={cn(
+                "size-4 mr-2",
+                value === "DEFAULT" || !value ? "opacity-100" : "opacity-0",
+              )}
+            />
+            <span className="font-medium text-gray-500">기본 계좌 사용</span>
+          </CommandItem>
+        )}
+        {accounts.map((account) => (
+          <CommandItem
+            key={account.id}
+            value={account.name}
+            onSelect={() => onValueChange(account.id)}
+            className="cursor-pointer py-2.5"
+          >
+            <CheckIcon
+              className={cn(
+                "size-4 mr-2",
+                value === account.id ? "opacity-100" : "opacity-0",
+              )}
+            />
+            <div className="flex flex-col flex-1 min-w-0">
+              <span className="truncate font-medium">{account.name}</span>
+              {account.broker && (
+                <span className="truncate text-xs text-muted-foreground">
+                  {account.broker}
+                </span>
+              )}
+            </div>
+          </CommandItem>
+        ))}
+      </CommandGroup>
+    </CommandList>
+  );
+}
+
+export function AccountSelector<T extends FieldValues>({
   control,
   name = "accountId" as Path<T>,
   variant = "card",
+  placeholder,
+  allowClear = false,
+  onChange,
 }: AccountSelectorProps<T>) {
-  const { data: accounts, isLoading } = useAccounts();
+  const { data: accounts = [], isLoading } = useAccounts();
   const { field } = useController({
     control,
     name,
   });
+  const isDesktop = useMediaQuery("(min-width: 768px)");
+  const [open, setOpen] = useState(false);
 
-  const wrap = (children: ReactNode) => {
+  const wrap = (
+    children: React.ComponentPropsWithoutRef<"div">["children"],
+  ) => {
     if (variant === "inline") {
       return <div className="space-y-2">{children}</div>;
     }
@@ -72,28 +197,87 @@ export function AccountSelector<T extends FieldValues & { accountId: string }>({
     );
   }
 
+  const selectedAccount = accounts.find((acc) => acc.id === field.value);
+  const triggerPlaceholder = placeholder ?? "계좌를 선택하세요";
+  const triggerLabel = selectedAccount
+    ? `${selectedAccount.name}${selectedAccount.broker ? ` (${selectedAccount.broker})` : ""}`
+    : allowClear && (field.value === "DEFAULT" || !field.value)
+      ? "기본 계좌 사용"
+      : triggerPlaceholder;
+
+  const handleSelect = (val: string) => {
+    const nextVal = val === "DEFAULT" ? undefined : val;
+    field.onChange(nextVal);
+    if (onChange) {
+      onChange(nextVal ?? "");
+    }
+    setOpen(false);
+  };
+
+  const desktopContent = (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <AccountSelectorTrigger
+          label={triggerLabel}
+          placeholder={triggerPlaceholder}
+          open={open}
+        />
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-[var(--radix-popover-trigger-width)] p-0"
+        align="start"
+      >
+        <Command>
+          <CommandInput placeholder="계좌명, 증권사 검색" />
+          <AccountCommandList
+            accounts={accounts}
+            value={field.value ?? ""}
+            allowClear={allowClear}
+            onValueChange={handleSelect}
+          />
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+
+  const mobileContent = (
+    <>
+      <AccountSelectorTrigger
+        label={triggerLabel}
+        placeholder={triggerPlaceholder}
+        onClick={() => setOpen(true)}
+      />
+      <Drawer open={open} onOpenChange={setOpen}>
+        <DrawerContent className="h-[70vh] p-0 flex flex-col">
+          <DrawerHeader className="sr-only">
+            <DrawerTitle>계좌 선택</DrawerTitle>
+            <DrawerDescription>
+              거래 계좌를 선택하고 검색해보세요.
+            </DrawerDescription>
+          </DrawerHeader>
+          <div className="flex-1 min-h-0 px-4 pt-3 pb-6 flex flex-col">
+            <Command className="h-full rounded-xl border flex flex-col">
+              <CommandInput
+                placeholder="계좌명, 증권사 검색"
+                className="h-11"
+              />
+              <AccountCommandList
+                accounts={accounts}
+                value={field.value ?? ""}
+                allowClear={allowClear}
+                onValueChange={handleSelect}
+              />
+            </Command>
+          </div>
+        </DrawerContent>
+      </Drawer>
+    </>
+  );
+
   return wrap(
     <>
       <Label className="text-gray-700">거래 계좌</Label>
-      <Select value={field.value} onValueChange={field.onChange}>
-        <SelectTrigger className="h-11 rounded-xl w-full">
-          <SelectValue placeholder="계좌를 선택하세요" />
-        </SelectTrigger>
-        <SelectContent>
-          {accounts.map((account) => (
-            <SelectItem key={account.id} value={account.id}>
-              <span className="flex items-center gap-2">
-                {account.name}
-                {account.broker && (
-                  <span className="text-gray-400 text-xs">
-                    ({account.broker})
-                  </span>
-                )}
-              </span>
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+      {isDesktop ? desktopContent : mobileContent}
     </>,
   );
 }

--- a/components/transactions/MultiTransactionForm.tsx
+++ b/components/transactions/MultiTransactionForm.tsx
@@ -10,7 +10,6 @@ import { FormProvider, useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { StockComposerFormStep } from "@/components/transactions/StockComposerFormStep";
 import { StockComposerListStep } from "@/components/transactions/StockComposerListStep";
-import { useMediaQuery } from "@/hooks/use-media-query";
 import { useCreateBatchTransactions } from "@/hooks/use-transaction";
 import {
   type MultiTransactionFormData,
@@ -63,19 +62,29 @@ export function MultiTransactionForm({
       type: data.type,
       transactedAt: new Date(data.transactedAt).toISOString(),
       accountId: data.accountId,
-      items: validItems.map((item) => ({
-        ticker: item.stock!.code,
-        quantity: Number(item.quantity),
-        price: Number(item.price) || 0,
-        memo: item.memo || undefined,
-        stock: {
-          name: item.stock!.name,
-          market: item.stock!.market,
-          currency:
-            item.stock!.market === "US" ? ("USD" as const) : ("KRW" as const),
-          assetType: "equity" as const,
-        },
-      })),
+      items: validItems.map((item) => {
+        const itemTransactedAt = item.transactedAt
+          ? item.transactedAt.includes("T")
+            ? item.transactedAt
+            : new Date(item.transactedAt).toISOString()
+          : new Date(data.transactedAt).toISOString();
+
+        return {
+          ticker: item.stock!.code,
+          quantity: Number(item.quantity),
+          price: Number(item.price) || 0,
+          memo: item.memo || undefined,
+          transactedAt: itemTransactedAt,
+          accountId: item.accountId || data.accountId,
+          stock: {
+            name: item.stock!.name,
+            market: item.stock!.market,
+            currency:
+              item.stock!.market === "US" ? ("USD" as const) : ("KRW" as const),
+            assetType: "equity" as const,
+          },
+        };
+      }),
     };
   };
 
@@ -122,7 +131,7 @@ export function MultiTransactionForm({
                 animate={{ y: 0 }}
                 exit={{ y: "100%" }}
                 transition={{ type: "spring", damping: 25, stiffness: 200 }}
-                className="fixed inset-0 z-50 bg-white flex flex-col lg:left-56 lg:top-14 lg:right-0 lg:bottom-0"
+                className="fixed inset-0 z-50 bg-background flex flex-col lg:left-56 lg:top-14 lg:right-0 lg:bottom-0"
               >
                 <StockComposerFormStep
                   key={editIndex}

--- a/components/transactions/StockComposerFormStep.tsx
+++ b/components/transactions/StockComposerFormStep.tsx
@@ -2,9 +2,12 @@
 
 import { XIcon } from "lucide-react";
 import { useState } from "react";
-import { useFormContext, useWatch } from "react-hook-form";
+import { useFormContext } from "react-hook-form";
+import { AccountSelector } from "@/components/transactions/AccountSelector";
 import { TransactionItemRow } from "@/components/transactions/TransactionItemRow";
 import { Button } from "@/components/ui/button";
+import { DatePickerInput } from "@/components/ui/date-picker";
+import { Label } from "@/components/ui/label";
 import type { MultiTransactionFormData } from "@/schemas/multi-transaction-form";
 
 interface StockComposerFormStepProps {
@@ -31,18 +34,6 @@ export function StockComposerFormStep({
     }
   };
 
-  const items = useWatch({ control: form.control, name: "items" });
-  const canRemove = items.length > 1;
-
-  const handleRemove = () => {
-    const currentItems = form.getValues("items");
-    form.setValue(
-      "items",
-      currentItems.filter((_, i) => i !== index),
-    );
-    onBack();
-  };
-
   return (
     <>
       <Button
@@ -54,19 +45,45 @@ export function StockComposerFormStep({
       </Button>
 
       {/* Form Content */}
-      <div className="flex-1 overflow-y-auto p-4 pt-16">
-        <div className="bg-white rounded-2xl shadow-sm p-4">
-          <TransactionItemRow
-            index={index}
-            control={form.control}
-            onRemove={handleRemove}
-            canRemove={canRemove}
-          />
+      <div className="flex-1 overflow-y-auto px-4 pt-16 pb-4 space-y-4">
+        <TransactionItemRow index={index} control={form.control} />
+
+        <div className="pt-2 space-y-3">
+          <div>
+            <h3 className="text-sm font-semibold text-gray-900">
+              거래일 및 계좌
+            </h3>
+            <p className="text-xs text-gray-500 mt-0.5">
+              이 거래 행에 적용할 거래일과 계좌를 변경할 수 있습니다.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label className="text-sm text-gray-700">거래일</Label>
+              <DatePickerInput
+                value={form.watch(`items.${index}.transactedAt`) ?? ""}
+                onChange={(v) =>
+                  form.setValue(`items.${index}.transactedAt`, v || "")
+                }
+                className="h-11 rounded-xl w-full"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <AccountSelector
+                control={form.control}
+                name={`items.${index}.accountId`}
+                variant="inline"
+                placeholder="계좌 선택"
+              />
+            </div>
+          </div>
         </div>
       </div>
 
       {/* Action Button */}
-      <div className="p-4 border-t border-gray-100 bg-white shrink-0">
+      <div className="p-4 border-t border-gray-100 bg-white shrink-0 pb-[calc(1rem+env(safe-area-inset-bottom))]">
         <Button
           type="button"
           onClick={handleConfirm}

--- a/components/transactions/StockComposerListStep.tsx
+++ b/components/transactions/StockComposerListStep.tsx
@@ -52,7 +52,11 @@ export function StockComposerListStep({
 
   const handleAddItem = () => {
     const newIndex = fields.length;
-    append({ ...DEFAULT_TRANSACTION_ITEM });
+    append({
+      ...DEFAULT_TRANSACTION_ITEM,
+      transactedAt: watchTransactedAt,
+      accountId: form.getValues("accountId"),
+    });
     onEditItem(newIndex);
   };
 
@@ -63,7 +67,7 @@ export function StockComposerListStep({
   };
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 pb-[calc(1rem+env(safe-area-inset-bottom))]">
       <div className="bg-white rounded-2xl shadow-sm p-4 space-y-4">
         <TransactionTypeSelector control={form.control} variant="inline" />
 
@@ -85,6 +89,19 @@ export function StockComposerListStep({
           </div>
 
           <AccountSelector control={form.control} variant="inline" />
+        </div>
+
+        {/* 종목 추가 버튼 통합 */}
+        <div className="pt-2 border-t border-gray-50 flex justify-end">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleAddItem}
+            className="w-full sm:w-auto rounded-xl border-dashed h-11 px-6"
+          >
+            <PlusIcon className="h-4 w-4 mr-2" />
+            종목 추가
+          </Button>
         </div>
       </div>
 
@@ -177,16 +194,6 @@ export function StockComposerListStep({
               );
             })}
           </div>
-
-          <Button
-            type="button"
-            variant="outline"
-            onClick={handleAddItem}
-            className="w-full h-12 rounded-xl border-dashed"
-          >
-            <PlusIcon className="h-4 w-4 mr-2" />
-            종목 추가
-          </Button>
 
           {fields.length > 0 && (
             <TransactionSummary items={watchItems} type={watchType} />

--- a/components/transactions/TransactionItemRow.tsx
+++ b/components/transactions/TransactionItemRow.tsx
@@ -7,6 +7,7 @@ import { useController, useWatch } from "react-hook-form";
 import { StockSearchDialog } from "@/components/stocks/StockSearchDialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { formatCurrency } from "@/lib/utils/format";
 import type { TransactionItemFormData } from "@/schemas/multi-transaction-form";
 import type { CurrencyType, StockMaster } from "@/types";
@@ -17,15 +18,15 @@ type FormWithItems = FieldValues & { items: TransactionItemFormData[] };
 interface TransactionItemRowProps<T extends FormWithItems> {
   index: number;
   control: Control<T>;
-  onRemove: () => void;
-  canRemove: boolean;
+  onRemove?: () => void;
+  canRemove?: boolean;
 }
 
 export function TransactionItemRow<T extends FormWithItems>({
   index,
   control,
   onRemove,
-  canRemove,
+  canRemove = false,
 }: TransactionItemRowProps<T>) {
   const { field: stockField } = useController({
     control,
@@ -62,62 +63,60 @@ export function TransactionItemRow<T extends FormWithItems>({
   };
 
   return (
-    <div className="py-4 border-b border-gray-200 last:border-b-0">
-      {/* 1줄: 종목 + 삭제 */}
-      <div className="flex items-center gap-2 mb-3">
-        {/* 종목 검색 */}
-        <div className="flex-1">
-          <StockSearchDialog
-            value={
-              stockField.value
-                ? ({
-                    code: stockField.value.code,
-                    name: stockField.value.name,
-                    market: stockField.value.market,
-                    exchange: stockField.value.exchange,
-                  } as StockMaster)
-                : null
-            }
-            onSelect={handleStockSelect}
-            placeholder="종목 검색"
-          />
+    <div className="py-2 space-y-4">
+      {/* 1줄: 종목 */}
+      <div className="space-y-1">
+        <div className="flex items-center justify-between">
+          <Label className="text-sm text-gray-700">종목 *</Label>
+          {canRemove && onRemove && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={onRemove}
+              className="h-8 w-8 text-gray-400 hover:text-red-500 shrink-0"
+            >
+              <Trash2Icon className="h-4 w-4" />
+            </Button>
+          )}
         </div>
-
-        {/* 삭제 버튼 */}
-        {canRemove && (
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            onClick={onRemove}
-            className="h-9 w-9 text-gray-400 hover:text-red-500 shrink-0"
-          >
-            <Trash2Icon className="h-4 w-4" />
-          </Button>
-        )}
+        <StockSearchDialog
+          value={
+            stockField.value
+              ? ({
+                  code: stockField.value.code,
+                  name: stockField.value.name,
+                  market: stockField.value.market,
+                  exchange: stockField.value.exchange,
+                } as StockMaster)
+              : null
+          }
+          onSelect={handleStockSelect}
+          placeholder="종목 검색"
+        />
       </div>
 
       {/* 2줄: 수량 + 단가 */}
-      <div className="flex items-center gap-2">
-        <div className="flex items-center gap-1.5 flex-1 min-w-0">
-          <span className="text-xs text-gray-500 shrink-0">수량</span>
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-1">
+          <Label className="text-sm text-gray-700">수량 *</Label>
           <Input
             type="number"
             inputMode="numeric"
             placeholder="0"
-            className="h-9 text-right text-sm"
+            className="h-11 rounded-xl text-right text-sm"
             {...control.register(`items.${index}.quantity` as FieldPath<T>)}
           />
         </div>
-        <div className="flex items-center gap-1.5 flex-1 min-w-0">
-          <span className="text-xs text-gray-500 shrink-0">
-            {currency === "KRW" ? "단가" : "$"}
-          </span>
+        <div className="space-y-1">
+          <Label className="text-sm text-gray-700">
+            {currency === "KRW" ? "단가 *" : "단가 ($) *"}
+          </Label>
           <Input
             type="number"
             inputMode="decimal"
             placeholder="0"
-            className="h-9 text-right text-sm"
+            className="h-11 rounded-xl text-right text-sm"
             {...control.register(`items.${index}.price` as FieldPath<T>)}
           />
         </div>

--- a/lib/api/transaction.ts
+++ b/lib/api/transaction.ts
@@ -486,6 +486,8 @@ export interface BatchTransactionItem {
   quantity: number;
   price: number;
   memo?: string;
+  transactedAt?: string;
+  accountId?: string;
   stock: {
     name: string;
     market: MarketType;
@@ -550,10 +552,12 @@ export async function createBatchTransactions(
 
   // 2. 매도 시 해당 계좌의 종목별 누적 수량 검증
   if (type === "sell") {
-    // 같은 종목 매도 수량 합산
-    const sellQuantityByTicker = items.reduce(
+    // 종목과 계좌 조합별 매도 수량 합산 (개별 계좌 override 고려)
+    const sellQuantityKeyMap = items.reduce(
       (acc, item) => {
-        acc[item.ticker] = (acc[item.ticker] || 0) + item.quantity;
+        const targetAccountId = item.accountId ?? accountId;
+        const key = `${item.ticker}:${targetAccountId}`;
+        acc[key] = (acc[key] || 0) + item.quantity;
         return acc;
       },
       {} as Record<string, number>,
@@ -562,22 +566,23 @@ export async function createBatchTransactions(
     // 모든 초과 종목 수집
     const insufficientStocks: string[] = [];
 
-    for (const [ticker, totalSellQuantity] of Object.entries(
-      sellQuantityByTicker,
-    )) {
+    for (const [key, totalSellQuantity] of Object.entries(sellQuantityKeyMap)) {
+      const [ticker, targetAccountId] = key.split(":");
       const currentQuantity = await getHoldingQuantity(
         supabase,
         householdId,
         ownerId,
         ticker,
-        accountId,
+        targetAccountId,
       );
 
       if (currentQuantity < totalSellQuantity) {
         const stockName =
           items.find((i) => i.ticker === ticker)?.stock.name || ticker;
+        const accountName =
+          targetAccountId === accountId ? "기본 계좌" : "선택한 계좌";
         insufficientStocks.push(
-          `${stockName}: 해당 계좌 보유 ${currentQuantity}주, 매도 ${totalSellQuantity}주`,
+          `${stockName}(${accountName}): 해당 계좌 보유 ${currentQuantity}주, 매도 ${totalSellQuantity}주`,
         );
       }
     }
@@ -600,9 +605,9 @@ export async function createBatchTransactions(
     type,
     quantity: item.quantity,
     price: item.price,
-    transacted_at: transactedAt,
+    transacted_at: item.transactedAt ?? transactedAt,
     memo: item.memo || null,
-    account_id: accountId,
+    account_id: item.accountId ?? accountId,
   }));
 
   const { data, error } = await supabase

--- a/schemas/multi-transaction-form.ts
+++ b/schemas/multi-transaction-form.ts
@@ -16,6 +16,8 @@ export const transactionItemSchema = z.object({
   quantity: z.string(),
   price: z.string(),
   memo: z.string().optional(),
+  transactedAt: z.string().optional(),
+  accountId: z.string().optional(),
 });
 
 export type TransactionItemFormData = z.infer<typeof transactionItemSchema>;
@@ -47,4 +49,6 @@ export const DEFAULT_TRANSACTION_ITEM: TransactionItemFormData = {
   quantity: "",
   price: "",
   memo: "",
+  transactedAt: undefined,
+  accountId: undefined,
 };

--- a/schemas/transaction.ts
+++ b/schemas/transaction.ts
@@ -84,6 +84,11 @@ export const batchTransactionItemSchema = z.object({
     .min(0, "가격은 0 이상이어야 합니다.")
     .max(999999999999, "가격이 너무 큽니다."),
   memo: z.string().max(500, "메모는 500자 이내여야 합니다.").optional(),
+  transactedAt: z
+    .string()
+    .datetime({ message: "유효한 날짜 형식이 아닙니다." })
+    .optional(),
+  accountId: z.string().uuid("유효한 계좌 ID가 아닙니다.").optional(),
   stock: z.object({
     name: z.string().min(1, "종목명은 필수입니다."),
     market: z.enum(["KR", "US", "OTHER"]),


### PR DESCRIPTION
이슈 #323에 명시된 폼 관련 스타일 및 모바일/데스크톱 반응형 사용성 개선 작업을 진행했습니다.

### 주요 작업 내용
1. **주식 검색 Trigger 텍스트 넘침 수정**: StockSearchDialog에서 이름이 길면 말줄임표(...) 처리가 정상 작동하도록 min-w-0 및 truncate 스타일을 추가했습니다.
2. **주식 거래일/계좌 행 단위 지정**: 가계부처럼 주식 행 추가 시 메인에 있는 설정값을 복제하여 삽입하고, 메인 값을 바꾸더라도 개별적으로 설정해놓은 행의 값은 보호되도록 개선했습니다.
3. **가계부 카테고리 반응형 검색 콤보박스 도입**: LedgerCategoryCombobox를 신규 제작하여 데스크톱(Popover 검색)과 모바일(Drawer 검색)에 각각 일관되게 교체했습니다.
4. **가계부 결제수단 반응형 바텀시트 적용**: ComposerFormStep의 결제 방법 영역을 모바일에서는 Drawer 검색 패널로 표시해 키패드 노출 시 가림 문제를 해결했습니다.
5. **계좌 선택기 반응형 Combobox로 교체**: 거래 계좌 선택기 AccountSelector 역시 계좌가 많아지면 탐색하기 어려운 문제를 극복하고자 팝오버 및 바텀시트 내 검색 창 형태로 고도화했습니다.
6. **디자인 통일성 및 테두리 정리**: 폼 내부의 이중 border 및 카드를 제거하고 라벨 크기/스타일을 일치시켰으며, 완료 버튼 하단에 Safe Area 패딩을 부여해 노치 디자인 겹침 문제를 예방했습니다.