### PR TITLE
fix: 주식 거래 및 보유 종목 관련 모바일 UI/UX 최적화 (#339)

### DIFF
--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -14,12 +14,12 @@ export default function MainLayout({
   return (
     <div className="h-dvh flex bg-gray-50">
       <Sidebar />
-      <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+      <div className="flex min-w-0 flex-1 flex-col overflow-hidden relative">
         <ServiceHeader variant="desktop" />
+        <ServiceHeader variant="mobile" />
         <div className="size-full overflow-y-scroll overflow-x-clip relative z-0">
           <PageTransitionProvider>
-            <PageTransition className="flex-1 pb-[calc(6rem+env(safe-area-inset-bottom))] lg:pb-4">
-              <ServiceHeader variant="mobile" />
+            <PageTransition className="flex-1 pb-[calc(6rem+env(safe-area-inset-bottom))] pt-14 lg:pb-4 lg:pt-0">
               <div className="p-4">
                 <div className="max-w-4xl mx-auto space-y-6">{children}</div>
               </div>

--- a/components/holdings/HoldingsTable.tsx
+++ b/components/holdings/HoldingsTable.tsx
@@ -4,10 +4,15 @@ import { ArrowDownUp, Building2, UserRound, WalletCards } from "lucide-react";
 import { useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { MARKET_LABELS } from "@/constants/enums";
 import type { HoldingWithDetails } from "@/lib/api/holdings";
 import { cn } from "@/lib/utils/cn";
-import { formatCurrency } from "@/lib/utils/format";
+import { formatCompactCurrency, formatCurrency } from "@/lib/utils/format";
 
 interface HoldingsTableProps {
   data: HoldingWithDetails[];
@@ -80,51 +85,72 @@ export function HoldingsTable({ data }: HoldingsTableProps) {
         {sortedHoldings.map((holding) => (
           <article
             key={`${holding.owner.id}:${holding.account.id ?? "none"}:${holding.ticker}`}
-            className="rounded-2xl bg-white p-5 shadow-sm ring-1 ring-gray-100"
+            className="flex flex-col gap-2 rounded-2xl bg-white p-4 shadow-sm ring-1 ring-gray-100"
           >
-            <div className="flex items-start justify-between gap-3">
-              <div className="min-w-0">
-                <div className="flex min-w-0 flex-wrap items-center gap-2">
-                  <h3 className="truncate font-semibold text-gray-900">
+            <div className="flex min-w-0 items-center justify-between gap-3">
+              <div className="flex min-w-0 flex-1 items-center gap-2">
+                <Badge
+                  variant="outline"
+                  className="shrink-0 px-1.5 py-0 text-[10px]"
+                >
+                  {MARKET_LABELS[holding.market] ?? holding.market}
+                </Badge>
+                <Popover>
+                  <PopoverTrigger className="cursor-pointer truncate text-left font-semibold text-gray-900 text-sm transition-colors hover:text-gray-600">
                     {holding.name}
-                  </h3>
-                  <Badge variant="outline">
-                    {MARKET_LABELS[holding.market] ?? holding.market}
-                  </Badge>
-                </div>
-                <p className="mt-1 text-gray-400 text-xs">{holding.ticker}</p>
+                  </PopoverTrigger>
+                  <PopoverContent
+                    className="w-auto p-3 text-sm shadow-md"
+                    align="start"
+                  >
+                    <div className="mb-1 font-semibold text-gray-900">
+                      {holding.name}
+                    </div>
+                    <div className="flex flex-col gap-1 text-gray-500">
+                      <div>
+                        총 투자 금액:{" "}
+                        <span className="font-medium text-gray-900">
+                          {formatCurrency(
+                            holding.totalInvested,
+                            holding.currency,
+                          )}
+                        </span>
+                      </div>
+                      <div>
+                        평균 매수가:{" "}
+                        <span className="font-medium text-gray-900">
+                          {formatCurrency(holding.avgPrice, holding.currency)}
+                        </span>
+                      </div>
+                    </div>
+                  </PopoverContent>
+                </Popover>
               </div>
-              <div className="text-right">
-                <p className="text-gray-500 text-xs">투자 금액</p>
-                <p className="font-bold text-gray-900 tabular-nums">
-                  {formatCurrency(holding.totalInvested, holding.currency)}
-                </p>
+              <div className="shrink-0 font-medium text-gray-900 text-sm tabular-nums">
+                {formatCompactCurrency(holding.totalInvested, holding.currency)}
               </div>
             </div>
 
-            <div className="mt-5 grid grid-cols-2 gap-3">
-              <div className="rounded-xl bg-gray-50 p-3">
-                <p className="text-gray-500 text-xs">수량</p>
-                <p className="mt-1 font-semibold text-gray-900 tabular-nums">
-                  {holding.quantity.toLocaleString()}주
-                </p>
-              </div>
-              <div className="rounded-xl bg-gray-50 p-3">
-                <p className="text-gray-500 text-xs">평균 매수가</p>
-                <p className="mt-1 font-semibold text-gray-900 tabular-nums">
-                  {formatCurrency(holding.avgPrice, holding.currency)}
-                </p>
-              </div>
-            </div>
-
-            <div className="mt-4 flex flex-wrap gap-x-4 gap-y-2 text-gray-500 text-sm">
-              <span className="inline-flex items-center gap-1">
-                <UserRound className="size-4" />
-                {holding.owner.name}
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-gray-500 text-xs">
+              <span className="font-medium text-gray-400">
+                {holding.ticker}
               </span>
-              <span className="inline-flex items-center gap-1">
-                <Building2 className="size-4" />
-                {holding.account.name ?? "미지정 계좌"}
+              <span>{holding.quantity.toLocaleString()}주</span>
+              <span>
+                평단 {formatCompactCurrency(holding.avgPrice, holding.currency)}
+              </span>
+            </div>
+
+            <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-gray-400 text-xs">
+              <span className="inline-flex min-w-0 items-center gap-1">
+                <UserRound className="size-3 shrink-0" />
+                <span className="truncate">{holding.owner.name}</span>
+              </span>
+              <span className="inline-flex min-w-0 items-center gap-1">
+                <Building2 className="size-3 shrink-0" />
+                <span className="truncate">
+                  {holding.account.name ?? "미지정 계좌"}
+                </span>
               </span>
             </div>
           </article>

--- a/components/layout/ServiceHeader.tsx
+++ b/components/layout/ServiceHeader.tsx
@@ -50,7 +50,7 @@ function MobileServiceHeader({
 
   if (meta.mobileVariant === "topLevel") {
     return (
-      <header className="sticky top-0 z-50 bg-gray-50/80 backdrop-blur-md h-14 px-4 flex items-center lg:hidden">
+      <header className="absolute inset-x-0 top-0 z-50 bg-gray-50/80 backdrop-blur-md h-14 px-4 flex items-center lg:hidden">
         <Link href="/home" className="inline-flex items-center">
           <span className="text-xl font-bold text-primary">oat</span>
         </Link>
@@ -59,7 +59,7 @@ function MobileServiceHeader({
   }
 
   return (
-    <header className="sticky top-0 z-50 bg-gray-50/80 backdrop-blur-md h-14 px-1 flex items-center lg:hidden">
+    <header className="absolute inset-x-0 top-0 z-50 bg-gray-50/80 backdrop-blur-md h-14 px-1 flex items-center lg:hidden">
       <IconLink
         href={parentHref}
         label="이전 화면으로 이동"

--- a/components/transactions/AccountSelector.tsx
+++ b/components/transactions/AccountSelector.tsx
@@ -504,6 +504,7 @@ export function AccountSelector<T extends FieldValues>({
                     value={search}
                     onValueChange={setSearch}
                     wrapperClassName="h-14 px-4"
+                    autoFocus={false}
                     endAdornment={
                       createLabel ? (
                         <Button

--- a/components/transactions/TransactionEditDialog.tsx
+++ b/components/transactions/TransactionEditDialog.tsx
@@ -309,7 +309,7 @@ export function TransactionEditDialog({
           </form>
         </div>
 
-        <DrawerFooter>
+        <DrawerFooter className="pb-[max(env(safe-area-inset-bottom),1rem)]">
           <div className="flex gap-2">
             <Button
               type="button"

--- a/components/transactions/TransactionTable.tsx
+++ b/components/transactions/TransactionTable.tsx
@@ -2,12 +2,11 @@
 
 import {
   CalendarDays,
-  MoreHorizontal,
+  MoreVertical,
   Pencil,
   Trash2,
-  TrendingDown,
-  TrendingUp,
-  UserRound,
+  User,
+  Wallet,
 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
@@ -18,9 +17,19 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import type { TransactionWithDetails } from "@/lib/api/transaction";
 import { cn } from "@/lib/utils/cn";
-import { formatCurrency, formatDate, formatDateISO } from "@/lib/utils/format";
+import {
+  formatCompactCurrency,
+  formatCurrency,
+  formatDate,
+  formatDateISO,
+} from "@/lib/utils/format";
 import { TransactionDeleteDialog } from "./TransactionDeleteDialog";
 import { TransactionEditDialog } from "./TransactionEditDialog";
 
@@ -76,53 +85,17 @@ function TransactionItem({
   const typeLabel = isBuy ? "매수" : "매도";
 
   return (
-    <article className="group flex min-h-[96px] items-center gap-3 border-gray-100 border-t px-4 py-4 first:border-t-0 sm:px-5">
-      <div
-        className={cn(
-          "flex size-10 shrink-0 items-center justify-center rounded-full",
-          isBuy ? "bg-red-50 text-red-500" : "bg-blue-50 text-blue-500",
-        )}
-        aria-hidden="true"
-      >
-        {isBuy ? (
-          <TrendingUp className="size-5" />
-        ) : (
-          <TrendingDown className="size-5" />
-        )}
-      </div>
-
-      <div className="min-w-0 flex-1">
-        <div className="flex min-w-0 flex-wrap items-center gap-2">
-          <p className="truncate font-semibold text-gray-900">
-            {transaction.stockName}
-          </p>
-          <Badge variant={isBuy ? "default" : "secondary"}>{typeLabel}</Badge>
-          <span className="text-gray-400 text-xs">{transaction.ticker}</span>
-        </div>
-        <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-gray-500 text-xs">
-          <span>{transaction.quantity.toLocaleString()}주</span>
-          <span>{formatCurrency(transaction.price, transaction.currency)}</span>
-          <span className="inline-flex items-center gap-1">
-            <UserRound className="size-3" />
-            {transaction.owner.name}
-          </span>
-          {transaction.memo && (
-            <span className="max-w-full truncate text-gray-400">
-              {transaction.memo}
-            </span>
-          )}
-        </div>
-      </div>
-
-      <div className="flex shrink-0 items-center gap-1">
-        <p className="min-w-[92px] text-right font-semibold text-gray-900 tabular-nums">
-          {formatCurrency(transaction.totalAmount, transaction.currency)}
-        </p>
+    <article className="group relative flex min-h-[72px] flex-col justify-center border-gray-100 border-t px-4 py-3.5 first:border-t-0 sm:px-5">
+      <div className="absolute right-2 top-1/2 z-10 -translate-y-1/2">
         {isOwner && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon" className="size-9">
-                <MoreHorizontal className="size-4" />
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-7 text-gray-400 hover:text-gray-600"
+              >
+                <MoreVertical className="size-4" />
                 <span className="sr-only">메뉴 열기</span>
               </Button>
             </DropdownMenuTrigger>
@@ -142,6 +115,60 @@ function TransactionItem({
           </DropdownMenu>
         )}
       </div>
+
+      <div className="flex min-w-0 flex-col gap-1 pr-6">
+        <div className="flex min-w-0 items-center justify-between gap-3">
+          <div className="flex min-w-0 flex-1 items-center gap-2">
+            <Badge
+              variant={isBuy ? "default" : "secondary"}
+              className="shrink-0 px-1.5 py-0 text-[10px]"
+            >
+              {typeLabel}
+            </Badge>
+            <Popover>
+              <PopoverTrigger className="cursor-pointer truncate text-left font-semibold text-gray-900 text-sm transition-colors hover:text-gray-600">
+                {transaction.stockName}
+              </PopoverTrigger>
+              <PopoverContent
+                className="w-auto p-3 text-sm shadow-md"
+                align="start"
+              >
+                <div className="mb-1 font-semibold text-gray-900">
+                  {transaction.stockName}
+                </div>
+                <div className="text-gray-500">
+                  총 거래금액:{" "}
+                  <span className="font-medium text-gray-900">
+                    {formatCurrency(
+                      transaction.price * transaction.quantity,
+                      transaction.currency,
+                    )}
+                  </span>
+                </div>
+              </PopoverContent>
+            </Popover>
+          </div>
+          <div className="shrink-0 font-medium text-gray-900 text-sm">
+            {formatCompactCurrency(
+              transaction.price * transaction.quantity,
+              transaction.currency,
+            )}
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-gray-500 text-xs">
+          <span>{transaction.quantity.toLocaleString()}주</span>
+          <span className="inline-flex min-w-0 items-center gap-1">
+            <User className="size-3 shrink-0" />
+            <span className="truncate">{transaction.owner.name}</span>
+          </span>
+          <span className="inline-flex min-w-0 items-center gap-1">
+            <Wallet className="size-3 shrink-0" />
+            <span className="truncate">
+              {transaction.accountName ?? "계좌 없음"}
+            </span>
+          </span>
+        </div>
+      </div>
     </article>
   );
 }
@@ -152,8 +179,11 @@ export function TransactionTable({
 }: TransactionTableProps) {
   const [editTransaction, setEditTransaction] =
     useState<TransactionWithDetails | null>(null);
+  const [isEditOpen, setIsEditOpen] = useState(false);
+
   const [deleteTransaction, setDeleteTransaction] =
     useState<TransactionWithDetails | null>(null);
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
 
   const groups = useMemo(() => groupTransactionsByDate(data), [data]);
 
@@ -181,8 +211,14 @@ export function TransactionTable({
                     key={transaction.id}
                     transaction={transaction}
                     currentUserId={currentUserId}
-                    onEdit={setEditTransaction}
-                    onDelete={setDeleteTransaction}
+                    onEdit={(t) => {
+                      setEditTransaction(t);
+                      setIsEditOpen(true);
+                    }}
+                    onDelete={(t) => {
+                      setDeleteTransaction(t);
+                      setIsDeleteOpen(true);
+                    }}
                   />
                 ))}
               </div>
@@ -201,14 +237,14 @@ export function TransactionTable({
 
       <TransactionEditDialog
         transaction={editTransaction}
-        open={!!editTransaction}
-        onOpenChange={(open) => !open && setEditTransaction(null)}
+        open={isEditOpen}
+        onOpenChange={setIsEditOpen}
       />
 
       <TransactionDeleteDialog
         transaction={deleteTransaction}
-        open={!!deleteTransaction}
-        onOpenChange={(open) => !open && setDeleteTransaction(null)}
+        open={isDeleteOpen}
+        onOpenChange={setIsDeleteOpen}
       />
     </>
   );

--- a/components/transactions/records/StockRecordDayList.tsx
+++ b/components/transactions/records/StockRecordDayList.tsx
@@ -2,11 +2,10 @@
 
 import {
   CalendarDays,
-  MoreHorizontal,
+  MoreVertical,
   Pencil,
   Trash2,
-  TrendingDown,
-  TrendingUp,
+  User,
   Wallet,
 } from "lucide-react";
 import { useState } from "react";
@@ -20,9 +19,18 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import type { TransactionWithDetails } from "@/lib/api/transaction";
 import { cn } from "@/lib/utils/cn";
-import { formatCurrency, formatDate } from "@/lib/utils/format";
+import {
+  formatCompactCurrency,
+  formatCurrency,
+  formatDate,
+} from "@/lib/utils/format";
 
 interface StockRecordDayListProps {
   selectedDate: string;
@@ -37,8 +45,11 @@ export function StockRecordDayList({
 }: StockRecordDayListProps) {
   const [editTransaction, setEditTransaction] =
     useState<TransactionWithDetails | null>(null);
+  const [isEditOpen, setIsEditOpen] = useState(false);
+
   const [deleteTransaction, setDeleteTransaction] =
     useState<TransactionWithDetails | null>(null);
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
 
   return (
     <>
@@ -63,46 +74,92 @@ export function StockRecordDayList({
               return (
                 <article
                   key={transaction.id}
-                  className="flex min-h-[92px] items-center gap-3 border-gray-100 border-t px-4 py-4 first:border-t-0 sm:px-5"
+                  className="group relative flex min-h-[72px] flex-col justify-center border-gray-100 border-t px-4 py-3.5 first:border-t-0 sm:px-5"
                 >
-                  <div
-                    className={cn(
-                      "flex size-10 shrink-0 items-center justify-center rounded-full",
-                      isBuy
-                        ? "bg-red-50 text-red-500"
-                        : "bg-blue-50 text-blue-500",
-                    )}
-                    aria-hidden="true"
-                  >
-                    {isBuy ? (
-                      <TrendingUp className="size-5" />
-                    ) : (
-                      <TrendingDown className="size-5" />
+                  <div className="absolute right-2 top-1/2 z-10 -translate-y-1/2">
+                    {isOwner && (
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="size-7 text-gray-400 hover:text-gray-600"
+                          >
+                            <MoreVertical className="size-4" />
+                            <span className="sr-only">메뉴 열기</span>
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem
+                            onClick={() => {
+                              setEditTransaction(transaction);
+                              setIsEditOpen(true);
+                            }}
+                          >
+                            <Pencil className="mr-2 size-4" />
+                            수정
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            onClick={() => {
+                              setDeleteTransaction(transaction);
+                              setIsDeleteOpen(true);
+                            }}
+                            className="text-destructive focus:text-destructive"
+                          >
+                            <Trash2 className="mr-2 size-4" />
+                            삭제
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
                     )}
                   </div>
 
-                  <div className="min-w-0 flex-1">
-                    <div className="flex min-w-0 items-center gap-2">
-                      <p className="truncate font-semibold text-gray-900">
-                        {transaction.stockName}
-                      </p>
-                      <Badge
-                        variant={isBuy ? "default" : "secondary"}
-                        className="shrink-0"
-                      >
-                        {typeLabel}
-                      </Badge>
-                      <span className="shrink-0 text-gray-400 text-xs">
-                        {transaction.ticker}
-                      </span>
-                    </div>
-                    <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-gray-500 text-xs">
-                      <span>{transaction.quantity.toLocaleString()}주</span>
-                      <span>
-                        {formatCurrency(
-                          transaction.price,
+                  <div className="flex min-w-0 flex-col gap-1 pr-6">
+                    <div className="flex min-w-0 items-center justify-between gap-3">
+                      <div className="flex min-w-0 flex-1 items-center gap-2">
+                        <Badge
+                          variant={isBuy ? "default" : "secondary"}
+                          className="shrink-0 px-1.5 py-0 text-[10px]"
+                        >
+                          {typeLabel}
+                        </Badge>
+                        <Popover>
+                          <PopoverTrigger className="cursor-pointer truncate text-left font-semibold text-gray-900 text-sm transition-colors hover:text-gray-600">
+                            {transaction.stockName}
+                          </PopoverTrigger>
+                          <PopoverContent
+                            className="w-auto p-3 text-sm shadow-md"
+                            align="start"
+                          >
+                            <div className="mb-1 font-semibold text-gray-900">
+                              {transaction.stockName}
+                            </div>
+                            <div className="text-gray-500">
+                              총 거래금액:{" "}
+                              <span className="font-medium text-gray-900">
+                                {formatCurrency(
+                                  transaction.price * transaction.quantity,
+                                  transaction.currency,
+                                )}
+                              </span>
+                            </div>
+                          </PopoverContent>
+                        </Popover>
+                      </div>
+                      <div className="shrink-0 font-medium text-gray-900 text-sm">
+                        {formatCompactCurrency(
+                          transaction.price * transaction.quantity,
                           transaction.currency,
                         )}
+                      </div>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-gray-500 text-xs">
+                      <span>{transaction.quantity.toLocaleString()}주</span>
+                      <span className="inline-flex min-w-0 items-center gap-1">
+                        <User className="size-3 shrink-0" />
+                        <span className="truncate">
+                          {transaction.owner.name}
+                        </span>
                       </span>
                       <span className="inline-flex min-w-0 items-center gap-1">
                         <Wallet className="size-3 shrink-0" />
@@ -112,36 +169,6 @@ export function StockRecordDayList({
                       </span>
                     </div>
                   </div>
-
-                  {isOwner && (
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="size-9 shrink-0"
-                        >
-                          <MoreHorizontal className="size-4" />
-                          <span className="sr-only">메뉴 열기</span>
-                        </Button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent align="end">
-                        <DropdownMenuItem
-                          onClick={() => setEditTransaction(transaction)}
-                        >
-                          <Pencil className="mr-2 size-4" />
-                          수정
-                        </DropdownMenuItem>
-                        <DropdownMenuItem
-                          onClick={() => setDeleteTransaction(transaction)}
-                          className="text-destructive focus:text-destructive"
-                        >
-                          <Trash2 className="mr-2 size-4" />
-                          삭제
-                        </DropdownMenuItem>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  )}
                 </article>
               );
             })}
@@ -160,13 +187,13 @@ export function StockRecordDayList({
 
       <TransactionEditDialog
         transaction={editTransaction}
-        open={!!editTransaction}
-        onOpenChange={(open) => !open && setEditTransaction(null)}
+        open={isEditOpen}
+        onOpenChange={setIsEditOpen}
       />
       <TransactionDeleteDialog
         transaction={deleteTransaction}
-        open={!!deleteTransaction}
-        onOpenChange={(open) => !open && setDeleteTransaction(null)}
+        open={isDeleteOpen}
+        onOpenChange={setIsDeleteOpen}
       />
     </>
   );

--- a/components/transactions/records/StockRecordsClient.tsx
+++ b/components/transactions/records/StockRecordsClient.tsx
@@ -117,28 +117,38 @@ export function StockRecordsClient({
     }
   };
 
-  const goToPrevMonth = () =>
-    setCurrentMonth((month) => startOfMonth(subMonths(month, 1)));
-  const goToNextMonth = () =>
-    setCurrentMonth((month) => startOfMonth(addMonths(month, 1)));
+  const changeMonthAndUpdateDate = (newMonthStart: Date) => {
+    setCurrentMonth(newMonthStart);
 
-  const handleMonthChange = (month: Date) =>
-    setCurrentMonth(startOfMonth(month));
-
-  const handleYearChange = (year: string) => {
-    setCurrentMonth((month) => {
-      const next = new Date(month);
-      next.setFullYear(Number(year));
-      return startOfMonth(next);
+    setSelectedDate((prevSelectedDate) => {
+      const nextDate = new Date(newMonthStart);
+      nextDate.setDate(prevSelectedDate.getDate());
+      if (nextDate.getMonth() !== newMonthStart.getMonth()) {
+        nextDate.setDate(0);
+      }
+      queueMicrotask(() => updateSelectedDateParam(nextDate));
+      return nextDate;
     });
   };
 
+  const goToPrevMonth = () =>
+    changeMonthAndUpdateDate(startOfMonth(subMonths(currentMonth, 1)));
+  const goToNextMonth = () =>
+    changeMonthAndUpdateDate(startOfMonth(addMonths(currentMonth, 1)));
+
+  const handleMonthChange = (month: Date) =>
+    changeMonthAndUpdateDate(startOfMonth(month));
+
+  const handleYearChange = (year: string) => {
+    const next = new Date(currentMonth);
+    next.setFullYear(Number(year));
+    changeMonthAndUpdateDate(startOfMonth(next));
+  };
+
   const handleMonthSelect = (month: string) => {
-    setCurrentMonth((value) => {
-      const next = new Date(value);
-      next.setMonth(Number(month) - 1);
-      return startOfMonth(next);
-    });
+    const next = new Date(currentMonth);
+    next.setMonth(Number(month) - 1);
+    changeMonthAndUpdateDate(startOfMonth(next));
   };
 
   const handleRefresh = () => {
@@ -204,7 +214,7 @@ export function StockRecordsClient({
           )}
         </div>
 
-        <div className="flex flex-col gap-4">
+        <div className="flex min-w-0 flex-col gap-4">
           <StockRecordDayList
             selectedDate={selectedDateKey}
             transactions={dayTransactions}

--- a/lib/utils/format.ts
+++ b/lib/utils/format.ts
@@ -13,6 +13,21 @@ export function formatCurrency(
 }
 
 /**
+ * 통화를 축약 형식으로 포맷 (예: $1.2M, ₩340만)
+ */
+export function formatCompactCurrency(
+  value: number,
+  currency: "KRW" | "USD" = "KRW",
+): string {
+  return new Intl.NumberFormat("ko-KR", {
+    style: "currency",
+    currency,
+    notation: "compact",
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+/**
  * 숫자를 퍼센트 형식으로 포맷
  * 양수/0일 경우 '+'를 앞에 붙임 (예: +10.46%, +0.00%)
  * 음수일 경우 '-'를 앞에 붙임 (예: -5.20%)


### PR DESCRIPTION
## 변경 내용
- 주식 거래 목록 및 보유 종목 카드 레이아웃 모바일 최적화 (컴팩트 리스트 뷰 적용)
- 너무 길어서 레이아웃을 밀어내던 주식명에 말줄임 처리 및 팝업(Popover) 상세 뷰 추가
- 큰 거래 단위 표시를 위한 `formatCompactCurrency` 유틸 적용
- 모바일(iOS PWA 등) 환경에서 상단 헤더(`MobileServiceHeader`)의 블러 효과와 스크롤 바운스가 겹쳐 부르르 떨리던 증상(Jitter) 완벽 해결
- 드로어/다이얼로그 닫힘 애니메이션 중 데이터 초기화로 인해 비정상적으로 Unmount 되던 문제 수정 (상태 분리)
- CSS Grid 모바일 환경에서 텍스트 말줄임이 레이아웃을 밀어내던 문제 수정 (`min-w-0` 추가)
- 렌더링 시 모바일 키보드 자동 팝업 방지 (`autoFocus` 제거) 및 Safe-area 여백 확보

## 관련 이슈
- resolves #339