### PR TITLE
fix: improve mobile form bottom sheets

### DIFF
--- a/components/ledger/LedgerCategoryCombobox.tsx
+++ b/components/ledger/LedgerCategoryCombobox.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowLeftIcon, CheckIcon, ChevronsUpDownIcon } from "lucide-react";
+import { CheckIcon, ChevronsUpDownIcon } from "lucide-react";
 import type { ComponentPropsWithoutRef } from "react";
 import { forwardRef, useState } from "react";
 import { CategoryIcon } from "@/components/ledger/CategoryIcon";
@@ -82,13 +82,15 @@ function CategoryCommandList({
   categories,
   value,
   onValueChange,
+  className,
 }: {
   categories: Category[];
   value: string;
   onValueChange: (value: string) => void;
+  className?: string;
 }) {
   return (
-    <CommandList className="max-h-[320px]">
+    <CommandList className={cn("max-h-[320px]", className)}>
       <CommandEmpty>검색 결과가 없습니다.</CommandEmpty>
       <CommandGroup heading="카테고리 선택">
         {categories.map((category) => (
@@ -162,38 +164,18 @@ export function LedgerCategoryCombobox({
 export function LedgerCategoryPickerPanel({
   value,
   categories,
-  title,
   searchPlaceholder,
-  onBack,
   onValueChange,
 }: LedgerCategoryPickerPanelProps) {
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
-      <div className="flex items-center gap-2 px-4 pb-3">
-        {onBack && (
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            className="size-9 shrink-0"
-            onClick={onBack}
-          >
-            <ArrowLeftIcon className="size-5" />
-            <span className="sr-only">돌아가기</span>
-          </Button>
-        )}
-        <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
-      </div>
-      <div className="min-h-0 flex-1 px-4">
-        <Command className="h-full rounded-xl border">
-          <CommandInput placeholder={searchPlaceholder} className="h-11" />
-          <CategoryCommandList
-            categories={categories}
-            value={value}
-            onValueChange={onValueChange}
-          />
-        </Command>
-      </div>
-    </div>
+    <Command className="h-full">
+      <CommandInput placeholder={searchPlaceholder} />
+      <CategoryCommandList
+        categories={categories}
+        value={value}
+        onValueChange={onValueChange}
+        className="max-h-none min-h-0 flex-1"
+      />
+    </Command>
   );
 }

--- a/components/ledger/LedgerMoneySourceCombobox.tsx
+++ b/components/ledger/LedgerMoneySourceCombobox.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowLeftIcon, CheckIcon, ChevronsUpDownIcon } from "lucide-react";
+import { CheckIcon, ChevronsUpDownIcon } from "lucide-react";
 import type { ComponentPropsWithoutRef } from "react";
 import { forwardRef, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
@@ -126,13 +126,15 @@ function MoneySourceCommandList({
   groups,
   value,
   onValueChange,
+  className,
 }: {
   groups: LedgerMoneySourceGroup[];
   value: string;
   onValueChange: (value: string) => void;
+  className?: string;
 }) {
   return (
-    <CommandList className="max-h-[320px]">
+    <CommandList className={cn("max-h-[320px]", className)}>
       <CommandEmpty>검색 결과가 없습니다.</CommandEmpty>
       {groups.map((group) => (
         <CommandGroup key={group.label} heading={group.label}>
@@ -224,9 +226,7 @@ export function LedgerMoneySourcePickerPanel({
   accounts,
   includeClearOption = true,
   excludedValues,
-  title,
   searchPlaceholder,
-  onBack,
   onValueChange,
 }: LedgerMoneySourcePickerPanelProps) {
   const groups = useMoneySourceGroups({
@@ -239,33 +239,15 @@ export function LedgerMoneySourcePickerPanel({
   });
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
-      <div className="flex items-center gap-2 px-4 pb-3">
-        {onBack && (
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            className="size-9 shrink-0"
-            onClick={onBack}
-          >
-            <ArrowLeftIcon className="size-5" />
-            <span className="sr-only">돌아가기</span>
-          </Button>
-        )}
-        <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
-      </div>
-      <div className="min-h-0 flex-1 px-4">
-        <Command className="h-full rounded-xl border">
-          <CommandInput placeholder={searchPlaceholder} className="h-11" />
-          <MoneySourceCommandList
-            groups={groups}
-            value={value}
-            onValueChange={onValueChange}
-          />
-        </Command>
-      </div>
-    </div>
+    <Command className="h-full">
+      <CommandInput placeholder={searchPlaceholder} />
+      <MoneySourceCommandList
+        groups={groups}
+        value={value}
+        onValueChange={onValueChange}
+        className="max-h-none min-h-0 flex-1"
+      />
+    </Command>
   );
 }
 

--- a/components/ledger/entry-composer/ComposerFormStep.tsx
+++ b/components/ledger/entry-composer/ComposerFormStep.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ledger/LedgerMoneySourceCombobox";
 import { Button } from "@/components/ui/button";
 import { DatePickerInput } from "@/components/ui/date-picker";
+import { Drawer, DrawerContent } from "@/components/ui/drawer";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -94,46 +95,6 @@ export function ComposerFormStep({
     form.setValue(`items.${index}.accountId`, undefined);
   };
 
-  if (!isDesktop && mobileView === "moneySourcePicker") {
-    return (
-      <div className="flex min-h-[70vh] flex-col pb-4 pt-16 bg-white h-full">
-        <LedgerMoneySourcePickerPanel
-          mode={itemType}
-          value={moneySourceValue}
-          paymentMethods={paymentMethods}
-          accounts={accounts}
-          title={itemType === "expense" ? "결제 방법 선택" : "입금 계좌 선택"}
-          searchPlaceholder="이름, 기관, 소유자 검색"
-          onBack={() => setMobileView("form")}
-          onValueChange={(v) => {
-            handleMoneySourceChange(v);
-            setMobileView("form");
-          }}
-        />
-      </div>
-    );
-  }
-
-  if (!isDesktop && mobileView === "categoryPicker") {
-    return (
-      <div className="flex min-h-[70vh] flex-col pb-4 pt-16 bg-white h-full">
-        <LedgerCategoryPickerPanel
-          value={form.watch(`items.${index}.categoryId`)}
-          categories={categories}
-          title="카테고리 선택"
-          searchPlaceholder="카테고리 이름 검색"
-          onBack={() => setMobileView("form")}
-          onValueChange={(v) => {
-            form.setValue(`items.${index}.categoryId`, v, {
-              shouldValidate: true,
-            });
-            setMobileView("form");
-          }}
-        />
-      </div>
-    );
-  }
-
   return (
     <>
       <Button
@@ -189,6 +150,21 @@ export function ComposerFormStep({
             </Select>
           </div>
         </div>
+
+        {mode === "full" && (
+          <div className="space-y-1">
+            <Label className="text-sm text-gray-700">날짜</Label>
+            <DatePickerInput
+              value={form.watch(`items.${index}.transactedAt`)}
+              onChange={(value) =>
+                form.setValue(`items.${index}.transactedAt`, value, {
+                  shouldValidate: true,
+                })
+              }
+            />
+          </div>
+        )}
+
         <div className="space-y-1">
           <Label className="text-sm text-gray-700">카테고리 *</Label>
           {isDesktop ? (
@@ -218,34 +194,31 @@ export function ComposerFormStep({
           )}
         </div>
 
-        <div className="grid grid-cols-[1fr_112px] gap-2">
-          <div className="space-y-1">
-            <Label className="text-sm text-gray-700">내용 *</Label>
-            <Input
-              placeholder="예: 점심, 커피"
-              {...form.register(`items.${index}.title`)}
-            />
-            {errors?.title && (
-              <p className="text-xs text-red-500">{errors.title.message}</p>
-            )}
-          </div>
+        <div className="space-y-1">
+          <Label className="text-sm text-gray-700">내용 *</Label>
+          <Input
+            placeholder="예: 점심, 커피"
+            {...form.register(`items.${index}.title`)}
+          />
+          {errors?.title && (
+            <p className="text-xs text-red-500">{errors.title.message}</p>
+          )}
+        </div>
 
+        <div className="grid grid-cols-2 gap-2">
           <div className="space-y-1">
             <Label className="text-sm text-gray-700">금액 *</Label>
             <Input
               type="number"
               inputMode="numeric"
               placeholder="0"
-              className="text-right"
               {...form.register(`items.${index}.amount`)}
             />
             {errors?.amount && (
               <p className="text-xs text-red-500">{errors.amount.message}</p>
             )}
           </div>
-        </div>
 
-        <div className="grid grid-cols-1 gap-2">
           <div className="space-y-1">
             <Label className="text-sm text-gray-700">
               {itemType === "expense" ? "결제 방법" : "입금 계좌"}
@@ -275,20 +248,6 @@ export function ComposerFormStep({
           </div>
         </div>
 
-        {mode === "full" && (
-          <div className="space-y-1">
-            <Label className="text-sm text-gray-700">날짜</Label>
-            <DatePickerInput
-              value={form.watch(`items.${index}.transactedAt`)}
-              onChange={(value) =>
-                form.setValue(`items.${index}.transactedAt`, value, {
-                  shouldValidate: true,
-                })
-              }
-            />
-          </div>
-        )}
-
         <div className="space-y-1">
           <Label className="text-sm text-gray-700">메모</Label>
           <Textarea
@@ -310,6 +269,64 @@ export function ComposerFormStep({
           완료
         </Button>
       </div>
+
+      {!isDesktop && (
+        <>
+          <Drawer
+            open={mobileView === "categoryPicker"}
+            onOpenChange={(open) => {
+              if (!open) setMobileView("form");
+            }}
+          >
+            <DrawerContent
+              className="h-[85dvh] max-h-[85dvh] p-0 flex flex-col data-[vaul-drawer-direction=bottom]:mt-0 data-[vaul-drawer-direction=bottom]:max-h-[85dvh]"
+              onOpenAutoFocus={(event) => event.preventDefault()}
+            >
+              <LedgerCategoryPickerPanel
+                value={form.watch(`items.${index}.categoryId`)}
+                categories={categories}
+                title="카테고리 선택"
+                searchPlaceholder="카테고리 이름 검색"
+                onBack={() => setMobileView("form")}
+                onValueChange={(v) => {
+                  form.setValue(`items.${index}.categoryId`, v, {
+                    shouldValidate: true,
+                  });
+                  setMobileView("form");
+                }}
+              />
+            </DrawerContent>
+          </Drawer>
+
+          <Drawer
+            open={mobileView === "moneySourcePicker"}
+            onOpenChange={(open) => {
+              if (!open) setMobileView("form");
+            }}
+          >
+            <DrawerContent
+              className="h-[85dvh] max-h-[85dvh] p-0 flex flex-col data-[vaul-drawer-direction=bottom]:mt-0 data-[vaul-drawer-direction=bottom]:max-h-[85dvh]"
+              onOpenAutoFocus={(event) => event.preventDefault()}
+            >
+              <LedgerMoneySourcePickerPanel
+                mode={itemType}
+                value={moneySourceValue}
+                paymentMethods={paymentMethods}
+                accounts={accounts}
+                title={
+                  itemType === "expense" ? "결제 방법 선택" : "입금 계좌 선택"
+                }
+                searchPlaceholder="이름, 기관, 소유자 검색"
+                onBack={() => setMobileView("form")}
+                onValueChange={(v) => {
+                  handleMoneySourceChange(v);
+                  setMobileView("form");
+                }}
+              />
+            </DrawerContent>
+          </Drawer>
+        </>
+      )}
     </>
   );
 }

--- a/components/ledger/entry-composer/ComposerListStep.tsx
+++ b/components/ledger/entry-composer/ComposerListStep.tsx
@@ -151,7 +151,7 @@ export function ComposerListStep({
               type="button"
               variant="outline"
               onClick={handleAddItem}
-              className="w-full sm:w-auto rounded-xl border-dashed h-11 px-6"
+              className="w-full rounded-xl border-dashed h-11 px-6"
             >
               <PlusIcon className="size-4 mr-2" />
               내역 추가

--- a/components/ledger/entry-composer/LedgerEntryComposer.tsx
+++ b/components/ledger/entry-composer/LedgerEntryComposer.tsx
@@ -9,10 +9,12 @@ import { createPortal } from "react-dom";
 import { FormProvider, useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
+import { Drawer, DrawerContent } from "@/components/ui/drawer";
 import {
   useCreateBatchLedgerEntries,
   useCreateLedgerEntry,
 } from "@/hooks/use-ledger-entries";
+import { useMediaQuery } from "@/hooks/use-media-query";
 import {
   buildLedgerEntryPayload,
   buildTransferLedgerEntryPayload,
@@ -78,13 +80,30 @@ export function LedgerEntryComposer({
   const router = useRouter();
   const createBatch = useCreateBatchLedgerEntries();
   const createSingle = useCreateLedgerEntry();
+  const isDesktop = useMediaQuery("(min-width: 768px)");
 
   const [editIndex, setEditIndex] = useQueryState("editIndex", parseAsInteger);
+  const [activeEditIndex, setActiveEditIndex] = useState<number | null>(null);
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
     setMounted(true);
   }, []);
+
+  useEffect(() => {
+    if (editIndex !== null) {
+      setActiveEditIndex(editIndex);
+      return;
+    }
+
+    if (activeEditIndex === null) return;
+
+    const timeoutId = window.setTimeout(() => {
+      setActiveEditIndex(null);
+    }, 300);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [editIndex, activeEditIndex]);
 
   const form = useForm<LedgerComposerFormValues>({
     resolver: zodResolver(ledgerComposerSchema),
@@ -148,6 +167,7 @@ export function LedgerEntryComposer({
       </div>
 
       {mounted &&
+        isDesktop &&
         createPortal(
           <AnimatePresence>
             {editIndex !== null && (
@@ -169,6 +189,30 @@ export function LedgerEntryComposer({
           </AnimatePresence>,
           document.body,
         )}
+
+      {mounted && !isDesktop && (
+        <Drawer
+          open={editIndex !== null}
+          onOpenChange={(open) => {
+            if (!open) setEditIndex(null);
+          }}
+        >
+          {activeEditIndex !== null && (
+            <DrawerContent
+              className="h-[100dvh] max-h-[100dvh] rounded-none border-t-0 p-0 flex flex-col data-[vaul-drawer-direction=bottom]:mt-0 data-[vaul-drawer-direction=bottom]:max-h-[100dvh] data-[vaul-drawer-direction=bottom]:rounded-none data-[vaul-drawer-direction=bottom]:border-t-0"
+              showHandle={false}
+              onOpenAutoFocus={(event) => event.preventDefault()}
+            >
+              <ComposerFormStep
+                key={activeEditIndex}
+                index={activeEditIndex}
+                mode={mode}
+                onBack={() => setEditIndex(null)}
+              />
+            </DrawerContent>
+          )}
+        </Drawer>
+      )}
     </FormProvider>
   );
 }

--- a/components/stocks/StockSearchDialog.tsx
+++ b/components/stocks/StockSearchDialog.tsx
@@ -221,7 +221,10 @@ export function StockSearchDialog({
     <>
       {triggerButton}
       <Drawer open={open} onOpenChange={handleOpenChange}>
-        <DrawerContent className="h-[85vh] p-0 flex flex-col">
+        <DrawerContent
+          className="h-[85dvh] max-h-[85dvh] p-0 flex flex-col data-[vaul-drawer-direction=bottom]:mt-0 data-[vaul-drawer-direction=bottom]:max-h-[85dvh]"
+          onOpenAutoFocus={(event) => event.preventDefault()}
+        >
           <DrawerHeader className="sr-only">
             <DrawerTitle>종목 검색</DrawerTitle>
             <DrawerDescription>

--- a/components/transactions/AccountSelector.tsx
+++ b/components/transactions/AccountSelector.tsx
@@ -86,15 +86,17 @@ function AccountCommandList({
   value,
   allowClear,
   onValueChange,
+  className,
 }: {
   // biome-ignore lint/suspicious/noExplicitAny: accounts type from useAccounts
   accounts: any[];
   value: string;
   allowClear: boolean;
   onValueChange: (value: string) => void;
+  className?: string;
 }) {
   return (
-    <CommandList className="max-h-[320px]">
+    <CommandList className={cn("max-h-[320px]", className)}>
       <CommandEmpty>검색 결과가 없습니다.</CommandEmpty>
       <CommandGroup heading="계좌 선택">
         {allowClear && (
@@ -248,27 +250,26 @@ export function AccountSelector<T extends FieldValues>({
         onClick={() => setOpen(true)}
       />
       <Drawer open={open} onOpenChange={setOpen}>
-        <DrawerContent className="h-[70vh] p-0 flex flex-col">
+        <DrawerContent
+          className="h-[85dvh] max-h-[85dvh] p-0 flex flex-col data-[vaul-drawer-direction=bottom]:mt-0 data-[vaul-drawer-direction=bottom]:max-h-[85dvh]"
+          onOpenAutoFocus={(event) => event.preventDefault()}
+        >
           <DrawerHeader className="sr-only">
             <DrawerTitle>계좌 선택</DrawerTitle>
             <DrawerDescription>
               거래 계좌를 선택하고 검색해보세요.
             </DrawerDescription>
           </DrawerHeader>
-          <div className="flex-1 min-h-0 px-4 pt-3 pb-6 flex flex-col">
-            <Command className="h-full rounded-xl border flex flex-col">
-              <CommandInput
-                placeholder="계좌명, 증권사 검색"
-                className="h-11"
-              />
-              <AccountCommandList
-                accounts={accounts}
-                value={field.value ?? ""}
-                allowClear={allowClear}
-                onValueChange={handleSelect}
-              />
-            </Command>
-          </div>
+          <Command className="h-full">
+            <CommandInput placeholder="계좌명, 증권사 검색" />
+            <AccountCommandList
+              accounts={accounts}
+              value={field.value ?? ""}
+              allowClear={allowClear}
+              onValueChange={handleSelect}
+              className="max-h-none min-h-0 flex-1"
+            />
+          </Command>
         </DrawerContent>
       </Drawer>
     </>

--- a/components/transactions/MultiTransactionForm.tsx
+++ b/components/transactions/MultiTransactionForm.tsx
@@ -10,6 +10,8 @@ import { FormProvider, useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { StockComposerFormStep } from "@/components/transactions/StockComposerFormStep";
 import { StockComposerListStep } from "@/components/transactions/StockComposerListStep";
+import { Drawer, DrawerContent } from "@/components/ui/drawer";
+import { useMediaQuery } from "@/hooks/use-media-query";
 import { useCreateBatchTransactions } from "@/hooks/use-transaction";
 import {
   type MultiTransactionFormData,
@@ -28,6 +30,7 @@ export function MultiTransactionForm({
 }: MultiTransactionFormProps) {
   const router = useRouter();
   const createBatchTransactions = useCreateBatchTransactions();
+  const isDesktop = useMediaQuery("(min-width: 768px)");
 
   const form = useForm<MultiTransactionFormData>({
     resolver: zodResolver(multiTransactionFormSchema),
@@ -40,11 +43,27 @@ export function MultiTransactionForm({
   });
 
   const [editIndex, setEditIndex] = useQueryState("editIndex", parseAsInteger);
+  const [activeEditIndex, setActiveEditIndex] = useState<number | null>(null);
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
     setMounted(true);
   }, []);
+
+  useEffect(() => {
+    if (editIndex !== null) {
+      setActiveEditIndex(editIndex);
+      return;
+    }
+
+    if (activeEditIndex === null) return;
+
+    const timeoutId = window.setTimeout(() => {
+      setActiveEditIndex(null);
+    }, 300);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [editIndex, activeEditIndex]);
 
   // 유효한 항목만 필터링 (종목 선택 + 수량 > 0)
   const getValidItems = (data: MultiTransactionFormData) => {
@@ -123,6 +142,7 @@ export function MultiTransactionForm({
       </div>
 
       {mounted &&
+        isDesktop &&
         createPortal(
           <AnimatePresence>
             {editIndex !== null && (
@@ -143,6 +163,29 @@ export function MultiTransactionForm({
           </AnimatePresence>,
           document.body,
         )}
+
+      {mounted && !isDesktop && (
+        <Drawer
+          open={editIndex !== null}
+          onOpenChange={(open) => {
+            if (!open) setEditIndex(null);
+          }}
+        >
+          {activeEditIndex !== null && (
+            <DrawerContent
+              className="h-[100dvh] max-h-[100dvh] rounded-none border-t-0 p-0 flex flex-col data-[vaul-drawer-direction=bottom]:mt-0 data-[vaul-drawer-direction=bottom]:max-h-[100dvh] data-[vaul-drawer-direction=bottom]:rounded-none data-[vaul-drawer-direction=bottom]:border-t-0"
+              showHandle={false}
+              onOpenAutoFocus={(event) => event.preventDefault()}
+            >
+              <StockComposerFormStep
+                key={activeEditIndex}
+                index={activeEditIndex}
+                onBack={() => setEditIndex(null)}
+              />
+            </DrawerContent>
+          )}
+        </Drawer>
+      )}
     </FormProvider>
   );
 }

--- a/components/transactions/StockComposerFormStep.tsx
+++ b/components/transactions/StockComposerFormStep.tsx
@@ -46,9 +46,7 @@ export function StockComposerFormStep({
 
       {/* Form Content */}
       <div className="flex-1 overflow-y-auto px-4 pt-16 pb-4 space-y-4">
-        <TransactionItemRow index={index} control={form.control} />
-
-        <div className="pt-2 space-y-3">
+        <div className="space-y-3">
           <div>
             <h3 className="text-sm font-semibold text-gray-900">
               거래일 및 계좌
@@ -80,6 +78,8 @@ export function StockComposerFormStep({
             </div>
           </div>
         </div>
+
+        <TransactionItemRow index={index} control={form.control} />
       </div>
 
       {/* Action Button */}

--- a/components/transactions/StockComposerListStep.tsx
+++ b/components/transactions/StockComposerListStep.tsx
@@ -97,7 +97,7 @@ export function StockComposerListStep({
             type="button"
             variant="outline"
             onClick={handleAddItem}
-            className="w-full sm:w-auto rounded-xl border-dashed h-11 px-6"
+            className="w-full rounded-xl border-dashed h-11 px-6"
           >
             <PlusIcon className="h-4 w-4 mr-2" />
             종목 추가

--- a/components/transactions/TransactionItemRow.tsx
+++ b/components/transactions/TransactionItemRow.tsx
@@ -104,7 +104,7 @@ export function TransactionItemRow<T extends FormWithItems>({
             type="number"
             inputMode="numeric"
             placeholder="0"
-            className="h-11 rounded-xl text-right text-sm"
+            className="h-11 rounded-xl text-sm"
             {...control.register(`items.${index}.quantity` as FieldPath<T>)}
           />
         </div>
@@ -116,7 +116,7 @@ export function TransactionItemRow<T extends FormWithItems>({
             type="number"
             inputMode="decimal"
             placeholder="0"
-            className="h-11 rounded-xl text-right text-sm"
+            className="h-11 rounded-xl text-sm"
             {...control.register(`items.${index}.price` as FieldPath<T>)}
           />
         </div>

--- a/components/ui/drawer.tsx
+++ b/components/ui/drawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import * as React from "react";
+import type * as React from "react";
 import { Drawer as DrawerPrimitive } from "vaul";
 
 import { cn } from "@/lib/utils/cn";
@@ -48,8 +48,11 @@ function DrawerOverlay({
 function DrawerContent({
   className,
   children,
+  showHandle = true,
   ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+}: React.ComponentProps<typeof DrawerPrimitive.Content> & {
+  showHandle?: boolean;
+}) {
   return (
     <DrawerPortal data-slot="drawer-portal">
       <DrawerOverlay />
@@ -65,7 +68,9 @@ function DrawerContent({
         )}
         {...props}
       >
-        <div className="mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full bg-muted group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        {showHandle && (
+          <div className="mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full bg-muted group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        )}
         {children}
       </DrawerPrimitive.Content>
     </DrawerPortal>


### PR DESCRIPTION
## Summary
- Align mobile picker sheets in the ledger and stock transaction add flows with the stock search bottom sheet style.
- Keep add/edit item forms full-screen on mobile while rendering category, payment source, account, and stock pickers as 85dvh sheets.
- Reorder date fields upward, adjust ledger amount/source layout, and remove right-aligned placeholders from numeric inputs.
- Preserve close animations by keeping drawer content mounted during mobile full-screen form close.

## Validation
- pnpm build
- pnpm test -- --run

Closes #329