### PR TITLE
feat: 주식 일자별 기록 캘린더 및 관련 컴포넌트 추가 (#294)

### DIFF
--- a/.claude/docs/CONVENTIONS_FE.md
+++ b/.claude/docs/CONVENTIONS_FE.md
@@ -144,9 +144,12 @@ app/(main)/
 │       │   └── page.tsx           # /assets/stock/analysis - 주식 분석
 │       ├── holdings/
 │       │   └── page.tsx           # /assets/stock/holdings - 주식 보유 현황
+│       ├── records/
+│       │   └── page.tsx           # /assets/stock/records - 주식 일별 기록
 │       └── transactions/
 │           ├── page.tsx           # /assets/stock/transactions - 주식 거래 내역
 │           └── new/
+│               ├── daily/page.tsx # /assets/stock/transactions/new/daily?date=YYYY-MM-DD
 │               ├── full/page.tsx  # /assets/stock/transactions/new/full
 │               └── account/page.tsx # /assets/stock/transactions/new/account
 └── settings/                      # /settings - 설정
@@ -184,6 +187,7 @@ assets/
     └── transactions/
         └── new/
             ├── full/             # /assets/stock/transactions/new/full
+            ├── daily/            # /assets/stock/transactions/new/daily?date=YYYY-MM-DD
             └── account/          # /assets/stock/transactions/new/account?accountId=...
 ```
 

--- a/app/(main)/assets/stock/records/page.tsx
+++ b/app/(main)/assets/stock/records/page.tsx
@@ -1,0 +1,24 @@
+import { StockRecordsClient } from "@/components/transactions/records/StockRecordsClient";
+import { normalizeRecordDate } from "@/lib/stock-records/records";
+import { requireUser } from "@/lib/supabase/auth";
+
+interface StockRecordsPageProps {
+  searchParams: Promise<{
+    date?: string;
+  }>;
+}
+
+export default async function StockRecordsPage({
+  searchParams,
+}: StockRecordsPageProps) {
+  const user = await requireUser();
+  const { date } = await searchParams;
+  const today = new Date().toISOString().split("T")[0];
+
+  return (
+    <StockRecordsClient
+      currentUserId={user.id}
+      initialDate={normalizeRecordDate(date, today)}
+    />
+  );
+}

--- a/app/(main)/assets/stock/transactions/new/daily/page.tsx
+++ b/app/(main)/assets/stock/transactions/new/daily/page.tsx
@@ -1,0 +1,37 @@
+import { Suspense } from "react";
+import { PageContainer } from "@/components/layout";
+import { MultiTransactionFormWrapper } from "@/components/transactions/MultiTransactionFormWrapper";
+import { normalizeRecordDate } from "@/lib/stock-records/records";
+
+interface NewDailyStockTransactionPageProps {
+  searchParams: Promise<{
+    date?: string;
+  }>;
+}
+
+export default async function NewDailyStockTransactionPage({
+  searchParams,
+}: NewDailyStockTransactionPageProps) {
+  const { date } = await searchParams;
+  const today = new Date().toISOString().split("T")[0];
+
+  return (
+    <PageContainer maxWidth="narrow">
+      <Suspense
+        fallback={
+          <div className="space-y-4">
+            <div className="h-14 animate-pulse rounded-2xl bg-gray-100" />
+            <div className="h-20 animate-pulse rounded-2xl bg-gray-100" />
+            <div className="h-20 animate-pulse rounded-2xl bg-gray-100" />
+            <div className="h-40 animate-pulse rounded-2xl bg-gray-100" />
+          </div>
+        }
+      >
+        <MultiTransactionFormWrapper
+          mode="daily"
+          defaultDate={normalizeRecordDate(date, today)}
+        />
+      </Suspense>
+    </PageContainer>
+  );
+}

--- a/app/(main)/ledger/records/page.tsx
+++ b/app/(main)/ledger/records/page.tsx
@@ -1,7 +1,19 @@
 import { LedgerRecordsClient } from "@/components/ledger/records/LedgerRecordsClient";
+import { normalizeRecordDate } from "@/lib/stock-records/records";
 import { requireUser } from "@/lib/supabase/auth";
 
-export default async function LedgerRecordsPage() {
+interface LedgerRecordsPageProps {
+  searchParams: Promise<{
+    date?: string;
+  }>;
+}
+
+export default async function LedgerRecordsPage({
+  searchParams,
+}: LedgerRecordsPageProps) {
   await requireUser();
-  return <LedgerRecordsClient />;
+  const { date } = await searchParams;
+  const today = new Date().toISOString().split("T")[0];
+
+  return <LedgerRecordsClient initialDate={normalizeRecordDate(date, today)} />;
 }

--- a/components/assets/stock/PortfolioNavSection.test.tsx
+++ b/components/assets/stock/PortfolioNavSection.test.tsx
@@ -26,4 +26,13 @@ describe("PortfolioNavSection", () => {
       "/assets/stock/analysis",
     );
   });
+
+  it("주식 일별 기록 진입점을 렌더링한다", () => {
+    render(<PortfolioNavSection />);
+
+    expect(screen.getByRole("link", { name: /일별 기록/ })).toHaveAttribute(
+      "href",
+      "/assets/stock/records",
+    );
+  });
 });

--- a/components/assets/stock/PortfolioNavSection.tsx
+++ b/components/assets/stock/PortfolioNavSection.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { BarChart3, ChartPie, Receipt, Settings, Wallet } from "lucide-react";
+import {
+  BarChart3,
+  CalendarDays,
+  ChartPie,
+  Receipt,
+  Settings,
+  Wallet,
+} from "lucide-react";
 import { AnalysisCard } from "@/components/dashboard/AnalysisCard";
 
 const navItems = [
@@ -19,6 +26,14 @@ const navItems = [
     href: "/assets/stock/transactions",
     color: "text-green-600",
     bgColor: "bg-green-50",
+  },
+  {
+    icon: CalendarDays,
+    label: "일별 기록",
+    description: "날짜별 매수·매도 기록을 확인해 보세요",
+    href: "/assets/stock/records",
+    color: "text-orange-600",
+    bgColor: "bg-orange-50",
   },
   {
     icon: ChartPie,

--- a/components/ledger/entry-composer/LedgerEntryComposer.tsx
+++ b/components/ledger/entry-composer/LedgerEntryComposer.tsx
@@ -128,7 +128,11 @@ export function LedgerEntryComposer({
       );
       const result = await createBatch.mutateAsync(entries);
       toast.success(`${result.count}건의 내역이 저장되었습니다.`);
-      router.push("/ledger/records");
+      router.push(
+        mode === "daily"
+          ? `/ledger/records?date=${values.defaultDate}`
+          : "/ledger/records",
+      );
     } catch (error) {
       toast.error(
         error instanceof Error ? error.message : "저장에 실패했습니다.",
@@ -145,7 +149,11 @@ export function LedgerEntryComposer({
         buildTransferLedgerEntryPayload(defaultIsShared, transferItem),
       );
       toast.success("1건의 내역이 저장되었습니다.");
-      router.push("/ledger/records");
+      router.push(
+        mode === "daily"
+          ? `/ledger/records?date=${transferItem.transactedAt}`
+          : "/ledger/records",
+      );
     } catch (error) {
       toast.error(
         error instanceof Error ? error.message : "저장에 실패했습니다.",

--- a/components/ledger/records/LedgerRecordsClient.tsx
+++ b/components/ledger/records/LedgerRecordsClient.tsx
@@ -4,6 +4,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { addMonths, format, getYear, startOfMonth, subMonths } from "date-fns";
 import { ChevronLeft, ChevronRight, Plus } from "lucide-react";
 import Link from "next/link";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useMemo, useState } from "react";
 import { LedgerEntryDeleteDialog } from "@/components/ledger/LedgerEntryDeleteDialog";
 import { LedgerEntryEditDialog } from "@/components/ledger/LedgerEntryEditDialog";
@@ -30,11 +31,23 @@ const CURRENT_YEAR = getYear(new Date());
 const YEAR_OPTIONS = Array.from({ length: 11 }, (_, i) => CURRENT_YEAR - 5 + i);
 const MONTH_OPTIONS = Array.from({ length: 12 }, (_, i) => i + 1);
 
-export function LedgerRecordsClient() {
-  const [currentMonth, setCurrentMonth] = useState<Date>(() =>
-    startOfMonth(new Date()),
+interface LedgerRecordsClientProps {
+  initialDate?: string;
+}
+
+export function LedgerRecordsClient({ initialDate }: LedgerRecordsClientProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const initial = useMemo(
+    () =>
+      new Date(`${initialDate ?? format(new Date(), "yyyy-MM-dd")}T00:00:00`),
+    [initialDate],
   );
-  const [selectedDate, setSelectedDate] = useState<Date>(new Date());
+  const [currentMonth, setCurrentMonth] = useState<Date>(() =>
+    startOfMonth(initial),
+  );
+  const [selectedDate, setSelectedDate] = useState<Date>(initial);
   const [selectedEntry, setSelectedEntry] =
     useState<LedgerEntryWithDetails | null>(null);
   const [editOpen, setEditOpen] = useState(false);
@@ -117,6 +130,9 @@ export function LedgerRecordsClient() {
 
   const handleDateSelect = (date: Date) => {
     setSelectedDate(date);
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("date", formatDateISO(date));
+    router.replace(`${pathname}?${params.toString()}`);
     // 선택된 날짜가 현재 표시 월과 다르면 월도 변경
     if (
       date.getFullYear() !== currentMonth.getFullYear() ||
@@ -237,7 +253,7 @@ export function LedgerRecordsClient() {
       </div>
 
       {/* md 이상: 캘린더(좌) + 목록(우) 2컬럼 / 모바일: 단일 컬럼 */}
-      <div className="md:grid md:grid-cols-[auto_1fr] md:gap-6 md:items-start">
+      <div className="grid gap-4 md:grid-cols-[auto_1fr] md:items-start md:gap-6">
         {/* 좌측: 요약 + 캘린더 */}
         <div className="md:w-[450px]">
           {summaryCard}

--- a/components/transactions/MultiTransactionForm.tsx
+++ b/components/transactions/MultiTransactionForm.tsx
@@ -20,11 +20,13 @@ import {
 import type { CreateBatchTransactionInput } from "@/schemas/transaction";
 
 interface MultiTransactionFormProps {
+  mode?: "full" | "daily";
   defaultDate: string;
   defaultAccountId: string;
 }
 
 export function MultiTransactionForm({
+  mode = "full",
   defaultDate,
   defaultAccountId,
 }: MultiTransactionFormProps) {
@@ -121,7 +123,11 @@ export function MultiTransactionForm({
       toast.success(
         `${validItems.length}건의 ${typeText} 거래가 등록되었습니다.`,
       );
-      router.push("/assets/stock/transactions");
+      router.push(
+        mode === "daily"
+          ? `/assets/stock/records?date=${data.transactedAt}`
+          : "/assets/stock/transactions",
+      );
     } catch (error) {
       if (error instanceof Error) {
         toast.error(error.message);
@@ -135,6 +141,7 @@ export function MultiTransactionForm({
     <FormProvider {...form}>
       <div className="w-full h-full">
         <StockComposerListStep
+          mode={mode}
           onEditItem={(index) => setEditIndex(index)}
           onSubmit={(data) => onSubmit(data)}
           isSubmitting={createBatchTransactions.isPending}
@@ -156,6 +163,7 @@ export function MultiTransactionForm({
                 <StockComposerFormStep
                   key={editIndex}
                   index={editIndex}
+                  mode={mode}
                   onBack={() => setEditIndex(null)}
                 />
               </motion.div>
@@ -180,6 +188,7 @@ export function MultiTransactionForm({
               <StockComposerFormStep
                 key={activeEditIndex}
                 index={activeEditIndex}
+                mode={mode}
                 onBack={() => setEditIndex(null)}
               />
             </DrawerContent>

--- a/components/transactions/MultiTransactionFormWrapper.tsx
+++ b/components/transactions/MultiTransactionFormWrapper.tsx
@@ -7,11 +7,13 @@ import { useCurrentUserId } from "@/hooks/use-current-user";
 interface MultiTransactionFormWrapperProps {
   defaultDate: string;
   defaultAccountId?: string;
+  mode?: "full" | "daily";
 }
 
 export function MultiTransactionFormWrapper({
   defaultDate,
   defaultAccountId,
+  mode = "full",
 }: MultiTransactionFormWrapperProps) {
   const { userId: currentUserId, isLoading: isLoadingCurrentUser } =
     useCurrentUserId();
@@ -41,6 +43,7 @@ export function MultiTransactionFormWrapper({
 
   return (
     <MultiTransactionForm
+      mode={mode}
       defaultDate={defaultDate}
       defaultAccountId={selectedDefaultAccountId}
     />

--- a/components/transactions/StockComposerFormStep.test.tsx
+++ b/components/transactions/StockComposerFormStep.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import { FormProvider, useForm } from "react-hook-form";
+import { describe, expect, it, vi } from "vitest";
+import type { MultiTransactionFormData } from "@/schemas/multi-transaction-form";
+import { StockComposerFormStep } from "./StockComposerFormStep";
+
+vi.mock("@/components/transactions/AccountSelector", () => ({
+  AccountSelector: () => <div>계좌 선택</div>,
+}));
+
+vi.mock("@/components/transactions/TransactionItemRow", () => ({
+  TransactionItemRow: () => <div>종목 입력</div>,
+}));
+
+function renderStep(mode: "full" | "daily") {
+  function Wrapper() {
+    const form = useForm<MultiTransactionFormData>({
+      defaultValues: {
+        type: "buy",
+        transactedAt: "2026-05-31",
+        accountId: "account-1",
+        items: [
+          {
+            stock: undefined,
+            quantity: "",
+            price: "",
+            memo: "",
+            transactedAt: "2026-05-31",
+            accountId: "account-1",
+          },
+        ],
+      },
+    });
+
+    return (
+      <FormProvider {...form}>
+        <StockComposerFormStep index={0} mode={mode} onBack={vi.fn()} />
+      </FormProvider>
+    );
+  }
+
+  render(<Wrapper />);
+}
+
+describe("StockComposerFormStep", () => {
+  it("hides transaction date input in daily mode", () => {
+    renderStep("daily");
+
+    expect(screen.queryByText("거래일")).not.toBeInTheDocument();
+    expect(screen.getByText("계좌 선택")).toBeInTheDocument();
+  });
+});

--- a/components/transactions/StockComposerFormStep.tsx
+++ b/components/transactions/StockComposerFormStep.tsx
@@ -12,11 +12,13 @@ import type { MultiTransactionFormData } from "@/schemas/multi-transaction-form"
 
 interface StockComposerFormStepProps {
   index: number;
+  mode?: "full" | "daily";
   onBack: () => void;
 }
 
 export function StockComposerFormStep({
   index,
+  mode = "full",
   onBack,
 }: StockComposerFormStepProps) {
   const form = useFormContext<MultiTransactionFormData>();
@@ -57,16 +59,18 @@ export function StockComposerFormStep({
           </div>
 
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-            <div className="space-y-2">
-              <Label className="text-sm text-gray-700">거래일</Label>
-              <DatePickerInput
-                value={form.watch(`items.${index}.transactedAt`) ?? ""}
-                onChange={(v) =>
-                  form.setValue(`items.${index}.transactedAt`, v || "")
-                }
-                className="h-11 rounded-xl w-full"
-              />
-            </div>
+            {mode === "full" && (
+              <div className="space-y-2">
+                <Label className="text-sm text-gray-700">거래일</Label>
+                <DatePickerInput
+                  value={form.watch(`items.${index}.transactedAt`) ?? ""}
+                  onChange={(v) =>
+                    form.setValue(`items.${index}.transactedAt`, v || "")
+                  }
+                  className="h-11 rounded-xl w-full"
+                />
+              </div>
+            )}
 
             <div className="space-y-2">
               <AccountSelector

--- a/components/transactions/StockComposerListStep.tsx
+++ b/components/transactions/StockComposerListStep.tsx
@@ -20,12 +20,14 @@ import type { MultiTransactionFormData } from "@/schemas/multi-transaction-form"
 import { DEFAULT_TRANSACTION_ITEM } from "@/schemas/multi-transaction-form";
 
 interface StockComposerListStepProps {
+  mode?: "full" | "daily";
   onEditItem: (index: number) => void;
   onSubmit: (data: MultiTransactionFormData) => void;
   isSubmitting: boolean;
 }
 
 export function StockComposerListStep({
+  mode = "full",
   onEditItem,
   onSubmit,
   isSubmitting,
@@ -73,7 +75,9 @@ export function StockComposerListStep({
 
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           <div className="space-y-2">
-            <Label className="text-gray-700">거래일</Label>
+            <Label className="text-gray-700">
+              {mode === "daily" ? "선택한 날짜" : "거래일"}
+            </Label>
             <DatePickerInput
               value={watchTransactedAt ?? ""}
               onChange={(v) =>

--- a/components/transactions/TransactionTable.test.tsx
+++ b/components/transactions/TransactionTable.test.tsx
@@ -24,6 +24,7 @@ const transactions: TransactionWithDetails[] = [
     transactedAt: "2026-05-03T09:00:00.000Z",
     memo: null,
     accountId: "account-1",
+    accountName: "삼성증권",
     owner: {
       id: "user-1",
       name: "진호",
@@ -41,6 +42,7 @@ const transactions: TransactionWithDetails[] = [
     transactedAt: "2026-05-03T13:00:00.000Z",
     memo: "리밸런싱",
     accountId: "account-2",
+    accountName: "토스증권",
     owner: {
       id: "user-2",
       name: "배우자",
@@ -58,6 +60,7 @@ const transactions: TransactionWithDetails[] = [
     transactedAt: "2026-05-01T09:00:00.000Z",
     memo: null,
     accountId: "account-1",
+    accountName: "삼성증권",
     owner: {
       id: "user-1",
       name: "진호",

--- a/components/transactions/records/StockRecordDayList.test.tsx
+++ b/components/transactions/records/StockRecordDayList.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { TransactionWithDetails } from "@/lib/api/transaction";
+import { StockRecordDayList } from "./StockRecordDayList";
+
+vi.mock("@/components/transactions/TransactionEditDialog", () => ({
+  TransactionEditDialog: () => null,
+}));
+
+vi.mock("@/components/transactions/TransactionDeleteDialog", () => ({
+  TransactionDeleteDialog: () => null,
+}));
+
+const transaction: TransactionWithDetails = {
+  id: "tx-1",
+  ticker: "LONG",
+  stockName: "아주아주아주아주아주아주아주긴종목명테스트주식회사",
+  type: "buy",
+  quantity: 12,
+  price: 34_500,
+  totalAmount: 414_000,
+  currency: "KRW",
+  transactedAt: "2026-05-31T09:00:00.000Z",
+  memo: "목록에서는 보이면 안 되는 메모",
+  accountId: "account-1",
+  accountName: "삼성증권",
+  owner: { id: "user-1", name: "진호" },
+};
+
+describe("StockRecordDayList", () => {
+  it("renders selected-date stock transactions without memo content", () => {
+    render(
+      <StockRecordDayList
+        selectedDate="2026-05-31"
+        transactions={[transaction]}
+        currentUserId="user-1"
+      />,
+    );
+
+    expect(screen.getByText("2026년 5월 31일")).toBeInTheDocument();
+    expect(screen.getByText("매수")).toBeInTheDocument();
+    expect(screen.getByText("LONG")).toBeInTheDocument();
+    expect(screen.getByText("12주")).toBeInTheDocument();
+    expect(screen.getByText("₩34,500")).toBeInTheDocument();
+    expect(screen.getByText("삼성증권")).toBeInTheDocument();
+    expect(
+      screen.queryByText("목록에서는 보이면 안 되는 메모"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps long stock names truncatable", () => {
+    render(
+      <StockRecordDayList
+        selectedDate="2026-05-31"
+        transactions={[transaction]}
+        currentUserId="user-1"
+      />,
+    );
+
+    expect(screen.getByText(transaction.stockName)).toHaveClass("truncate");
+  });
+});

--- a/components/transactions/records/StockRecordDayList.tsx
+++ b/components/transactions/records/StockRecordDayList.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import {
+  CalendarDays,
+  MoreHorizontal,
+  Pencil,
+  Trash2,
+  TrendingDown,
+  TrendingUp,
+  Wallet,
+} from "lucide-react";
+import { useState } from "react";
+import { TransactionDeleteDialog } from "@/components/transactions/TransactionDeleteDialog";
+import { TransactionEditDialog } from "@/components/transactions/TransactionEditDialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import type { TransactionWithDetails } from "@/lib/api/transaction";
+import { cn } from "@/lib/utils/cn";
+import { formatCurrency, formatDate } from "@/lib/utils/format";
+
+interface StockRecordDayListProps {
+  selectedDate: string;
+  transactions: TransactionWithDetails[];
+  currentUserId: string;
+}
+
+export function StockRecordDayList({
+  selectedDate,
+  transactions,
+  currentUserId,
+}: StockRecordDayListProps) {
+  const [editTransaction, setEditTransaction] =
+    useState<TransactionWithDetails | null>(null);
+  const [deleteTransaction, setDeleteTransaction] =
+    useState<TransactionWithDetails | null>(null);
+
+  return (
+    <>
+      <section className="overflow-hidden rounded-2xl bg-white shadow-sm ring-1 ring-gray-100">
+        <div className="flex items-center justify-between gap-3 bg-gray-50/70 px-4 py-3 sm:px-5">
+          <div className="flex min-w-0 items-center gap-2">
+            <CalendarDays className="size-4 shrink-0 text-gray-400" />
+            <h3 className="truncate font-semibold text-gray-900 text-sm">
+              {formatDate(selectedDate)}
+            </h3>
+          </div>
+          <Badge variant="outline">{transactions.length}건</Badge>
+        </div>
+
+        {transactions.length > 0 ? (
+          <div>
+            {transactions.map((transaction) => {
+              const isBuy = transaction.type === "buy";
+              const isOwner = transaction.owner.id === currentUserId;
+              const typeLabel = isBuy ? "매수" : "매도";
+
+              return (
+                <article
+                  key={transaction.id}
+                  className="flex min-h-[92px] items-center gap-3 border-gray-100 border-t px-4 py-4 first:border-t-0 sm:px-5"
+                >
+                  <div
+                    className={cn(
+                      "flex size-10 shrink-0 items-center justify-center rounded-full",
+                      isBuy
+                        ? "bg-red-50 text-red-500"
+                        : "bg-blue-50 text-blue-500",
+                    )}
+                    aria-hidden="true"
+                  >
+                    {isBuy ? (
+                      <TrendingUp className="size-5" />
+                    ) : (
+                      <TrendingDown className="size-5" />
+                    )}
+                  </div>
+
+                  <div className="min-w-0 flex-1">
+                    <div className="flex min-w-0 items-center gap-2">
+                      <p className="truncate font-semibold text-gray-900">
+                        {transaction.stockName}
+                      </p>
+                      <Badge
+                        variant={isBuy ? "default" : "secondary"}
+                        className="shrink-0"
+                      >
+                        {typeLabel}
+                      </Badge>
+                      <span className="shrink-0 text-gray-400 text-xs">
+                        {transaction.ticker}
+                      </span>
+                    </div>
+                    <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-gray-500 text-xs">
+                      <span>{transaction.quantity.toLocaleString()}주</span>
+                      <span>
+                        {formatCurrency(
+                          transaction.price,
+                          transaction.currency,
+                        )}
+                      </span>
+                      <span className="inline-flex min-w-0 items-center gap-1">
+                        <Wallet className="size-3 shrink-0" />
+                        <span className="truncate">
+                          {transaction.accountName ?? "계좌 없음"}
+                        </span>
+                      </span>
+                    </div>
+                  </div>
+
+                  {isOwner && (
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="size-9 shrink-0"
+                        >
+                          <MoreHorizontal className="size-4" />
+                          <span className="sr-only">메뉴 열기</span>
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem
+                          onClick={() => setEditTransaction(transaction)}
+                        >
+                          <Pencil className="mr-2 size-4" />
+                          수정
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          onClick={() => setDeleteTransaction(transaction)}
+                          className="text-destructive focus:text-destructive"
+                        >
+                          <Trash2 className="mr-2 size-4" />
+                          삭제
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  )}
+                </article>
+              );
+            })}
+          </div>
+        ) : (
+          <div className="px-6 py-12 text-center">
+            <p className="font-medium text-gray-700">
+              선택한 날짜의 거래가 없습니다.
+            </p>
+            <p className="mt-1 text-gray-400 text-sm">
+              날짜를 바꾸거나 새 거래를 추가해보세요.
+            </p>
+          </div>
+        )}
+      </section>
+
+      <TransactionEditDialog
+        transaction={editTransaction}
+        open={!!editTransaction}
+        onOpenChange={(open) => !open && setEditTransaction(null)}
+      />
+      <TransactionDeleteDialog
+        transaction={deleteTransaction}
+        open={!!deleteTransaction}
+        onOpenChange={(open) => !open && setDeleteTransaction(null)}
+      />
+    </>
+  );
+}

--- a/components/transactions/records/StockRecordsCalendar.tsx
+++ b/components/transactions/records/StockRecordsCalendar.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { RefreshCw } from "lucide-react";
+import { type ComponentProps, useCallback } from "react";
+import type { DayButton } from "react-day-picker";
+import { Button } from "@/components/ui/button";
+import { Calendar, CalendarDayButton } from "@/components/ui/calendar";
+import type { StockRecordDailySummary } from "@/lib/stock-records/records";
+
+interface StockRecordsCalendarProps {
+  currentMonth: Date;
+  onMonthChange: (month: Date) => void;
+  selectedDate: Date;
+  onDateSelect: (date: Date) => void;
+  summariesByDate: Map<string, StockRecordDailySummary>;
+  onRefresh: () => void;
+}
+
+function formatDateKey(date: Date) {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+}
+
+export function StockRecordsCalendar({
+  currentMonth,
+  onMonthChange,
+  selectedDate,
+  onDateSelect,
+  summariesByDate,
+  onRefresh,
+}: StockRecordsCalendarProps) {
+  const DayButtonWithCounts = useCallback(
+    function DayButtonWithCounts({
+      day,
+      modifiers,
+      children,
+      ...props
+    }: ComponentProps<typeof DayButton>) {
+      const summary = summariesByDate.get(formatDateKey(day.date));
+      const isSelected =
+        modifiers.selected &&
+        !modifiers.range_start &&
+        !modifiers.range_end &&
+        !modifiers.range_middle;
+
+      return (
+        <CalendarDayButton
+          day={day}
+          modifiers={modifiers}
+          {...props}
+          className="flex-col gap-0 py-1 data-[selected-single=true]:!bg-transparent data-[selected-single=true]:!text-inherit hover:!bg-transparent"
+        >
+          <span
+            className={`flex h-8 w-8 items-center justify-center rounded-full text-sm font-medium transition-colors ${
+              isSelected
+                ? "bg-gray-800 text-white"
+                : modifiers.today
+                  ? "bg-gray-100 text-gray-900"
+                  : "text-gray-900"
+            }`}
+          >
+            {children}
+          </span>
+
+          <span className="flex min-h-[22px] flex-col items-center justify-start gap-0.5 pt-0.5">
+            {summary && summary.buy > 0 && (
+              <span className="text-[9px] font-medium text-red-500 leading-none">
+                매수 {summary.buy}건
+              </span>
+            )}
+            {summary && summary.sell > 0 && (
+              <span className="text-[9px] text-blue-500 leading-none">
+                매도 {summary.sell}건
+              </span>
+            )}
+          </span>
+        </CalendarDayButton>
+      );
+    },
+    [summariesByDate],
+  );
+
+  return (
+    <div className="relative overflow-hidden rounded-2xl bg-white">
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={onRefresh}
+        className="absolute top-5 right-6 z-10 h-7 w-7 text-gray-400 hover:text-gray-600"
+        title="새로고침"
+      >
+        <RefreshCw className="h-3.5 w-3.5" />
+      </Button>
+      <Calendar
+        mode="single"
+        month={currentMonth}
+        onMonthChange={onMonthChange}
+        selected={selectedDate}
+        onSelect={(date) => date && onDateSelect(date)}
+        hideNavigation
+        components={{ DayButton: DayButtonWithCounts }}
+        className="w-full"
+        classNames={{
+          day: "group/day relative w-full p-0 text-center select-none [&:last-child[data-selected=true]_button]:rounded-r-md [&:first-child[data-selected=true]_button]:rounded-l-md",
+        }}
+      />
+    </div>
+  );
+}

--- a/components/transactions/records/StockRecordsClient.test.tsx
+++ b/components/transactions/records/StockRecordsClient.test.tsx
@@ -1,0 +1,112 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useTransactions } from "@/hooks/use-transaction";
+import type { TransactionWithDetails } from "@/lib/api/transaction";
+import { StockRecordsClient } from "./StockRecordsClient";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/assets/stock/records",
+  useRouter: () => ({ replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams("date=2026-05-31"),
+}));
+
+vi.mock("@/hooks/use-transaction", () => ({
+  useTransactions: vi.fn(),
+}));
+
+vi.mock("@/components/transactions/TransactionEditDialog", () => ({
+  TransactionEditDialog: () => null,
+}));
+
+vi.mock("@/components/transactions/TransactionDeleteDialog", () => ({
+  TransactionDeleteDialog: () => null,
+}));
+
+const transactions: TransactionWithDetails[] = [
+  {
+    id: "tx-1",
+    ticker: "005930",
+    stockName: "삼성전자",
+    type: "buy",
+    quantity: 10,
+    price: 70_000,
+    totalAmount: 700_000,
+    currency: "KRW",
+    transactedAt: "2026-05-31T09:00:00.000Z",
+    memo: null,
+    accountId: "account-1",
+    accountName: "삼성증권",
+    owner: { id: "user-1", name: "진호" },
+  },
+  {
+    id: "tx-2",
+    ticker: "AAPL",
+    stockName: "Apple",
+    type: "sell",
+    quantity: 2,
+    price: 190,
+    totalAmount: 380,
+    currency: "USD",
+    transactedAt: "2026-05-31T13:00:00.000Z",
+    memo: null,
+    accountId: "account-2",
+    accountName: "토스증권",
+    owner: { id: "user-1", name: "진호" },
+  },
+];
+
+describe("StockRecordsClient", () => {
+  it("restores selected date, shows count summary, and links daily entry with date", () => {
+    vi.mocked(useTransactions)
+      .mockReturnValueOnce({
+        data: {
+          data: [],
+          total: 0,
+          page: 1,
+          pageSize: 500,
+          totalPages: 1,
+        },
+        isLoading: false,
+      } as ReturnType<typeof useTransactions>)
+      .mockReturnValueOnce({
+        data: {
+          data: transactions,
+          total: 2,
+          page: 1,
+          pageSize: 500,
+          totalPages: 1,
+        },
+        isLoading: false,
+      } as ReturnType<typeof useTransactions>)
+      .mockReturnValueOnce({
+        data: {
+          data: [],
+          total: 0,
+          page: 1,
+          pageSize: 500,
+          totalPages: 1,
+        },
+        isLoading: false,
+      } as ReturnType<typeof useTransactions>);
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <StockRecordsClient currentUserId="user-1" initialDate="2026-05-31" />
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByText("매수 1건")).toBeInTheDocument();
+    expect(screen.getByText("매도 1건")).toBeInTheDocument();
+    expect(screen.getByText("삼성전자")).toBeInTheDocument();
+    expect(screen.getByText("Apple")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /거래 등록/ })).toHaveAttribute(
+      "href",
+      "/assets/stock/transactions/new/daily?date=2026-05-31",
+    );
+  });
+});

--- a/components/transactions/records/StockRecordsClient.tsx
+++ b/components/transactions/records/StockRecordsClient.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+import { addMonths, format, getYear, startOfMonth, subMonths } from "date-fns";
+import { ChevronLeft, ChevronRight, Plus } from "lucide-react";
+import Link from "next/link";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useTransactions } from "@/hooks/use-transaction";
+import { queries } from "@/lib/queries/keys";
+import {
+  buildStockRecordDailySummaries,
+  getTransactionsForRecordDate,
+} from "@/lib/stock-records/records";
+import { formatDateISO } from "@/lib/utils/format";
+import { StockRecordDayList } from "./StockRecordDayList";
+import { StockRecordsCalendar } from "./StockRecordsCalendar";
+
+const CURRENT_YEAR = getYear(new Date());
+const YEAR_OPTIONS = Array.from({ length: 11 }, (_, i) => CURRENT_YEAR - 5 + i);
+const MONTH_OPTIONS = Array.from({ length: 12 }, (_, i) => i + 1);
+
+interface StockRecordsClientProps {
+  currentUserId: string;
+  initialDate: string;
+}
+
+function getMonthFilters(month: Date) {
+  const start = startOfMonth(month);
+  const end = new Date(start.getFullYear(), start.getMonth() + 1, 0);
+
+  return {
+    startDate: `${formatDateISO(start)}T00:00:00.000Z`,
+    endDate: `${formatDateISO(end)}T23:59:59.999Z`,
+  };
+}
+
+export function StockRecordsClient({
+  currentUserId,
+  initialDate,
+}: StockRecordsClientProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const queryClient = useQueryClient();
+
+  const initial = useMemo(
+    () => new Date(`${initialDate}T00:00:00`),
+    [initialDate],
+  );
+  const [currentMonth, setCurrentMonth] = useState<Date>(() =>
+    startOfMonth(initial),
+  );
+  const [selectedDate, setSelectedDate] = useState<Date>(initial);
+
+  const prevMonth = useMemo(() => subMonths(currentMonth, 1), [currentMonth]);
+  const nextMonth = useMemo(() => addMonths(currentMonth, 1), [currentMonth]);
+
+  const { data: prevTransactions } = useTransactions({
+    filters: getMonthFilters(prevMonth),
+    page: 1,
+    pageSize: 500,
+  });
+  const { data: currentTransactions, isLoading } = useTransactions({
+    filters: getMonthFilters(currentMonth),
+    page: 1,
+    pageSize: 500,
+  });
+  const { data: nextTransactions } = useTransactions({
+    filters: getMonthFilters(nextMonth),
+    page: 1,
+    pageSize: 500,
+  });
+
+  const transactions = useMemo(
+    () => [
+      ...(prevTransactions?.data ?? []),
+      ...(currentTransactions?.data ?? []),
+      ...(nextTransactions?.data ?? []),
+    ],
+    [prevTransactions, currentTransactions, nextTransactions],
+  );
+
+  const selectedDateKey = formatDateISO(selectedDate);
+  const summariesByDate = useMemo(
+    () => buildStockRecordDailySummaries(transactions),
+    [transactions],
+  );
+  const dayTransactions = useMemo(
+    () => getTransactionsForRecordDate(transactions, selectedDateKey),
+    [transactions, selectedDateKey],
+  );
+
+  const updateSelectedDateParam = (date: Date) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("date", formatDateISO(date));
+    router.replace(`${pathname}?${params.toString()}`);
+  };
+
+  const handleDateSelect = (date: Date) => {
+    setSelectedDate(date);
+    updateSelectedDateParam(date);
+    if (
+      date.getFullYear() !== currentMonth.getFullYear() ||
+      date.getMonth() !== currentMonth.getMonth()
+    ) {
+      setCurrentMonth(startOfMonth(date));
+    }
+  };
+
+  const goToPrevMonth = () =>
+    setCurrentMonth((month) => startOfMonth(subMonths(month, 1)));
+  const goToNextMonth = () =>
+    setCurrentMonth((month) => startOfMonth(addMonths(month, 1)));
+
+  const handleMonthChange = (month: Date) =>
+    setCurrentMonth(startOfMonth(month));
+
+  const handleYearChange = (year: string) => {
+    setCurrentMonth((month) => {
+      const next = new Date(month);
+      next.setFullYear(Number(year));
+      return startOfMonth(next);
+    });
+  };
+
+  const handleMonthSelect = (month: string) => {
+    setCurrentMonth((value) => {
+      const next = new Date(value);
+      next.setMonth(Number(month) - 1);
+      return startOfMonth(next);
+    });
+  };
+
+  const handleRefresh = () => {
+    queryClient.invalidateQueries({ queryKey: queries.transactions._def });
+  };
+
+  return (
+    <div className="pb-6">
+      <div className="mb-4 flex items-center justify-between">
+        <Button variant="ghost" size="icon" onClick={goToPrevMonth}>
+          <ChevronLeft className="h-5 w-5" />
+        </Button>
+        <div className="flex items-center gap-1">
+          <Select
+            value={String(currentMonth.getFullYear())}
+            onValueChange={handleYearChange}
+          >
+            <SelectTrigger className="h-auto w-auto gap-0.5 rounded-lg border-none px-1.5 py-0.5 font-semibold text-gray-900 text-lg shadow-none transition-colors hover:bg-gray-100 focus:ring-0">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {YEAR_OPTIONS.map((year) => (
+                <SelectItem key={year} value={String(year)}>
+                  {year}년
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select
+            value={String(currentMonth.getMonth() + 1)}
+            onValueChange={handleMonthSelect}
+          >
+            <SelectTrigger className="h-auto w-auto gap-0.5 rounded-lg border-none px-1.5 py-0.5 font-semibold text-gray-900 text-lg shadow-none transition-colors hover:bg-gray-100 focus:ring-0">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {MONTH_OPTIONS.map((month) => (
+                <SelectItem key={month} value={String(month)}>
+                  {month}월
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <Button variant="ghost" size="icon" onClick={goToNextMonth}>
+          <ChevronRight className="h-5 w-5" />
+        </Button>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-[auto_1fr] md:items-start md:gap-6">
+        <div className="md:w-[450px]">
+          {isLoading ? (
+            <Skeleton className="h-72 rounded-2xl" />
+          ) : (
+            <StockRecordsCalendar
+              currentMonth={currentMonth}
+              onMonthChange={handleMonthChange}
+              selectedDate={selectedDate}
+              onDateSelect={handleDateSelect}
+              summariesByDate={summariesByDate}
+              onRefresh={handleRefresh}
+            />
+          )}
+        </div>
+
+        <div className="flex flex-col gap-4">
+          <StockRecordDayList
+            selectedDate={selectedDateKey}
+            transactions={dayTransactions}
+            currentUserId={currentUserId}
+          />
+          <Button asChild className="w-full" size="icon-sm">
+            <Link
+              href={`/assets/stock/transactions/new/daily?date=${format(selectedDate, "yyyy-MM-dd")}`}
+            >
+              <Plus className="h-5 w-5" />
+              거래 등록
+            </Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/constants/service-routes.test.ts
+++ b/constants/service-routes.test.ts
@@ -50,6 +50,13 @@ describe("getServiceRouteMeta", () => {
     });
   });
 
+  it("가계부 기록 조회 route는 선택 날짜 query를 보존한다", () => {
+    expect(getServiceRouteMeta("/ledger/records")).toMatchObject({
+      label: "기록 조회",
+      preserveSearchParams: ["date"],
+    });
+  });
+
   it("주식 거래 Entry Composer route를 task 화면으로 계산한다", () => {
     expect(
       getServiceRouteMeta("/assets/stock/transactions/new/full"),
@@ -69,6 +76,33 @@ describe("getServiceRouteMeta", () => {
       mobileVariant: "task",
       parentHref: "/assets/stock/transactions",
       closeHref: "/assets/stock/transactions",
+    });
+
+    expect(
+      getServiceRouteMeta(
+        "/assets/stock/transactions/new/daily?date=2026-05-29",
+      ),
+    ).toMatchObject({
+      label: "하루 거래 등록",
+      mobileVariant: "task",
+      parentHref: "/assets/stock/records",
+      closeHref: "/assets/stock/records",
+    });
+  });
+
+  it("주식 일별 기록 route를 계산하고 선택 날짜 query를 보존한다", () => {
+    expect(
+      getServiceRouteMeta("/assets/stock/records?date=2026-05-29"),
+    ).toMatchObject({
+      label: "일별 기록",
+      mobileVariant: "child",
+      parentHref: "/assets/stock",
+      preserveSearchParams: ["date"],
+      breadcrumb: [
+        { href: "/assets", label: "자산" },
+        { href: "/assets/stock", label: "주식" },
+        { href: "/assets/stock/records", label: "일별 기록" },
+      ],
     });
   });
 

--- a/constants/service-routes.ts
+++ b/constants/service-routes.ts
@@ -46,6 +46,7 @@ export const SERVICE_ROUTE_TREE = [
       {
         href: "/ledger/records",
         label: "기록 조회",
+        preserveSearchParams: ["date"],
         children: [
           {
             href: "/ledger/records/new/daily",
@@ -137,6 +138,19 @@ export const SERVICE_ROUTE_TREE = [
         label: "주식",
         children: [
           { href: "/assets/stock/holdings", label: "보유 종목" },
+          {
+            href: "/assets/stock/records",
+            label: "일별 기록",
+            preserveSearchParams: ["date"],
+            children: [
+              {
+                href: "/assets/stock/transactions/new/daily",
+                label: "하루 거래 등록",
+                mobile: "task",
+                closeHref: "/assets/stock/records",
+              },
+            ],
+          },
           {
             href: "/assets/stock/transactions",
             label: "거래 내역",

--- a/lib/api/transaction.test.ts
+++ b/lib/api/transaction.test.ts
@@ -2,24 +2,50 @@ import { describe, expect, it, vi } from "vitest";
 import { getTransactions } from "./transaction";
 
 function createTransactionsSupabaseMock() {
+  const transactionRows = [
+    {
+      id: "tx-1",
+      ticker: "005930",
+      type: "buy",
+      quantity: 10,
+      price: 70000,
+      transacted_at: "2026-05-31T09:00:00.000Z",
+      memo: null,
+      account_id: "account-1",
+      owner_id: "user-1",
+      profiles: { id: "user-1", name: "진호" },
+    },
+  ];
   const transactionsBuilder = {
     select: vi.fn().mockReturnThis(),
     eq: vi.fn().mockReturnThis(),
     gte: vi.fn().mockReturnThis(),
     lte: vi.fn().mockReturnThis(),
     order: vi.fn().mockReturnThis(),
-    range: vi.fn().mockResolvedValue({ data: [], error: null, count: 0 }),
+    range: vi
+      .fn()
+      .mockResolvedValue({ data: transactionRows, error: null, count: 1 }),
   };
   const settingsBuilder = {
     select: vi.fn().mockReturnThis(),
     eq: vi.fn().mockReturnThis(),
-    in: vi.fn().mockResolvedValue({ data: [] }),
+    in: vi.fn().mockResolvedValue({
+      data: [{ ticker: "005930", name: "삼성전자", currency: "KRW" }],
+    }),
+  };
+  const accountsBuilder = {
+    select: vi.fn().mockReturnThis(),
+    in: vi
+      .fn()
+      .mockResolvedValue({ data: [{ id: "account-1", name: "삼성증권" }] }),
   };
 
   return {
-    from: vi.fn((table: string) =>
-      table === "transactions" ? transactionsBuilder : settingsBuilder,
-    ),
+    from: vi.fn((table: string) => {
+      if (table === "transactions") return transactionsBuilder;
+      if (table === "accounts") return accountsBuilder;
+      return settingsBuilder;
+    }),
     transactionsBuilder,
   };
 }
@@ -37,5 +63,15 @@ describe("getTransactions", () => {
       "account_id",
       "account-1",
     );
+  });
+
+  it("maps account name for transaction records", async () => {
+    const supabase = createTransactionsSupabaseMock();
+
+    const result = await getTransactions(supabase as never, "household-1", {
+      pagination: { page: 1, pageSize: 20 },
+    });
+
+    expect(result.data[0].accountName).toBe("삼성증권");
   });
 });

--- a/lib/api/transaction.ts
+++ b/lib/api/transaction.ts
@@ -163,6 +163,7 @@ export interface TransactionWithDetails {
   transactedAt: string;
   memo: string | null;
   accountId: string | null;
+  accountName: string | null;
   owner: {
     id: string;
     name: string;
@@ -282,6 +283,10 @@ export async function getTransactions(
     string,
     { name: string; currency: CurrencyType }
   >();
+  const accountIds = [
+    ...new Set((data ?? []).map((t) => t.account_id).filter(Boolean)),
+  ];
+  const accountMap = new Map<string, string>();
 
   if (tickers.length > 0) {
     const { data: stockSettings } = await supabase
@@ -292,6 +297,17 @@ export async function getTransactions(
 
     for (const s of stockSettings ?? []) {
       stockSettingsMap.set(s.ticker, { name: s.name, currency: s.currency });
+    }
+  }
+
+  if (accountIds.length > 0) {
+    const { data: accounts } = await supabase
+      .from("accounts")
+      .select("id, name")
+      .in("id", accountIds);
+
+    for (const account of accounts ?? []) {
+      accountMap.set(account.id, account.name);
     }
   }
 
@@ -312,6 +328,7 @@ export async function getTransactions(
       transactedAt: t.transacted_at,
       memo: t.memo,
       accountId: t.account_id,
+      accountName: t.account_id ? (accountMap.get(t.account_id) ?? null) : null,
       owner: {
         id: profile?.id ?? t.owner_id,
         name: profile?.name ?? "알 수 없음",

--- a/lib/stock-records/records.test.ts
+++ b/lib/stock-records/records.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import type { TransactionWithDetails } from "@/lib/api/transaction";
+import {
+  buildStockRecordDailySummaries,
+  getTransactionsForRecordDate,
+  normalizeRecordDate,
+} from "./records";
+
+function transaction(
+  id: string,
+  type: "buy" | "sell",
+  transactedAt: string,
+): TransactionWithDetails {
+  return {
+    id,
+    ticker: "005930",
+    stockName: "삼성전자",
+    type,
+    quantity: 1,
+    price: 70_000,
+    totalAmount: 70_000,
+    currency: "KRW",
+    transactedAt,
+    memo: null,
+    accountId: "account-1",
+    accountName: "삼성증권",
+    owner: { id: "user-1", name: "진호" },
+  };
+}
+
+describe("stock records", () => {
+  it("summarizes stock transactions by buy/sell count per date", () => {
+    const summaries = buildStockRecordDailySummaries([
+      transaction("tx-1", "buy", "2026-05-31T09:00:00.000Z"),
+      transaction("tx-2", "buy", "2026-05-31T10:00:00.000Z"),
+      transaction("tx-3", "sell", "2026-05-31T11:00:00.000Z"),
+      transaction("tx-4", "sell", "2026-05-30T09:00:00.000Z"),
+    ]);
+
+    expect(summaries.get("2026-05-31")).toEqual({ buy: 2, sell: 1 });
+    expect(summaries.get("2026-05-30")).toEqual({ buy: 0, sell: 1 });
+  });
+
+  it("returns only transactions for the selected record date", () => {
+    const selected = getTransactionsForRecordDate(
+      [
+        transaction("tx-1", "buy", "2026-05-31T09:00:00.000Z"),
+        transaction("tx-2", "sell", "2026-06-01T09:00:00.000Z"),
+      ],
+      "2026-05-31",
+    );
+
+    expect(selected.map((item) => item.id)).toEqual(["tx-1"]);
+  });
+
+  it("normalizes invalid record date params to today's date", () => {
+    expect(normalizeRecordDate("2026-05-31", "2026-06-01")).toBe("2026-05-31");
+    expect(normalizeRecordDate("not-a-date", "2026-06-01")).toBe("2026-06-01");
+  });
+});

--- a/lib/stock-records/records.ts
+++ b/lib/stock-records/records.ts
@@ -1,0 +1,40 @@
+import type { TransactionWithDetails } from "@/lib/api/transaction";
+import { formatDateISO } from "@/lib/utils/format";
+
+export interface StockRecordDailySummary {
+  buy: number;
+  sell: number;
+}
+
+const RECORD_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+export function normalizeRecordDate(
+  date: string | undefined,
+  fallback: string,
+) {
+  return date && RECORD_DATE_PATTERN.test(date) ? date : fallback;
+}
+
+export function buildStockRecordDailySummaries(
+  transactions: TransactionWithDetails[],
+) {
+  const summaries = new Map<string, StockRecordDailySummary>();
+
+  for (const transaction of transactions) {
+    const dateKey = formatDateISO(transaction.transactedAt);
+    const summary = summaries.get(dateKey) ?? { buy: 0, sell: 0 };
+    summary[transaction.type] += 1;
+    summaries.set(dateKey, summary);
+  }
+
+  return summaries;
+}
+
+export function getTransactionsForRecordDate(
+  transactions: TransactionWithDetails[],
+  date: string,
+) {
+  return transactions.filter(
+    (transaction) => formatDateISO(transaction.transactedAt) === date,
+  );
+}


### PR DESCRIPTION
Resolve #294

### 설명
- 주식 거래기록을 캘린더로 조회할 수 있도록 기능 추가 (`StockRecordsClient`, `StockRecordsCalendar`)
- 일자별 거래 목록/상세/추가 화면 흐름 및 transition 구조 반영 (`StockRecordDayList`)
- 캘린더 스타일을 다양한 뷰포트 너비에 맞게 개선 (SSGOI 기반 화면 전환 및 drill-down 전환 방식 참고)
- 주식 거래 내역에 계좌명(`accountName`) 연동 처리
- 관련 테스트 코드 및 라우트 트리 업데이트