### PR TITLE
[codex] Add notification foundation

### DIFF
--- a/.claude/docs/NOTIFICATIONS.md
+++ b/.claude/docs/NOTIFICATIONS.md
@@ -7,6 +7,8 @@
 - 알림의 원장은 **User Notification**이다. 앱 안 알림함에 저장되고 읽음/미읽음, 이동 링크, 중복 방지, 수신자 범위를 가진다.
 - 푸시와 이메일은 **Notification Channel**이다. 현재 마일스톤은 앱 내 알림과 Push를 구현하고, 이메일은 향후 채널로 열어둔다.
 - 알림 수신 제어는 사용자별 **Notification Preference**로 관리한다. 가구 단위 전역 설정으로 두지 않는다.
+- 알림은 가구 단위 row가 아니라 수신자별 **User Notification** row로 저장한다. 같은 사건이 여러 명에게 전달되면 수신자 수만큼 row를 만든다.
+- 알림 이동은 raw URL이 아니라 **Notification Link Kind**와 params로 저장하고, 클라이언트가 앱 route로 해석한다.
 - 알림함과 알림 설정은 화면을 분리한다. 알림 아이콘은 알림함으로 이동하고, `/settings/notifications`는 수신 제어 전용 화면이다.
 - 개인 장부 내용은 알림에도 노출하지 않는다. 파트너에게 보낼 수 있는 알림은 공용 장부 또는 가구 전체에 이미 공개되는 데이터에 한정한다.
 - 1차 구현은 알림 인프라와 **Collaboration Notification**을 우선한다. 수정/삭제 요청은 협업 알림의 대표 사례이며, 리마인더/분석 임계치 알림은 이번 마일스톤에서 제외한다.
@@ -20,7 +22,10 @@
 | User Notification | 특정 사용자에게 저장되는 알림 메시지. 앱 안 알림함에서 조회하고 읽음 처리한다. |
 | Notification Channel | User Notification을 앱 밖으로 전달하는 경로. Push, 이메일 등이 가능하다. |
 | Notification Event | 알림을 만들 수 있는 도메인 사건. 예: 공용 지출 기록, 초대 수락. |
+| Notification Type | 알림 설정과 표시 그룹에 사용하는 도메인+액션 단위 키. 예: `ledger_record_changed`, `stock_transaction_changed`. |
+| Notification Link Kind | User Notification에 저장되는 제한된 이동 의도. 앱 route 문자열 대신 params와 함께 저장한다. |
 | Notification Preference | 사용자가 알림 종류별로 앱 내/Push 수신 여부를 조정하는 설정. |
+| Default Notification Preference | 사용자가 저장한 override가 없을 때 적용하는 제품 기본값. |
 | Collaboration Notification | 가구 구성원이 공유 재무 데이터를 함께 관리하기 위해 받는 알림. |
 | Record Change Request | 공용 기록의 비소유자가 소유자에게 수정 또는 삭제를 요청하는 협업 요청. |
 
@@ -119,21 +124,43 @@
 
 | 축 | 예시 | 원칙 |
 |----|------|------|
-| notification type | `record_change_request`, `request_result`, `invitation_accepted` | 알림 의미 단위. UI에서는 사람이 읽는 그룹명으로 노출한다. |
-| channel | `in_app`, `push`, 향후 `email` | 전달 경로. in_app은 기본값 on, push는 사용자 opt-in. |
+| notification type | `ledger_record_changed`, `stock_transaction_changed`, `invitation_accepted` | 도메인+액션 단위. UI에서는 사람이 읽는 그룹명으로 묶어 노출할 수 있다. |
+| channel | `in_app`, `push`, 향후 `email` | 전달 경로. 현재 저장 구조는 타입별 row에 채널별 boolean 컬럼을 둔다. |
 | enabled | true/false | 사용자별로 저장한다. |
+
+`notification_preferences`는 notification type별 1 row를 저장한다.
+
+```sql
+notification_preferences (
+  user_id uuid not null references profiles(id) on delete cascade,
+  type notification_type not null,
+  in_app_enabled boolean not null,
+  push_enabled boolean not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (user_id, type)
+)
+```
+
+저장된 row가 없으면 Default Notification Preference를 적용한다. 알림 종류가 늘어날 때 기존 사용자 전체에 preference row를 backfill하지 않는다.
 
 초기 기본값:
 
 | 알림 종류 | In-app | Push | 비고 |
 |----------|:------:|:----:|------|
-| 수정/삭제 요청 | on | opt-in | 상대방 조치가 필요한 요청형 |
-| 요청 처리 결과 | on | opt-in | 요청자 확인형 |
-| 공유 기록 수정/삭제 | on | opt-in | 함께 보던 데이터가 바뀌는 변경형 |
-| 새 공유 기록 추가 | off | opt-in | 노이즈 가능성이 높아 기본 off |
+| 가계부 수정/삭제 요청 | on | off | 상대방 조치가 필요한 요청형 |
+| 주식 거래 수정/삭제 요청 | on | off | 상대방 조치가 필요한 요청형 |
+| 가계부 요청 처리 결과 | on | off | 요청자 확인형 |
+| 주식 거래 요청 처리 결과 | on | off | 요청자 확인형 |
+| 가계부 기록 수정/삭제 | on | off | 함께 보던 데이터가 바뀌는 변경형 |
+| 주식 거래 수정/삭제 | on | off | 함께 보던 데이터가 바뀌는 변경형 |
+| 새 공용 가계부 기록 추가 | off | off | 노이즈 가능성이 높아 기본 off |
+| 새 주식 거래 추가 | off | off | 노이즈 가능성이 높아 기본 off |
 | 초대 수락 | on | off | 중요하지만 즉시성은 낮음 |
 
 Preference가 꺼져 있더라도 시스템이 요청 상태 자체를 잃으면 안 된다. 예를 들어 수정 요청은 `record_change_requests`에 저장되고, preference는 User Notification 생성/채널 전달만 제어한다.
+
+`in_app_enabled=false`이면 해당 User Notification row를 만들지 않는다. 나중에 사용자가 설정을 켜도 과거 알림이 알림함에 나타나지 않는다. `push_enabled=false`이면 Push 발송만 하지 않는다. Issue #342에서는 Push 토글을 저장하고 UI에 노출하지만 실제 Push 발송은 후속 이슈에서 구현한다.
 
 이번 마일스톤에서 제외:
 
@@ -141,6 +168,159 @@ Preference가 꺼져 있더라도 시스템이 요청 상태 자체를 잃으면
 - 조용한 시간
 - 이메일 채널 설정 UI
 - 알림 digest 또는 요약 발송
+
+### 3.2 User Notification 기반 구축 확정 설계 (#342)
+
+#### 저장 모델
+
+`notifications`는 가구 단위 알림이 아니라 수신자별 User Notification row를 저장한다. 같은 Notification Event가 여러 명에게 전달되어야 하면 수신자마다 row를 만든다.
+
+핵심 컬럼:
+
+```sql
+notifications (
+  id uuid primary key default gen_random_uuid(),
+  recipient_id uuid not null references profiles(id) on delete cascade,
+  household_id uuid null references households(id) on delete cascade,
+  type notification_type not null,
+  title text not null,
+  body text null,
+  link_kind notification_link_kind null,
+  link_params jsonb not null default '{}',
+  source_type text null,
+  source_id uuid null,
+  dedupe_key text null,
+  read_at timestamptz null,
+  created_at timestamptz not null default now(),
+  check (
+    (source_type is null and source_id is null)
+    or (source_type is not null and source_id is not null)
+  )
+)
+```
+
+RLS 기준은 `recipient_id = auth.uid()`이다. `household_id`는 필터링, 디버깅, 향후 다중 가구 지원을 위한 nullable context이며, 같은 가구 구성원이라는 이유로 다른 사람의 알림을 조회할 수 없어야 한다.
+
+알림 생성은 클라이언트가 직접 insert하지 않는다. 서버 helper가 admin client로 생성하고, RLS는 본인 조회와 본인 읽음 처리의 최소 방어선으로 둔다.
+
+#### Notification Type
+
+`notifications.type`과 `notification_preferences.type`은 같은 `notification_type` enum을 공유한다.
+
+초기 타입:
+
+```ts
+type NotificationType =
+  | 'ledger_record_change_request'
+  | 'stock_transaction_change_request'
+  | 'ledger_request_result'
+  | 'stock_transaction_request_result'
+  | 'ledger_record_changed'
+  | 'stock_transaction_changed'
+  | 'ledger_record_created'
+  | 'stock_transaction_created'
+  | 'invitation_accepted';
+```
+
+설정 UI에서는 필요하면 "협업 요청", "요청 처리 결과", "공유 기록 변경", "새 공유 기록 추가" 같은 섹션으로 그룹핑한다. 타입 자체는 장부/주식 도메인을 숨기지 않는다.
+
+#### Notification Link
+
+알림 이동은 raw URL을 저장하지 않는다. `link_kind`와 `link_params`를 저장하고, 클라이언트의 공용 route builder가 앱 route로 해석한다.
+
+초기 link kind:
+
+```ts
+type NotificationLinkKind =
+  | 'ledger_record_date'
+  | 'stock_record_date'
+  | 'record_change_request_detail'
+  | 'household_settings'
+  | 'notification_settings';
+```
+
+예시:
+
+| link_kind | link_params | route |
+|-----------|-------------|-------|
+| `ledger_record_date` | `{ "date": "2026-06-01" }` | `/ledger/records?date=2026-06-01` |
+| `stock_record_date` | `{ "date": "2026-06-01" }` | `/assets/stock/records?date=2026-06-01` |
+| `record_change_request_detail` | `{ "requestId": "..." }` | 후속 이슈의 요청 상세 화면 |
+| `household_settings` | `{}` | `/settings/household` |
+| `notification_settings` | `{}` | `/settings/notifications` |
+
+`notification_link_kind`는 DB enum으로 제한한다. `link_params` 형태는 DB에서 강하게 검증하지 않고, 클라이언트와 서버가 공유하는 Zod schema와 TypeScript discriminated union으로 검증한다. 공유 schema 모듈은 브라우저에서도 import할 수 있도록 Supabase server client나 `next/server`를 의존하지 않는다.
+
+#### Source and Dedupe
+
+`source_type`과 `source_id`는 이 알림이 어떤 도메인 객체에서 왔는지 추적하는 메타데이터다. `source_type`은 text로 두고 앱 코드에서 Zod로 현재 허용 값을 제한한다. `notification_type`과 `link_kind`처럼 UI/설정/라우팅에 직접 영향을 주는 값만 DB enum으로 잠근다.
+
+초기 source type 후보:
+
+```ts
+type NotificationSourceType =
+  | 'ledger_entry'
+  | 'stock_transaction'
+  | 'record_change_request'
+  | 'invitation';
+```
+
+`dedupe_key`는 같은 수신자에게 같은 사건의 알림이 중복 저장되는 것을 막는다.
+
+```sql
+create unique index notifications_recipient_dedupe_key_unique
+on public.notifications (recipient_id, dedupe_key)
+where dedupe_key is not null;
+```
+
+예시:
+
+- `invitation_accepted:{invitationId}`
+- `record_change_request_created:{requestId}`
+- `stock_transaction_batch_created:{batchId}`
+
+반복해서 발생할 수 있는 이벤트는 너무 넓은 key를 쓰지 않는다. 예를 들어 같은 장부 기록이 여러 번 수정될 수 있으면 이벤트 id나 수정 시각을 포함한다.
+
+#### Read State and APIs
+
+읽음 상태는 `read_at timestamptz null` 하나로 표현한다. `is_read` boolean은 두지 않는다.
+
+필수 API:
+
+```txt
+GET /api/notifications?limit=20&cursor=...
+GET /api/notifications/unread-count
+PATCH /api/notifications/[id]/read
+POST /api/notifications/read-all
+GET /api/notification-preferences
+PATCH /api/notification-preferences/[type]
+```
+
+알림 목록은 최신순 cursor pagination을 사용한다.
+
+```sql
+order by created_at desc, id desc
+```
+
+cursor는 `createdAt + id` 조합을 인코딩한다. 알림 삭제, 아카이브, 자동 만료, 보존 기간 정책은 Issue #342 범위에서 제외한다.
+
+`GET /api/notification-preferences`는 Default Notification Preference와 저장된 override를 서버에서 merge한 완성 목록을 반환한다. `PATCH /api/notification-preferences/[type]`는 단건 타입의 `inAppEnabled`, `pushEnabled`를 저장한다. 설정 토글은 낙관적 업데이트를 적용하고 실패 시 rollback한다.
+
+#### UI Behavior
+
+알림함은 `/notifications`, 알림 설정은 `/settings/notifications`로 분리한다.
+
+메인 UI에는 전역 bell 아이콘을 둔다.
+
+- 모바일 top-level header 우측: bell + unread badge
+- 데스크톱 header 우측: bell + unread badge
+- sidebar와 bottom nav에는 추가하지 않는다.
+
+미읽음 배지는 `GET /api/notifications/unread-count`를 사용한다. Issue #342에서는 Supabase Realtime 구독을 붙이지 않고, React Query 조회/무효화/focus refetch 수준으로 시작한다.
+
+알림 클릭 시 해당 알림을 낙관적으로 읽음 처리하고 즉시 이동한다. 읽음 처리 실패가 navigation을 막지는 않는다. 알림함에는 단건 읽음과 전체 읽음 액션을 제공한다.
+
+`/settings/notifications`의 Push 토글은 저장 가능하게 제공한다. 실제 Push 발송은 후속 이슈에서 구현하므로, UI에는 "Push 발송은 이후 지원" 수준의 짧은 보조 문구를 둔다.
 
 ### Slice 2. Collaboration Request 모델 구축 (#343)
 
@@ -198,4 +378,3 @@ Preference가 꺼져 있더라도 시스템이 요청 상태 자체를 잃으면
 1. 수정 요청이 구체적인 변경안을 포함해야 하는지, 아니면 사유/메시지만 보내고 소유자가 직접 수정해야 하는지.
 2. 삭제 요청 승인 시 시스템이 즉시 삭제할지, 소유자가 원본 화면에서 다시 삭제해야 하는지.
 3. 요청 상태를 pending/approved/rejected/cancelled로 충분히 볼지, expired도 둘지.
-4. Push를 Record Change Request에 기본 적용할지, 앱 내 알림만 기본으로 둘지.

--- a/app/(main)/notifications/page.tsx
+++ b/app/(main)/notifications/page.tsx
@@ -1,0 +1,13 @@
+import { PageContainer } from "@/components/layout";
+import { NotificationInboxClient } from "@/components/notifications";
+import { requireUser } from "@/lib/supabase/auth";
+
+export default async function NotificationsPage() {
+  await requireUser();
+
+  return (
+    <PageContainer maxWidth="narrow">
+      <NotificationInboxClient />
+    </PageContainer>
+  );
+}

--- a/app/(main)/settings/notifications/page.tsx
+++ b/app/(main)/settings/notifications/page.tsx
@@ -1,0 +1,13 @@
+import { PageContainer } from "@/components/layout";
+import { NotificationSettingsClient } from "@/components/notifications";
+import { requireUser } from "@/lib/supabase/auth";
+
+export default async function NotificationSettingsPage() {
+  await requireUser();
+
+  return (
+    <PageContainer>
+      <NotificationSettingsClient />
+    </PageContainer>
+  );
+}

--- a/app/api/notification-preferences/[type]/route.ts
+++ b/app/api/notification-preferences/[type]/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import {
+  assertKnownNotificationType,
+  upsertNotificationPreference,
+} from "@/lib/api/notifications";
+import { notificationPreferenceUpdateSchema } from "@/lib/notifications/schema";
+import { createClient } from "@/lib/supabase/server";
+
+interface RouteContext {
+  params: Promise<{
+    type: string;
+  }>;
+}
+
+export async function PATCH(request: Request, { params }: RouteContext) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    const { type: typeParam } = await params;
+    const type = assertKnownNotificationType(typeParam);
+    const body = await request.json();
+    const result = notificationPreferenceUpdateSchema.safeParse(body);
+
+    if (!result.success) {
+      const firstError = result.error.issues[0];
+      throw new APIError(
+        "VALIDATION_ERROR",
+        firstError?.message ?? "유효하지 않은 요청입니다.",
+        400,
+      );
+    }
+
+    const preference = await upsertNotificationPreference(
+      supabase,
+      user.id,
+      type,
+      result.data,
+    );
+
+    return NextResponse.json({ data: preference });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    console.error("Notification preference update error:", error);
+    return NextResponse.json(
+      {
+        error: { code: "INTERNAL_ERROR", message: "서버 오류가 발생했습니다." },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/notification-preferences/route.ts
+++ b/app/api/notification-preferences/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import { getNotificationPreferences } from "@/lib/api/notifications";
+import { createClient } from "@/lib/supabase/server";
+
+export async function GET() {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    const preferences = await getNotificationPreferences(supabase, user.id);
+
+    return NextResponse.json({ data: preferences });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    console.error("Notification preferences list error:", error);
+    return NextResponse.json(
+      {
+        error: { code: "INTERNAL_ERROR", message: "서버 오류가 발생했습니다." },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/notifications/[id]/read/route.ts
+++ b/app/api/notifications/[id]/read/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import { markNotificationAsRead } from "@/lib/api/notifications";
+import { createClient } from "@/lib/supabase/server";
+
+interface RouteContext {
+  params: Promise<{
+    id: string;
+  }>;
+}
+
+export async function PATCH(_request: Request, { params }: RouteContext) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    const { id } = await params;
+    const notification = await markNotificationAsRead(supabase, user.id, id);
+
+    return NextResponse.json({ data: notification });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    console.error("Notification read error:", error);
+    return NextResponse.json(
+      {
+        error: { code: "INTERNAL_ERROR", message: "서버 오류가 발생했습니다." },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/notifications/read-all/route.ts
+++ b/app/api/notifications/read-all/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import { markAllNotificationsAsRead } from "@/lib/api/notifications";
+import { createClient } from "@/lib/supabase/server";
+
+export async function POST() {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    const count = await markAllNotificationsAsRead(supabase, user.id);
+
+    return NextResponse.json({ data: { count } });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    console.error("Notifications read-all error:", error);
+    return NextResponse.json(
+      {
+        error: { code: "INTERNAL_ERROR", message: "서버 오류가 발생했습니다." },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -1,0 +1,48 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import {
+  decodeNotificationCursor,
+  getNotifications,
+  normalizeNotificationLimit,
+} from "@/lib/api/notifications";
+import { createClient } from "@/lib/supabase/server";
+
+export async function GET(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    const { searchParams } = request.nextUrl;
+    const cursor = decodeNotificationCursor(searchParams.get("cursor"));
+    const limit = normalizeNotificationLimit(searchParams.get("limit"));
+
+    const result = await getNotifications(supabase, user.id, {
+      cursor,
+      limit,
+    });
+
+    return NextResponse.json({ data: result });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    console.error("Notifications list error:", error);
+    return NextResponse.json(
+      {
+        error: { code: "INTERNAL_ERROR", message: "서버 오류가 발생했습니다." },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/notifications/unread-count/route.ts
+++ b/app/api/notifications/unread-count/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import { getUnreadNotificationCount } from "@/lib/api/notifications";
+import { createClient } from "@/lib/supabase/server";
+
+export async function GET() {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    const count = await getUnreadNotificationCount(supabase, user.id);
+
+    return NextResponse.json({ data: { count } });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    console.error("Unread notification count error:", error);
+    return NextResponse.json(
+      {
+        error: { code: "INTERNAL_ERROR", message: "서버 오류가 발생했습니다." },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/components/layout/ServiceHeader.tsx
+++ b/components/layout/ServiceHeader.tsx
@@ -4,6 +4,7 @@ import { ChevronLeft, ChevronRight, X } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
+import { NotificationBell } from "@/components/notifications";
 import { getServiceRouteMeta } from "@/constants/service-routes";
 import { cn } from "@/lib/utils/cn";
 
@@ -50,10 +51,11 @@ function MobileServiceHeader({
 
   if (meta.mobileVariant === "topLevel") {
     return (
-      <header className="absolute inset-x-0 top-0 z-50 bg-gray-50/80 backdrop-blur-md h-14 px-4 flex items-center lg:hidden">
+      <header className="absolute inset-x-0 top-0 z-50 bg-gray-50/80 backdrop-blur-md h-14 px-4 flex items-center justify-between lg:hidden">
         <Link href="/home" className="inline-flex items-center">
           <span className="text-xl font-bold text-primary">oat</span>
         </Link>
+        <NotificationBell />
       </header>
     );
   }
@@ -116,7 +118,7 @@ function DesktopServiceHeader({
   meta: ReturnType<typeof getServiceRouteMeta>;
 }) {
   return (
-    <header className="hidden lg:flex h-14 shrink-0 items-center bg-white border-b border-gray-200 px-4">
+    <header className="hidden lg:flex h-14 shrink-0 items-center justify-between bg-white border-b border-gray-200 px-4">
       {meta && (
         <nav
           aria-label="Breadcrumb"
@@ -147,6 +149,7 @@ function DesktopServiceHeader({
           })}
         </nav>
       )}
+      <NotificationBell className="shrink-0" />
     </header>
   );
 }

--- a/components/notifications/NotificationBell.tsx
+++ b/components/notifications/NotificationBell.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { Bell } from "lucide-react";
+import Link from "next/link";
+import { useUnreadNotificationCount } from "@/hooks/use-notifications";
+import { cn } from "@/lib/utils/cn";
+
+interface NotificationBellProps {
+  className?: string;
+}
+
+export function NotificationBell({ className }: NotificationBellProps) {
+  const { data: count = 0 } = useUnreadNotificationCount();
+  const badgeText = count > 99 ? "99+" : String(count);
+
+  return (
+    <Link
+      href="/notifications"
+      aria-label={count > 0 ? `읽지 않은 알림 ${count}개` : "알림함"}
+      className={cn(
+        "relative inline-flex size-10 items-center justify-center rounded-full text-gray-700 transition-colors hover:bg-gray-100",
+        className,
+      )}
+    >
+      <Bell className="size-5" />
+      {count > 0 && (
+        <span className="absolute right-1.5 top-1 inline-flex min-w-4 items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-semibold leading-4 text-white">
+          {badgeText}
+        </span>
+      )}
+    </Link>
+  );
+}

--- a/components/notifications/NotificationInboxClient.tsx
+++ b/components/notifications/NotificationInboxClient.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { Check, ChevronRight, Loader2 } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  useMarkAllNotificationsAsRead,
+  useMarkNotificationAsRead,
+  useNotifications,
+} from "@/hooks/use-notifications";
+import type { NotificationItem } from "@/lib/api/notifications";
+import { NOTIFICATION_TYPE_CONFIG } from "@/lib/notifications/defaults";
+import { buildNotificationHref } from "@/lib/notifications/links";
+import { cn } from "@/lib/utils/cn";
+
+function formatNotificationTime(value: string) {
+  return new Intl.DateTimeFormat("ko-KR", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
+export function NotificationInboxClient() {
+  const { data, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } =
+    useNotifications();
+  const markAllRead = useMarkAllNotificationsAsRead();
+
+  const notifications = data?.pages.flatMap((page) => page.items) ?? [];
+  const hasUnread = notifications.some((notification) => !notification.readAt);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-16 rounded-2xl" />
+        <Skeleton className="h-20 rounded-2xl" />
+        <Skeleton className="h-20 rounded-2xl" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-semibold text-gray-900">알림함</h1>
+          <p className="mt-1 text-sm text-gray-500">
+            나에게 도착한 알림을 확인합니다.
+          </p>
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => markAllRead.mutate()}
+          disabled={!hasUnread || markAllRead.isPending}
+        >
+          {markAllRead.isPending ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : (
+            <Check className="size-4" />
+          )}
+          전체 읽음
+        </Button>
+      </div>
+
+      {notifications.length === 0 ? (
+        <div className="rounded-2xl bg-white p-8 text-center shadow-sm">
+          <p className="font-medium text-gray-900">아직 알림이 없습니다</p>
+          <p className="mt-2 text-sm text-gray-500">
+            협업 요청이나 공유 기록 변경이 생기면 여기에 표시됩니다.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {notifications.map((notification) => (
+            <NotificationItemCard
+              key={notification.id}
+              notification={notification}
+            />
+          ))}
+        </div>
+      )}
+
+      {hasNextPage && (
+        <Button
+          variant="outline"
+          className="w-full"
+          onClick={() => fetchNextPage()}
+          disabled={isFetchingNextPage}
+        >
+          {isFetchingNextPage && <Loader2 className="size-4 animate-spin" />}더
+          보기
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function NotificationItemCard({
+  notification,
+}: {
+  notification: NotificationItem;
+}) {
+  const markRead = useMarkNotificationAsRead();
+  const href = buildNotificationHref({
+    linkKind: notification.linkKind,
+    linkParams: notification.linkParams,
+  });
+  const config = NOTIFICATION_TYPE_CONFIG[notification.type];
+  const isUnread = !notification.readAt;
+
+  const handleClick = () => {
+    if (isUnread) {
+      markRead.mutate(notification.id);
+    }
+  };
+
+  const handleMarkRead = () => {
+    if (isUnread) {
+      markRead.mutate(notification.id);
+    }
+  };
+
+  return (
+    <div
+      className={cn(
+        "relative rounded-2xl bg-white p-4 shadow-sm transition-colors",
+        isUnread && "ring-1 ring-primary/15",
+      )}
+    >
+      <Link href={href} onClick={handleClick} className="block pr-8">
+        <div className="flex items-start gap-3">
+          <span
+            className={cn(
+              "mt-1 size-2.5 rounded-full",
+              isUnread ? "bg-primary" : "bg-gray-200",
+            )}
+          />
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <p className="font-medium text-gray-900">{notification.title}</p>
+              <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500">
+                {config.label}
+              </span>
+            </div>
+            {notification.body && (
+              <p className="mt-1 line-clamp-2 text-sm text-gray-600">
+                {notification.body}
+              </p>
+            )}
+            <p className="mt-2 text-xs text-gray-400">
+              {formatNotificationTime(notification.createdAt)}
+            </p>
+          </div>
+        </div>
+      </Link>
+      <div className="absolute right-3 top-4 flex items-center gap-1">
+        {isUnread && (
+          <button
+            type="button"
+            onClick={handleMarkRead}
+            disabled={markRead.isPending}
+            className="rounded-full px-2 py-1 text-xs font-medium text-primary transition-colors hover:bg-primary/10 disabled:opacity-50"
+          >
+            읽음
+          </button>
+        )}
+        <ChevronRight className="size-4 text-gray-300" />
+      </div>
+    </div>
+  );
+}

--- a/components/notifications/NotificationSettingsClient.tsx
+++ b/components/notifications/NotificationSettingsClient.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  useNotificationPreferences,
+  useUpdateNotificationPreference,
+} from "@/hooks/use-notification-preferences";
+import {
+  NOTIFICATION_PREFERENCE_GROUP_LABELS,
+  type NotificationPreferenceView,
+} from "@/lib/notifications/defaults";
+import { cn } from "@/lib/utils/cn";
+
+export function NotificationSettingsClient() {
+  const { data: preferences = [], isLoading } = useNotificationPreferences();
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-16 rounded-2xl" />
+        <Skeleton className="h-32 rounded-2xl" />
+        <Skeleton className="h-32 rounded-2xl" />
+      </div>
+    );
+  }
+
+  const groups = preferences.reduce<
+    Partial<
+      Record<NotificationPreferenceView["group"], NotificationPreferenceView[]>
+    >
+  >((acc, preference) => {
+    acc[preference.group] = [...(acc[preference.group] ?? []), preference];
+    return acc;
+  }, {});
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <h1 className="text-xl font-semibold text-gray-900">알림 설정</h1>
+        <p className="mt-1 text-sm text-gray-500">
+          알림 종류별 앱 내 알림과 Push 수신 여부를 설정합니다.
+        </p>
+        <p className="mt-2 rounded-xl bg-gray-100 px-3 py-2 text-sm text-gray-500">
+          Push 발송은 이후 지원됩니다. 지금은 선호 설정만 저장합니다.
+        </p>
+      </div>
+
+      {Object.entries(NOTIFICATION_PREFERENCE_GROUP_LABELS).map(
+        ([group, label]) => {
+          const items =
+            groups[group as NotificationPreferenceView["group"]] ?? [];
+
+          if (items.length === 0) {
+            return null;
+          }
+
+          return (
+            <section key={group} className="space-y-2">
+              <h2 className="px-1 text-sm font-semibold text-gray-700">
+                {label}
+              </h2>
+              <div className="overflow-hidden rounded-2xl bg-white shadow-sm">
+                {items.map((preference, index) => (
+                  <PreferenceRow
+                    key={preference.type}
+                    preference={preference}
+                    showBorder={index > 0}
+                  />
+                ))}
+              </div>
+            </section>
+          );
+        },
+      )}
+    </div>
+  );
+}
+
+function PreferenceRow({
+  preference,
+  showBorder,
+}: {
+  preference: NotificationPreferenceView;
+  showBorder: boolean;
+}) {
+  const updatePreference = useUpdateNotificationPreference();
+
+  const handleToggle = (field: "inAppEnabled" | "pushEnabled") => {
+    updatePreference.mutate({
+      type: preference.type,
+      input: {
+        inAppEnabled:
+          field === "inAppEnabled"
+            ? !preference.inAppEnabled
+            : preference.inAppEnabled,
+        pushEnabled:
+          field === "pushEnabled"
+            ? !preference.pushEnabled
+            : preference.pushEnabled,
+      },
+    });
+  };
+
+  return (
+    <div
+      className={cn(
+        "flex items-start justify-between gap-4 p-4",
+        showBorder && "border-gray-100 border-t",
+      )}
+    >
+      <div className="min-w-0 flex-1">
+        <p className="font-medium text-gray-900">{preference.label}</p>
+        <p className="mt-1 text-sm text-gray-500">{preference.description}</p>
+      </div>
+      <div className="flex shrink-0 items-center gap-3">
+        <ToggleButton
+          label="앱"
+          enabled={preference.inAppEnabled}
+          disabled={updatePreference.isPending}
+          onClick={() => handleToggle("inAppEnabled")}
+        />
+        <ToggleButton
+          label="Push"
+          enabled={preference.pushEnabled}
+          disabled={updatePreference.isPending}
+          onClick={() => handleToggle("pushEnabled")}
+        />
+      </div>
+    </div>
+  );
+}
+
+function ToggleButton({
+  label,
+  enabled,
+  disabled,
+  onClick,
+}: {
+  label: string;
+  enabled: boolean;
+  disabled: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={enabled}
+      disabled={disabled}
+      onClick={onClick}
+      className={cn(
+        "inline-flex h-8 min-w-16 items-center justify-center gap-1.5 rounded-full px-3 text-xs font-semibold transition-colors disabled:opacity-60",
+        enabled ? "bg-primary text-white" : "bg-gray-100 text-gray-500",
+      )}
+    >
+      {disabled && <Loader2 className="size-3 animate-spin" />}
+      {label}
+    </button>
+  );
+}

--- a/components/notifications/index.ts
+++ b/components/notifications/index.ts
@@ -1,0 +1,3 @@
+export { NotificationBell } from "./NotificationBell";
+export { NotificationInboxClient } from "./NotificationInboxClient";
+export { NotificationSettingsClient } from "./NotificationSettingsClient";

--- a/components/settings/SettingsMenu.tsx
+++ b/components/settings/SettingsMenu.tsx
@@ -49,8 +49,8 @@ export function SettingsMenu() {
       <SettingsMenuItem
         icon={Bell}
         label="알림 설정"
+        description="앱 알림, Push 수신 여부 관리"
         href="/settings/notifications"
-        disabled
       />
 
       <SettingsMenuItem

--- a/components/transactions/records/StockRecordsClient.test.tsx
+++ b/components/transactions/records/StockRecordsClient.test.tsx
@@ -68,7 +68,7 @@ describe("StockRecordsClient", () => {
           totalPages: 1,
         },
         isLoading: false,
-      } as ReturnType<typeof useTransactions>)
+      } as unknown as ReturnType<typeof useTransactions>)
       .mockReturnValueOnce({
         data: {
           data: transactions,
@@ -78,7 +78,7 @@ describe("StockRecordsClient", () => {
           totalPages: 1,
         },
         isLoading: false,
-      } as ReturnType<typeof useTransactions>)
+      } as unknown as ReturnType<typeof useTransactions>)
       .mockReturnValueOnce({
         data: {
           data: [],
@@ -88,7 +88,7 @@ describe("StockRecordsClient", () => {
           totalPages: 1,
         },
         isLoading: false,
-      } as ReturnType<typeof useTransactions>);
+      } as unknown as ReturnType<typeof useTransactions>);
 
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },

--- a/constants/service-routes.ts
+++ b/constants/service-routes.ts
@@ -31,6 +31,7 @@ export const SERVICE_ROUTE_TREE = [
     href: "/home",
     label: "홈",
     mobile: "topLevel",
+    children: [{ href: "/notifications", label: "알림함" }],
   },
   {
     href: "/ledger",
@@ -183,6 +184,7 @@ export const SERVICE_ROUTE_TREE = [
     children: [
       { href: "/settings/household", label: "가구 관리" },
       { href: "/settings/mcp", label: "MCP 연결" },
+      { href: "/settings/notifications", label: "알림 설정" },
     ],
   },
 ] as const satisfies readonly ServiceRouteNode[];

--- a/hooks/use-notification-preferences.ts
+++ b/hooks/use-notification-preferences.ts
@@ -1,0 +1,110 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import type { NotificationPreferenceView } from "@/lib/notifications/defaults";
+import type {
+  NotificationPreferenceUpdate,
+  NotificationType,
+} from "@/lib/notifications/schema";
+import { queries } from "@/lib/queries/keys";
+
+interface ApiDataResponse<T> {
+  data: T;
+}
+
+interface ApiErrorResponse {
+  error?: {
+    message?: string;
+  };
+}
+
+async function readApiJson<T>(response: Response): Promise<T> {
+  const json = (await response.json()) as ApiDataResponse<T> | ApiErrorResponse;
+
+  if (!response.ok) {
+    throw new Error(
+      (json as ApiErrorResponse).error?.message ?? "요청에 실패했습니다.",
+    );
+  }
+
+  return (json as ApiDataResponse<T>).data;
+}
+
+async function fetchNotificationPreferences() {
+  const response = await fetch("/api/notification-preferences");
+  return readApiJson<NotificationPreferenceView[]>(response);
+}
+
+async function updateNotificationPreference({
+  type,
+  input,
+}: {
+  type: NotificationType;
+  input: NotificationPreferenceUpdate;
+}) {
+  const response = await fetch(`/api/notification-preferences/${type}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  return readApiJson<NotificationPreferenceView>(response);
+}
+
+export function useNotificationPreferences() {
+  return useQuery({
+    queryKey: queries.notifications.preferences.queryKey,
+    queryFn: fetchNotificationPreferences,
+  });
+}
+
+export function useUpdateNotificationPreference() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updateNotificationPreference,
+    onMutate: async ({ type, input }) => {
+      await queryClient.cancelQueries({
+        queryKey: queries.notifications.preferences.queryKey,
+      });
+      const previous = queryClient.getQueryData<NotificationPreferenceView[]>(
+        queries.notifications.preferences.queryKey,
+      );
+
+      queryClient.setQueryData<NotificationPreferenceView[]>(
+        queries.notifications.preferences.queryKey,
+        (current) =>
+          current?.map((preference) =>
+            preference.type === type
+              ? {
+                  ...preference,
+                  inAppEnabled: input.inAppEnabled,
+                  pushEnabled: input.pushEnabled,
+                }
+              : preference,
+          ) ?? current,
+      );
+
+      return { previous };
+    },
+    onError: (error, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(
+          queries.notifications.preferences.queryKey,
+          context.previous,
+        );
+      }
+
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "알림 설정 저장에 실패했습니다.",
+      );
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({
+        queryKey: queries.notifications.preferences.queryKey,
+      });
+    },
+  });
+}

--- a/hooks/use-notifications.ts
+++ b/hooks/use-notifications.ts
@@ -1,0 +1,159 @@
+"use client";
+
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { toast } from "sonner";
+import type {
+  NotificationItem,
+  NotificationListResult,
+} from "@/lib/api/notifications";
+import { queries } from "@/lib/queries/keys";
+
+interface ApiDataResponse<T> {
+  data: T;
+}
+
+interface ApiErrorResponse {
+  error?: {
+    message?: string;
+  };
+}
+
+async function readApiJson<T>(response: Response): Promise<T> {
+  const json = (await response.json()) as ApiDataResponse<T> | ApiErrorResponse;
+
+  if (!response.ok) {
+    throw new Error(
+      (json as ApiErrorResponse).error?.message ?? "요청에 실패했습니다.",
+    );
+  }
+
+  return (json as ApiDataResponse<T>).data;
+}
+
+async function fetchNotifications({
+  pageParam,
+  limit,
+}: {
+  pageParam?: string | null;
+  limit: number;
+}): Promise<NotificationListResult> {
+  const params = new URLSearchParams({ limit: String(limit) });
+  if (pageParam) {
+    params.set("cursor", pageParam);
+  }
+
+  const response = await fetch(`/api/notifications?${params.toString()}`);
+  return readApiJson<NotificationListResult>(response);
+}
+
+async function fetchUnreadNotificationCount(): Promise<number> {
+  const response = await fetch("/api/notifications/unread-count");
+  const data = await readApiJson<{ count: number }>(response);
+  return data.count;
+}
+
+async function markNotificationAsRead(id: string): Promise<NotificationItem> {
+  const response = await fetch(`/api/notifications/${id}/read`, {
+    method: "PATCH",
+  });
+  return readApiJson<NotificationItem>(response);
+}
+
+async function markAllNotificationsAsRead(): Promise<{ count: number }> {
+  const response = await fetch("/api/notifications/read-all", {
+    method: "POST",
+  });
+  return readApiJson<{ count: number }>(response);
+}
+
+export function useNotifications(limit = 20) {
+  return useInfiniteQuery({
+    queryKey: queries.notifications.list({ limit }).queryKey,
+    queryFn: ({ pageParam }) => fetchNotifications({ pageParam, limit }),
+    initialPageParam: null as string | null,
+    getNextPageParam: (lastPage) => lastPage.nextCursor,
+  });
+}
+
+export function useUnreadNotificationCount() {
+  return useQuery({
+    queryKey: queries.notifications.unreadCount.queryKey,
+    queryFn: fetchUnreadNotificationCount,
+    staleTime: 1000 * 30,
+  });
+}
+
+export function useMarkNotificationAsRead() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: markNotificationAsRead,
+    onMutate: async (id) => {
+      await queryClient.cancelQueries({ queryKey: queries.notifications._def });
+
+      const previousCount = queryClient.getQueryData<number>(
+        queries.notifications.unreadCount.queryKey,
+      );
+
+      queryClient.setQueryData<number>(
+        queries.notifications.unreadCount.queryKey,
+        (count) => Math.max((count ?? 0) - 1, 0),
+      );
+
+      return { previousCount, id };
+    },
+    onError: (error, _id, context) => {
+      if (context?.previousCount !== undefined) {
+        queryClient.setQueryData(
+          queries.notifications.unreadCount.queryKey,
+          context.previousCount,
+        );
+      }
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "알림 읽음 처리에 실패했습니다.",
+      );
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: queries.notifications._def });
+    },
+  });
+}
+
+export function useMarkAllNotificationsAsRead() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: markAllNotificationsAsRead,
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: queries.notifications._def });
+      const previousCount = queryClient.getQueryData<number>(
+        queries.notifications.unreadCount.queryKey,
+      );
+      queryClient.setQueryData(queries.notifications.unreadCount.queryKey, 0);
+      return { previousCount };
+    },
+    onError: (error, _variables, context) => {
+      if (context?.previousCount !== undefined) {
+        queryClient.setQueryData(
+          queries.notifications.unreadCount.queryKey,
+          context.previousCount,
+        );
+      }
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "전체 읽음 처리에 실패했습니다.",
+      );
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: queries.notifications._def });
+    },
+  });
+}

--- a/lib/api/notifications.ts
+++ b/lib/api/notifications.ts
@@ -1,0 +1,343 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { APIError } from "@/lib/api/error";
+import {
+  getDefaultNotificationPreference,
+  NOTIFICATION_TYPE_CONFIG,
+  type NotificationPreferenceView,
+} from "@/lib/notifications/defaults";
+import {
+  type NotificationLink,
+  type NotificationType,
+  normalizeNotificationLink,
+  notificationSourceTypeSchema,
+  notificationTypeSchema,
+} from "@/lib/notifications/schema";
+import { createAdminClient } from "@/lib/supabase/admin";
+import type {
+  Database,
+  Json,
+  Notification,
+  NotificationPreference,
+} from "@/types";
+
+export interface NotificationItem {
+  id: string;
+  type: NotificationType;
+  title: string;
+  body: string | null;
+  householdId: string | null;
+  linkKind: Notification["link_kind"];
+  linkParams: Json;
+  sourceType: string | null;
+  sourceId: string | null;
+  readAt: string | null;
+  createdAt: string;
+}
+
+export interface NotificationListResult {
+  items: NotificationItem[];
+  nextCursor: string | null;
+}
+
+export interface CreateUserNotificationInput {
+  recipientId: string;
+  type: NotificationType;
+  title: string;
+  body?: string | null;
+  householdId?: string | null;
+  link?: NotificationLink | null;
+  source?: {
+    type: string;
+    id: string;
+  } | null;
+  dedupeKey?: string | null;
+}
+
+interface NotificationCursor {
+  createdAt: string;
+  id: string;
+}
+
+const DEFAULT_NOTIFICATION_LIMIT = 20;
+const MAX_NOTIFICATION_LIMIT = 50;
+
+function encodeCursor(cursor: NotificationCursor): string {
+  return Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url");
+}
+
+export function decodeNotificationCursor(
+  cursor: string | null,
+): NotificationCursor | null {
+  if (!cursor) {
+    return null;
+  }
+
+  try {
+    const raw = Buffer.from(cursor, "base64url").toString("utf8");
+    const parsed = JSON.parse(raw) as Partial<NotificationCursor>;
+    if (typeof parsed.createdAt !== "string" || typeof parsed.id !== "string") {
+      return null;
+    }
+    return { createdAt: parsed.createdAt, id: parsed.id };
+  } catch {
+    return null;
+  }
+}
+
+export function normalizeNotificationLimit(limitParam: string | null): number {
+  const parsed = limitParam ? Number(limitParam) : DEFAULT_NOTIFICATION_LIMIT;
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_NOTIFICATION_LIMIT;
+  }
+  return Math.min(Math.floor(parsed), MAX_NOTIFICATION_LIMIT);
+}
+
+function mapNotification(row: Notification): NotificationItem {
+  return {
+    id: row.id,
+    type: row.type,
+    title: row.title,
+    body: row.body,
+    householdId: row.household_id,
+    linkKind: row.link_kind,
+    linkParams: row.link_params,
+    sourceType: row.source_type,
+    sourceId: row.source_id,
+    readAt: row.read_at,
+    createdAt: row.created_at,
+  };
+}
+
+export async function getNotifications(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+  options: {
+    limit: number;
+    cursor: NotificationCursor | null;
+  },
+): Promise<NotificationListResult> {
+  let query = supabase
+    .from("notifications")
+    .select("*")
+    .eq("recipient_id", userId)
+    .order("created_at", { ascending: false })
+    .order("id", { ascending: false })
+    .limit(options.limit + 1);
+
+  if (options.cursor) {
+    query = query.or(
+      `created_at.lt.${options.cursor.createdAt},and(created_at.eq.${options.cursor.createdAt},id.lt.${options.cursor.id})`,
+    );
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    throw error;
+  }
+
+  const rows = data ?? [];
+  const pageRows = rows.slice(0, options.limit);
+  const nextRow = rows.length > options.limit ? pageRows.at(-1) : null;
+
+  return {
+    items: pageRows.map(mapNotification),
+    nextCursor: nextRow
+      ? encodeCursor({ createdAt: nextRow.created_at, id: nextRow.id })
+      : null,
+  };
+}
+
+export async function getUnreadNotificationCount(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+): Promise<number> {
+  const { count, error } = await supabase
+    .from("notifications")
+    .select("id", { count: "exact", head: true })
+    .eq("recipient_id", userId)
+    .is("read_at", null);
+
+  if (error) {
+    throw error;
+  }
+
+  return count ?? 0;
+}
+
+export async function markNotificationAsRead(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+  id: string,
+): Promise<NotificationItem> {
+  const { data, error } = await supabase
+    .from("notifications")
+    .update({ read_at: new Date().toISOString() })
+    .eq("id", id)
+    .eq("recipient_id", userId)
+    .select()
+    .single();
+
+  if (error) {
+    throw error;
+  }
+
+  return mapNotification(data);
+}
+
+export async function markAllNotificationsAsRead(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+): Promise<number> {
+  const { data, error } = await supabase
+    .from("notifications")
+    .update({ read_at: new Date().toISOString() })
+    .eq("recipient_id", userId)
+    .is("read_at", null)
+    .select("id");
+
+  if (error) {
+    throw error;
+  }
+
+  return data?.length ?? 0;
+}
+
+export async function getNotificationPreferences(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+): Promise<NotificationPreferenceView[]> {
+  const { data, error } = await supabase
+    .from("notification_preferences")
+    .select("*")
+    .eq("user_id", userId);
+
+  if (error) {
+    throw error;
+  }
+
+  const overrides = new Map<NotificationType, NotificationPreference>();
+  for (const row of data ?? []) {
+    overrides.set(row.type, row);
+  }
+
+  return notificationTypeSchema.options.map((type) => {
+    const config = NOTIFICATION_TYPE_CONFIG[type];
+    const override = overrides.get(type);
+    return {
+      type,
+      label: config.label,
+      description: config.description,
+      group: config.group,
+      inAppEnabled: override?.in_app_enabled ?? config.defaults.inAppEnabled,
+      pushEnabled: override?.push_enabled ?? config.defaults.pushEnabled,
+      defaults: config.defaults,
+    };
+  });
+}
+
+export async function upsertNotificationPreference(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+  type: NotificationType,
+  input: {
+    inAppEnabled: boolean;
+    pushEnabled: boolean;
+  },
+): Promise<NotificationPreferenceView> {
+  const { error } = await supabase.from("notification_preferences").upsert(
+    {
+      user_id: userId,
+      type,
+      in_app_enabled: input.inAppEnabled,
+      push_enabled: input.pushEnabled,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: "user_id,type" },
+  );
+
+  if (error) {
+    throw error;
+  }
+
+  const config = NOTIFICATION_TYPE_CONFIG[type];
+  return {
+    type,
+    label: config.label,
+    description: config.description,
+    group: config.group,
+    inAppEnabled: input.inAppEnabled,
+    pushEnabled: input.pushEnabled,
+    defaults: config.defaults,
+  };
+}
+
+export async function createUserNotification(
+  input: CreateUserNotificationInput,
+): Promise<NotificationItem | null> {
+  const type = notificationTypeSchema.parse(input.type);
+  const admin = createAdminClient();
+  const defaults = getDefaultNotificationPreference(type);
+
+  const { data: preference, error: preferenceError } = await admin
+    .from("notification_preferences")
+    .select("*")
+    .eq("user_id", input.recipientId)
+    .eq("type", type)
+    .maybeSingle();
+
+  if (preferenceError) {
+    throw preferenceError;
+  }
+
+  const inAppEnabled = preference?.in_app_enabled ?? defaults.inAppEnabled;
+  if (!inAppEnabled) {
+    return null;
+  }
+
+  const link = normalizeNotificationLink(input.link);
+  const source = input.source
+    ? {
+        type: notificationSourceTypeSchema.parse(input.source.type),
+        id: input.source.id,
+      }
+    : null;
+
+  const { data, error } = await admin
+    .from("notifications")
+    .insert({
+      recipient_id: input.recipientId,
+      household_id: input.householdId ?? null,
+      type,
+      title: input.title,
+      body: input.body ?? null,
+      link_kind: link.linkKind,
+      link_params: link.linkParams as Json,
+      source_type: source?.type ?? null,
+      source_id: source?.id ?? null,
+      dedupe_key: input.dedupeKey ?? null,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    if (error.code === "23505" && input.dedupeKey) {
+      return null;
+    }
+    throw error;
+  }
+
+  return mapNotification(data);
+}
+
+export function assertKnownNotificationType(type: string): NotificationType {
+  const parsed = notificationTypeSchema.safeParse(type);
+  if (!parsed.success) {
+    throw new APIError(
+      "NOTIFICATION_TYPE_INVALID",
+      "알 수 없는 알림 종류입니다.",
+      400,
+    );
+  }
+  return parsed.data;
+}

--- a/lib/notifications/defaults.ts
+++ b/lib/notifications/defaults.ts
@@ -1,0 +1,93 @@
+import type { NotificationType } from "./schema";
+
+export interface NotificationPreferenceView {
+  type: NotificationType;
+  label: string;
+  description: string;
+  group: "requests" | "results" | "changes" | "newRecords" | "household";
+  inAppEnabled: boolean;
+  pushEnabled: boolean;
+  defaults: {
+    inAppEnabled: boolean;
+    pushEnabled: boolean;
+  };
+}
+
+interface NotificationTypeConfig {
+  label: string;
+  description: string;
+  group: NotificationPreferenceView["group"];
+  defaults: {
+    inAppEnabled: boolean;
+    pushEnabled: boolean;
+  };
+}
+
+export const NOTIFICATION_TYPE_CONFIG = {
+  ledger_record_change_request: {
+    label: "가계부 수정/삭제 요청",
+    description: "공용 가계부 기록에 대한 수정 또는 삭제 요청",
+    group: "requests",
+    defaults: { inAppEnabled: true, pushEnabled: false },
+  },
+  stock_transaction_change_request: {
+    label: "주식 거래 수정/삭제 요청",
+    description: "주식 거래 기록에 대한 수정 또는 삭제 요청",
+    group: "requests",
+    defaults: { inAppEnabled: true, pushEnabled: false },
+  },
+  ledger_request_result: {
+    label: "가계부 요청 처리 결과",
+    description: "가계부 기록 요청의 승인 또는 거절 결과",
+    group: "results",
+    defaults: { inAppEnabled: true, pushEnabled: false },
+  },
+  stock_transaction_request_result: {
+    label: "주식 요청 처리 결과",
+    description: "주식 거래 요청의 승인 또는 거절 결과",
+    group: "results",
+    defaults: { inAppEnabled: true, pushEnabled: false },
+  },
+  ledger_record_changed: {
+    label: "가계부 기록 수정/삭제",
+    description: "함께 보는 가계부 기록이 수정되거나 삭제됨",
+    group: "changes",
+    defaults: { inAppEnabled: true, pushEnabled: false },
+  },
+  stock_transaction_changed: {
+    label: "주식 거래 수정/삭제",
+    description: "함께 보는 주식 거래 기록이 수정되거나 삭제됨",
+    group: "changes",
+    defaults: { inAppEnabled: true, pushEnabled: false },
+  },
+  ledger_record_created: {
+    label: "새 공용 가계부 기록",
+    description: "가구 구성원이 새 공용 가계부 기록을 추가함",
+    group: "newRecords",
+    defaults: { inAppEnabled: false, pushEnabled: false },
+  },
+  stock_transaction_created: {
+    label: "새 주식 거래",
+    description: "가구 구성원이 새 주식 거래 기록을 추가함",
+    group: "newRecords",
+    defaults: { inAppEnabled: false, pushEnabled: false },
+  },
+  invitation_accepted: {
+    label: "초대 수락",
+    description: "초대받은 사용자가 가구에 합류함",
+    group: "household",
+    defaults: { inAppEnabled: true, pushEnabled: false },
+  },
+} as const satisfies Record<NotificationType, NotificationTypeConfig>;
+
+export const NOTIFICATION_PREFERENCE_GROUP_LABELS = {
+  requests: "협업 요청",
+  results: "요청 처리 결과",
+  changes: "공유 기록 변경",
+  newRecords: "새 공유 기록 추가",
+  household: "가구",
+} as const satisfies Record<NotificationPreferenceView["group"], string>;
+
+export function getDefaultNotificationPreference(type: NotificationType) {
+  return NOTIFICATION_TYPE_CONFIG[type].defaults;
+}

--- a/lib/notifications/links.ts
+++ b/lib/notifications/links.ts
@@ -1,0 +1,46 @@
+import type { NotificationLink, NotificationLinkKind } from "./schema";
+
+interface NotificationLinkParts {
+  linkKind: NotificationLinkKind | null;
+  linkParams: unknown;
+}
+
+function getParamObject(params: unknown): Record<string, unknown> {
+  if (!params || typeof params !== "object" || Array.isArray(params)) {
+    return {};
+  }
+
+  return params as Record<string, unknown>;
+}
+
+export function buildNotificationHref(link: NotificationLinkParts): string {
+  const params = getParamObject(link.linkParams);
+
+  switch (link.linkKind) {
+    case "ledger_record_date":
+      return typeof params.date === "string"
+        ? `/ledger/records?date=${encodeURIComponent(params.date)}`
+        : "/ledger/records";
+    case "stock_record_date":
+      return typeof params.date === "string"
+        ? `/assets/stock/records?date=${encodeURIComponent(params.date)}`
+        : "/assets/stock/records";
+    case "record_change_request_detail":
+      return typeof params.requestId === "string"
+        ? `/notifications/requests/${encodeURIComponent(params.requestId)}`
+        : "/notifications";
+    case "household_settings":
+      return "/settings/household";
+    case "notification_settings":
+      return "/settings/notifications";
+    default:
+      return "/notifications";
+  }
+}
+
+export function toNotificationLinkParts(link?: NotificationLink | null) {
+  return {
+    linkKind: link?.kind ?? null,
+    linkParams: link?.params ?? {},
+  };
+}

--- a/lib/notifications/schema.ts
+++ b/lib/notifications/schema.ts
@@ -1,0 +1,86 @@
+import { z } from "zod";
+
+export const notificationTypeSchema = z.enum([
+  "ledger_record_change_request",
+  "stock_transaction_change_request",
+  "ledger_request_result",
+  "stock_transaction_request_result",
+  "ledger_record_changed",
+  "stock_transaction_changed",
+  "ledger_record_created",
+  "stock_transaction_created",
+  "invitation_accepted",
+]);
+
+export type NotificationType = z.infer<typeof notificationTypeSchema>;
+
+export const notificationTypes = notificationTypeSchema.options;
+
+export const notificationSourceTypeSchema = z.enum([
+  "ledger_entry",
+  "stock_transaction",
+  "record_change_request",
+  "invitation",
+]);
+
+export type NotificationSourceType = z.infer<
+  typeof notificationSourceTypeSchema
+>;
+
+export const notificationLinkSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("ledger_record_date"),
+    params: z.object({ date: z.iso.date() }),
+  }),
+  z.object({
+    kind: z.literal("stock_record_date"),
+    params: z.object({ date: z.iso.date() }),
+  }),
+  z.object({
+    kind: z.literal("record_change_request_detail"),
+    params: z.object({ requestId: z.uuid() }),
+  }),
+  z.object({
+    kind: z.literal("household_settings"),
+    params: z.object({}).optional(),
+  }),
+  z.object({
+    kind: z.literal("notification_settings"),
+    params: z.object({}).optional(),
+  }),
+]);
+
+export type NotificationLink = z.infer<typeof notificationLinkSchema>;
+export type NotificationLinkKind = NotificationLink["kind"];
+
+export const notificationLinkKindSchema = z.enum([
+  "ledger_record_date",
+  "stock_record_date",
+  "record_change_request_detail",
+  "household_settings",
+  "notification_settings",
+]);
+
+export const notificationPreferenceUpdateSchema = z.object({
+  inAppEnabled: z.boolean(),
+  pushEnabled: z.boolean(),
+});
+
+export type NotificationPreferenceUpdate = z.infer<
+  typeof notificationPreferenceUpdateSchema
+>;
+
+export function normalizeNotificationLink(link?: NotificationLink | null): {
+  linkKind: NotificationLinkKind | null;
+  linkParams: Record<string, unknown>;
+} {
+  if (!link) {
+    return { linkKind: null, linkParams: {} };
+  }
+
+  const parsed = notificationLinkSchema.parse(link);
+  return {
+    linkKind: parsed.kind,
+    linkParams: parsed.params ?? {},
+  };
+}

--- a/lib/queries/keys.ts
+++ b/lib/queries/keys.ts
@@ -92,6 +92,13 @@ export const queries = createQueryKeyStore({
     holiday: null,
   },
 
+  notifications: {
+    all: null,
+    list: (params?: { limit?: number }) => ({ queryKey: [params] }),
+    unreadCount: null,
+    preferences: null,
+  },
+
   categories: {
     all: null,
     list: (type?: "expense" | "income") => ({ queryKey: [type] }),

--- a/supabase/migrations/20260601000000_create_notifications.sql
+++ b/supabase/migrations/20260601000000_create_notifications.sql
@@ -1,0 +1,92 @@
+-- User Notification foundation
+
+create type notification_type as enum (
+  'ledger_record_change_request',
+  'stock_transaction_change_request',
+  'ledger_request_result',
+  'stock_transaction_request_result',
+  'ledger_record_changed',
+  'stock_transaction_changed',
+  'ledger_record_created',
+  'stock_transaction_created',
+  'invitation_accepted'
+);
+
+create type notification_link_kind as enum (
+  'ledger_record_date',
+  'stock_record_date',
+  'record_change_request_detail',
+  'household_settings',
+  'notification_settings'
+);
+
+create table public.notifications (
+  id            uuid primary key default gen_random_uuid(),
+  recipient_id  uuid not null references public.profiles(id) on delete cascade,
+  household_id  uuid references public.households(id) on delete cascade,
+  type          notification_type not null,
+  title         text not null,
+  body          text,
+  link_kind     notification_link_kind,
+  link_params   jsonb not null default '{}'::jsonb,
+  source_type   text,
+  source_id     uuid,
+  dedupe_key    text,
+  read_at       timestamptz,
+  created_at    timestamptz not null default now(),
+
+  constraint notifications_source_pair_check check (
+    (source_type is null and source_id is null)
+    or (source_type is not null and source_id is not null)
+  ),
+  constraint notifications_link_params_object_check check (
+    jsonb_typeof(link_params) = 'object'
+  )
+);
+
+create index notifications_recipient_created_at_idx
+  on public.notifications(recipient_id, created_at desc, id desc);
+
+create index notifications_recipient_unread_idx
+  on public.notifications(recipient_id)
+  where read_at is null;
+
+create unique index notifications_recipient_dedupe_key_unique
+  on public.notifications(recipient_id, dedupe_key)
+  where dedupe_key is not null;
+
+alter table public.notifications enable row level security;
+
+create policy "Users can view own notifications"
+  on public.notifications for select
+  using (recipient_id = (select auth.uid()));
+
+create policy "Users can mark own notifications as read"
+  on public.notifications for update
+  using (recipient_id = (select auth.uid()))
+  with check (recipient_id = (select auth.uid()));
+
+create table public.notification_preferences (
+  user_id        uuid not null references public.profiles(id) on delete cascade,
+  type           notification_type not null,
+  in_app_enabled boolean not null,
+  push_enabled   boolean not null,
+  created_at     timestamptz not null default now(),
+  updated_at     timestamptz not null default now(),
+  primary key (user_id, type)
+);
+
+alter table public.notification_preferences enable row level security;
+
+create policy "Users can view own notification preferences"
+  on public.notification_preferences for select
+  using (user_id = (select auth.uid()));
+
+create policy "Users can upsert own notification preferences"
+  on public.notification_preferences for insert
+  with check (user_id = (select auth.uid()));
+
+create policy "Users can update own notification preferences"
+  on public.notification_preferences for update
+  using (user_id = (select auth.uid()))
+  with check (user_id = (select auth.uid()));

--- a/types/index.ts
+++ b/types/index.ts
@@ -26,6 +26,8 @@ export type UserRole = Enums<"user_role">;
 export type AllocationCategory = Enums<"allocation_category">;
 export type LedgerEntryType = Enums<"ledger_entry_type">;
 export type CategoryType = Enums<"category_type">;
+export type NotificationType = Enums<"notification_type">;
+export type NotificationLinkKind = Enums<"notification_link_kind">;
 
 // 테이블 Row 타입 (편의를 위해)
 export type Account = Tables<"accounts">;
@@ -43,6 +45,8 @@ export type HoldingTag = Tables<"holding_tags">;
 export type TargetAllocation = Tables<"target_allocations">;
 export type McpToken = Tables<"mcp_tokens">;
 export type McpAuditLog = Tables<"mcp_audit_logs">;
+export type Notification = Tables<"notifications">;
+export type NotificationPreference = Tables<"notification_preferences">;
 
 // 가계부 테이블 타입
 export type LedgerEntry = Tables<"ledger_entries">;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -568,6 +568,110 @@ export type Database = {
           },
         ];
       };
+      notification_preferences: {
+        Row: {
+          created_at: string;
+          in_app_enabled: boolean;
+          push_enabled: boolean;
+          type: Database["public"]["Enums"]["notification_type"];
+          updated_at: string;
+          user_id: string;
+        };
+        Insert: {
+          created_at?: string;
+          in_app_enabled: boolean;
+          push_enabled: boolean;
+          type: Database["public"]["Enums"]["notification_type"];
+          updated_at?: string;
+          user_id: string;
+        };
+        Update: {
+          created_at?: string;
+          in_app_enabled?: boolean;
+          push_enabled?: boolean;
+          type?: Database["public"]["Enums"]["notification_type"];
+          updated_at?: string;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "notification_preferences_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      notifications: {
+        Row: {
+          body: string | null;
+          created_at: string;
+          dedupe_key: string | null;
+          household_id: string | null;
+          id: string;
+          link_kind:
+            | Database["public"]["Enums"]["notification_link_kind"]
+            | null;
+          link_params: Json;
+          read_at: string | null;
+          recipient_id: string;
+          source_id: string | null;
+          source_type: string | null;
+          title: string;
+          type: Database["public"]["Enums"]["notification_type"];
+        };
+        Insert: {
+          body?: string | null;
+          created_at?: string;
+          dedupe_key?: string | null;
+          household_id?: string | null;
+          id?: string;
+          link_kind?:
+            | Database["public"]["Enums"]["notification_link_kind"]
+            | null;
+          link_params?: Json;
+          read_at?: string | null;
+          recipient_id: string;
+          source_id?: string | null;
+          source_type?: string | null;
+          title: string;
+          type: Database["public"]["Enums"]["notification_type"];
+        };
+        Update: {
+          body?: string | null;
+          created_at?: string;
+          dedupe_key?: string | null;
+          household_id?: string | null;
+          id?: string;
+          link_kind?:
+            | Database["public"]["Enums"]["notification_link_kind"]
+            | null;
+          link_params?: Json;
+          read_at?: string | null;
+          recipient_id?: string;
+          source_id?: string | null;
+          source_type?: string | null;
+          title?: string;
+          type?: Database["public"]["Enums"]["notification_type"];
+        };
+        Relationships: [
+          {
+            foreignKeyName: "notifications_household_id_fkey";
+            columns: ["household_id"];
+            isOneToOne: false;
+            referencedRelation: "households";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "notifications_recipient_id_fkey";
+            columns: ["recipient_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
       payment_methods: {
         Row: {
           balance: number | null;
@@ -1030,6 +1134,22 @@ export type Database = {
       invitation_status: "pending" | "accepted" | "expired" | "cancelled";
       ledger_entry_type: "expense" | "income" | "transfer";
       market_type: "KR" | "US" | "OTHER";
+      notification_link_kind:
+        | "ledger_record_date"
+        | "stock_record_date"
+        | "record_change_request_detail"
+        | "household_settings"
+        | "notification_settings";
+      notification_type:
+        | "ledger_record_change_request"
+        | "stock_transaction_change_request"
+        | "ledger_request_result"
+        | "stock_transaction_request_result"
+        | "ledger_record_changed"
+        | "stock_transaction_changed"
+        | "ledger_record_created"
+        | "stock_transaction_created"
+        | "invitation_accepted";
       payment_method_type:
         | "credit_card"
         | "debit_card"
@@ -1216,6 +1336,24 @@ export const Constants = {
       invitation_status: ["pending", "accepted", "expired", "cancelled"],
       ledger_entry_type: ["expense", "income", "transfer"],
       market_type: ["KR", "US", "OTHER"],
+      notification_link_kind: [
+        "ledger_record_date",
+        "stock_record_date",
+        "record_change_request_detail",
+        "household_settings",
+        "notification_settings",
+      ],
+      notification_type: [
+        "ledger_record_change_request",
+        "stock_transaction_change_request",
+        "ledger_request_result",
+        "stock_transaction_request_result",
+        "ledger_record_changed",
+        "stock_transaction_changed",
+        "ledger_record_created",
+        "stock_transaction_created",
+        "invitation_accepted",
+      ],
       payment_method_type: [
         "credit_card",
         "debit_card",


### PR DESCRIPTION
## Summary

- Adds the #342 notification foundation schema with recipient-scoped notifications, preferences, link metadata, source metadata, dedupe keys, and RLS.
- Adds notification and notification preference API routes plus shared Zod/type utilities.
- Adds the notification inbox, notification settings page, header unread badge, and optimistic read/preference updates.

## Notes

- Push preferences are saved now, but actual push delivery remains a follow-up scope.
- types/supabase.ts was regenerated after supabase db reset and pnpm supabase:types.

## Validation

- supabase db reset
- pnpm supabase:types
- pnpm type-check
- pnpm build