### PR TITLE
fix: #353 레이아웃 버그 수정 및 거래 기록 수정 다이얼로그 모바일 전체화면 Drawer 전환

### DIFF
--- a/app/(main)/assets/stock/transactions/new/full/page.tsx
+++ b/app/(main)/assets/stock/transactions/new/full/page.tsx
@@ -1,11 +1,8 @@
 import { Suspense } from "react";
 import { PageContainer } from "@/components/layout";
 import { MultiTransactionFormWrapper } from "@/components/transactions/MultiTransactionFormWrapper";
-import { formatKst, getKstToday } from "@/lib/date";
 
 export default function NewStockTransactionFullPage() {
-  const today = getKstToday();
-
   return (
     <PageContainer maxWidth="narrow">
       <Suspense
@@ -18,7 +15,7 @@ export default function NewStockTransactionFullPage() {
           </div>
         }
       >
-        <MultiTransactionFormWrapper defaultDate={today} />
+        <MultiTransactionFormWrapper />
       </Suspense>
     </PageContainer>
   );

--- a/app/(main)/ledger/records/new/full/page.tsx
+++ b/app/(main)/ledger/records/new/full/page.tsx
@@ -1,11 +1,8 @@
 import { Suspense } from "react";
 import { PageContainer } from "@/components/layout";
 import { LedgerEntryComposer } from "@/components/ledger/entry-composer/LedgerEntryComposer";
-import { formatKst, getKstToday } from "@/lib/date";
 
 export default function FullLedgerEntryPage() {
-  const today = getKstToday();
-
   return (
     <PageContainer maxWidth="narrow">
       <Suspense
@@ -18,7 +15,7 @@ export default function FullLedgerEntryPage() {
           </div>
         }
       >
-        <LedgerEntryComposer mode="full" defaultDate={today} />
+        <LedgerEntryComposer mode="full" />
       </Suspense>
     </PageContainer>
   );

--- a/components/ledger/LedgerEntryEditDialog.tsx
+++ b/components/ledger/LedgerEntryEditDialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { InfoIcon } from "lucide-react";
+import { InfoIcon, XIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
@@ -269,19 +269,38 @@ export function LedgerEntryEditDialog({
 
     return (
       <Drawer open={open} onOpenChange={onOpenChange}>
-        <DrawerContent>
-          <DrawerHeader>
-            <DrawerTitle>이체 기록</DrawerTitle>
-            <DrawerDescription asChild>{descriptionContent}</DrawerDescription>
-          </DrawerHeader>
+        <DrawerContent
+          className="h-[100dvh] max-h-[100dvh] rounded-none border-t-0 p-0 flex flex-col data-[vaul-drawer-direction=bottom]:mt-0 data-[vaul-drawer-direction=bottom]:max-h-[100dvh] data-[vaul-drawer-direction=bottom]:rounded-none data-[vaul-drawer-direction=bottom]:border-t-0"
+          showHandle={false}
+          onOpenAutoFocus={(event) => event.preventDefault()}
+        >
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => onOpenChange(false)}
+            className="absolute right-2 top-2 z-10 inline-flex size-11 items-center justify-center rounded-full text-gray-700 transition-colors hover:bg-gray-100"
+          >
+            <XIcon className="size-5" />
+          </Button>
 
-          <div className="px-4">{transferEditNotice}</div>
+          <div className="flex-1 overflow-y-auto px-4 pt-16 space-y-4">
+            <div className="space-y-1">
+              <h3 className="text-lg font-bold text-gray-900">이체 기록</h3>
+              <div className="text-sm text-gray-500">{descriptionContent}</div>
+            </div>
 
-          <DrawerFooter>
-            <Button type="button" onClick={() => onOpenChange(false)}>
-              확인
-            </Button>
-          </DrawerFooter>
+            <div className="py-2">{transferEditNotice}</div>
+
+            <div className="pt-4 pb-[calc(1rem+env(safe-area-inset-bottom))]">
+              <Button
+                type="button"
+                onClick={() => onOpenChange(false)}
+                className="w-full h-12 rounded-xl text-base font-semibold"
+              >
+                확인
+              </Button>
+            </div>
+          </div>
         </DrawerContent>
       </Drawer>
     );
@@ -446,12 +465,100 @@ export function LedgerEntryEditDialog({
     );
   }
 
-  // 모바일: Drawer (Bottom Sheet)
+  // 모바일: 전체 화면 Drawer
   return (
-    <Drawer open={open} onOpenChange={handleDrawerOpenChange}>
-      <DrawerContent>
-        {mobileView === "moneySourcePicker" ? (
-          <div className="flex min-h-[70vh] flex-col pb-4">
+    <>
+      <Drawer open={open} onOpenChange={onOpenChange}>
+        <DrawerContent
+          className="h-[100dvh] max-h-[100dvh] rounded-none border-t-0 p-0 flex flex-col data-[vaul-drawer-direction=bottom]:mt-0 data-[vaul-drawer-direction=bottom]:max-h-[100dvh] data-[vaul-drawer-direction=bottom]:rounded-none data-[vaul-drawer-direction=bottom]:border-t-0"
+          showHandle={false}
+          onOpenAutoFocus={(event) => event.preventDefault()}
+        >
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => onOpenChange(false)}
+            className="absolute right-2 top-2 z-10 inline-flex size-11 items-center justify-center rounded-full text-gray-700 transition-colors hover:bg-gray-100"
+          >
+            <XIcon className="size-5" />
+          </Button>
+
+          <div className="flex-1 overflow-y-auto px-4 pt-16 space-y-4">
+            <div className="space-y-1">
+              <h3 className="text-lg font-bold text-gray-900">기록 수정</h3>
+              <div className="text-sm text-gray-500">{descriptionContent}</div>
+            </div>
+
+            <form
+              id="ledger-entry-edit-form"
+              onSubmit={handleSubmit(onSubmit)}
+              className="space-y-4 pb-[calc(1rem+env(safe-area-inset-bottom))]"
+            >
+              {infoBanner}
+              {formFields}
+
+              <div className="flex gap-2 pt-4">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => onOpenChange(false)}
+                  disabled={isSubmitting}
+                  className="flex-1 h-12 rounded-xl text-base font-semibold"
+                >
+                  취소
+                </Button>
+                <Button
+                  type="submit"
+                  disabled={isSubmitting}
+                  className="flex-1 h-12 rounded-xl text-base font-semibold"
+                >
+                  {isSubmitting ? "저장 중..." : "저장"}
+                </Button>
+              </div>
+            </form>
+          </div>
+        </DrawerContent>
+      </Drawer>
+
+      {/* 카테고리 선택 중첩 Drawer */}
+      <Drawer
+        open={open && mobileView === "categoryPicker"}
+        onOpenChange={(op) => {
+          if (!op) setMobileView("form");
+        }}
+      >
+        <DrawerContent
+          className="h-[85dvh] max-h-[85dvh] p-0 flex flex-col data-[vaul-drawer-direction=bottom]:mt-0 data-[vaul-drawer-direction=bottom]:max-h-[85dvh]"
+          onOpenAutoFocus={(event) => event.preventDefault()}
+        >
+          <div className="flex h-full flex-col pb-4">
+            <LedgerCategoryPickerPanel
+              value={watchCategoryId ?? ""}
+              categories={categories}
+              title="카테고리 선택"
+              searchPlaceholder="카테고리 이름 검색"
+              onBack={() => setMobileView("form")}
+              onValueChange={(v) => {
+                setValue("categoryId", v, { shouldValidate: true });
+                setMobileView("form");
+              }}
+            />
+          </div>
+        </DrawerContent>
+      </Drawer>
+
+      {/* 결제 방법 선택 중첩 Drawer */}
+      <Drawer
+        open={open && mobileView === "moneySourcePicker"}
+        onOpenChange={(op) => {
+          if (!op) setMobileView("form");
+        }}
+      >
+        <DrawerContent
+          className="h-[85dvh] max-h-[85dvh] p-0 flex flex-col data-[vaul-drawer-direction=bottom]:mt-0 data-[vaul-drawer-direction=bottom]:max-h-[85dvh]"
+          onOpenAutoFocus={(event) => event.preventDefault()}
+        >
+          <div className="flex h-full flex-col pb-4">
             <LedgerMoneySourcePickerPanel
               mode={moneySourceMode}
               value={paymentValue}
@@ -465,64 +572,8 @@ export function LedgerEntryEditDialog({
               onValueChange={handleMobileMoneySourceChange}
             />
           </div>
-        ) : mobileView === "categoryPicker" ? (
-          <div className="flex min-h-[70vh] flex-col pb-4">
-            <LedgerCategoryPickerPanel
-              value={watchCategoryId ?? ""}
-              categories={categories}
-              title="카테고리 선택"
-              searchPlaceholder="카테고리 이름 검색"
-              onBack={() => setMobileView("form")}
-              onValueChange={(v) => {
-                setValue("categoryId", v, { shouldValidate: true });
-                setMobileView("form");
-              }}
-            />
-          </div>
-        ) : (
-          <>
-            <DrawerHeader>
-              <DrawerTitle>기록 수정</DrawerTitle>
-              <DrawerDescription asChild>
-                {descriptionContent}
-              </DrawerDescription>
-            </DrawerHeader>
-
-            <div className="overflow-y-auto flex-1 px-4">
-              <form
-                id="ledger-entry-edit-form"
-                onSubmit={handleSubmit(onSubmit)}
-                className="space-y-4 pb-2"
-              >
-                {infoBanner}
-                {formFields}
-              </form>
-            </div>
-
-            <DrawerFooter className="pb-[calc(1rem+env(safe-area-inset-bottom))]">
-              <div className="flex gap-2">
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => onOpenChange(false)}
-                  disabled={isSubmitting}
-                  className="flex-1"
-                >
-                  취소
-                </Button>
-                <Button
-                  type="submit"
-                  form="ledger-entry-edit-form"
-                  disabled={isSubmitting}
-                  className="flex-1"
-                >
-                  {isSubmitting ? "저장 중..." : "저장"}
-                </Button>
-              </div>
-            </DrawerFooter>
-          </>
-        )}
-      </DrawerContent>
-    </Drawer>
+        </DrawerContent>
+      </Drawer>
+    </>
   );
 }

--- a/components/ledger/entry-composer/LedgerEntryComposer.tsx
+++ b/components/ledger/entry-composer/LedgerEntryComposer.tsx
@@ -48,7 +48,7 @@ export type LedgerComposerItemValues = z.infer<typeof ledgerComposerItemSchema>;
 
 interface LedgerEntryComposerProps {
   mode: "full" | "daily";
-  defaultDate: string;
+  defaultDate?: string;
 }
 
 export function createDefaultItem({
@@ -86,9 +86,24 @@ export function LedgerEntryComposer({
   const [activeEditIndex, setActiveEditIndex] = useState<number | null>(null);
   const [mounted, setMounted] = useState(false);
 
+  const form = useForm<LedgerComposerFormValues>({
+    resolver: zodResolver(ledgerComposerSchema),
+    defaultValues: {
+      defaultType: "expense",
+      defaultIsShared: true,
+      defaultDate: defaultDate ?? "",
+      items: [],
+    },
+  });
+
   useEffect(() => {
     setMounted(true);
-  }, []);
+    if (!defaultDate) {
+      import("@/lib/date").then(({ getKstToday }) => {
+        form.setValue("defaultDate", getKstToday());
+      });
+    }
+  }, [defaultDate, form]);
 
   useEffect(() => {
     if (editIndex !== null) {
@@ -104,22 +119,6 @@ export function LedgerEntryComposer({
 
     return () => window.clearTimeout(timeoutId);
   }, [editIndex, activeEditIndex]);
-
-  const form = useForm<LedgerComposerFormValues>({
-    resolver: zodResolver(ledgerComposerSchema),
-    defaultValues: {
-      defaultType: "expense",
-      defaultIsShared: true,
-      defaultDate,
-      items: [
-        createDefaultItem({
-          type: "expense",
-          isShared: true,
-          date: defaultDate,
-        }),
-      ],
-    },
-  });
 
   const handleSubmit = async (values: LedgerComposerFormValues) => {
     try {

--- a/components/ledger/records/LedgerEntryRow.tsx
+++ b/components/ledger/records/LedgerEntryRow.tsx
@@ -48,7 +48,33 @@ export function LedgerEntryRow({
   ].filter(Boolean);
 
   return (
-    <div className="flex items-center gap-3 py-3 border-b last:border-b-0">
+    <div className="group relative flex items-center gap-3 py-3 border-b last:border-b-0 pr-10">
+      {/* 메뉴 (Absolute) */}
+      <div className="absolute right-0 top-1/2 z-10 -translate-y-1/2">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 text-gray-400 hover:text-gray-600"
+            >
+              <MoreVertical className="w-4 h-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={() => onEdit(entry)}>
+              수정
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              className="text-destructive"
+              onClick={() => onDelete(entry)}
+            >
+              삭제
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
       {/* 카테고리 아이콘 */}
       <div className="flex-shrink-0 w-11 h-11 rounded-xl bg-gray-100 flex items-center justify-center">
         <CategoryIcon
@@ -59,7 +85,7 @@ export function LedgerEntryRow({
 
       {/* 내용 */}
       <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-1">
+        <div className="flex min-w-0 items-center gap-1">
           <span className="font-semibold text-gray-900 text-sm truncate">
             {entry.title ??
               entry.categoryName ??
@@ -76,30 +102,12 @@ export function LedgerEntryRow({
         )}
       </div>
 
-      {/* 금액 + 메뉴 */}
+      {/* 금액 */}
       <div className="flex items-center gap-1 flex-shrink-0">
         <span className={`text-sm font-semibold ${amountColor}`}>
           {amountSign}
           {formatCurrency(entry.amount)}
         </span>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="ghost" size="icon" className="h-8 w-8">
-              <MoreVertical className="w-4 h-4 text-gray-400" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuItem onClick={() => onEdit(entry)}>
-              수정
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              className="text-destructive"
-              onClick={() => onDelete(entry)}
-            >
-              삭제
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
       </div>
     </div>
   );

--- a/components/ledger/records/LedgerRecordsClient.tsx
+++ b/components/ledger/records/LedgerRecordsClient.tsx
@@ -261,7 +261,7 @@ export function LedgerRecordsClient({ initialDate }: LedgerRecordsClientProps) {
         </div>
 
         {/* 우측(데스크탑) / 하단(모바일): 항목 목록 + 등록 버튼 */}
-        <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-4 min-w-0">
           <LedgerDayEntryList
             selectedDate={selectedDate}
             entries={dayEntries}

--- a/components/transactions/AccountSelector.tsx
+++ b/components/transactions/AccountSelector.tsx
@@ -176,10 +176,12 @@ function InvestmentAccountInlineCreateForm({
   initialName,
   onBack,
   onCreated,
+  shouldFocus = false,
 }: {
   initialName: string;
   onBack?: () => void;
   onCreated: (account: Account) => void;
+  shouldFocus?: boolean;
 }) {
   const createAccount = useCreateAccount();
   const [name, setName] = useState(initialName);
@@ -191,6 +193,15 @@ function InvestmentAccountInlineCreateForm({
     setBroker("");
     setError(null);
   }, [initialName]);
+
+  useEffect(() => {
+    if (shouldFocus) {
+      const timer = setTimeout(() => {
+        document.getElementById("inline-investment-account-name")?.focus();
+      }, 350);
+      return () => clearTimeout(timer);
+    }
+  }, [shouldFocus]);
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -228,7 +239,6 @@ function InvestmentAccountInlineCreateForm({
             setName(event.target.value);
             setError(null);
           }}
-          autoFocus
         />
       </div>
       <div className="space-y-2">
@@ -276,6 +286,7 @@ function InvestmentAccountCreateDialog({
         </DialogHeader>
         <InvestmentAccountInlineCreateForm
           initialName={initialName}
+          shouldFocus={open}
           onCreated={(account) => {
             onCreated(account);
             onOpenChange(false);
@@ -549,6 +560,7 @@ export function AccountSelector<T extends FieldValues>({
                     <InvestmentAccountInlineCreateForm
                       initialName={createInitialName}
                       onCreated={handleCreated}
+                      shouldFocus={mobileCreateOpen}
                     />
                   </div>
                 </div>

--- a/components/transactions/MultiTransactionForm.tsx
+++ b/components/transactions/MultiTransactionForm.tsx
@@ -21,7 +21,7 @@ import type { CreateBatchTransactionInput } from "@/schemas/transaction";
 
 interface MultiTransactionFormProps {
   mode?: "full" | "daily";
-  defaultDate: string;
+  defaultDate?: string;
   defaultAccountId: string;
 }
 
@@ -38,7 +38,7 @@ export function MultiTransactionForm({
     resolver: zodResolver(multiTransactionFormSchema),
     defaultValues: {
       type: "buy",
-      transactedAt: defaultDate,
+      transactedAt: defaultDate ?? "",
       accountId: defaultAccountId,
       items: [],
     },
@@ -50,7 +50,12 @@ export function MultiTransactionForm({
 
   useEffect(() => {
     setMounted(true);
-  }, []);
+    if (!defaultDate) {
+      import("@/lib/date").then(({ getKstToday }) => {
+        form.setValue("transactedAt", getKstToday());
+      });
+    }
+  }, [defaultDate, form]);
 
   useEffect(() => {
     if (editIndex !== null) {

--- a/components/transactions/MultiTransactionFormWrapper.tsx
+++ b/components/transactions/MultiTransactionFormWrapper.tsx
@@ -5,7 +5,7 @@ import { useAccounts } from "@/hooks/use-accounts";
 import { useCurrentUserId } from "@/hooks/use-current-user";
 
 interface MultiTransactionFormWrapperProps {
-  defaultDate: string;
+  defaultDate?: string;
   defaultAccountId?: string;
   mode?: "full" | "daily";
 }

--- a/components/transactions/TransactionEditDialog.tsx
+++ b/components/transactions/TransactionEditDialog.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { InfoIcon } from "lucide-react";
+import { InfoIcon, XIcon } from "lucide-react";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
+import { AccountSelector } from "@/components/transactions/AccountSelector";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { DatePickerInput } from "@/components/ui/date-picker";
@@ -80,12 +81,12 @@ export function TransactionEditDialog({
     reset,
     watch,
     setValue,
+    control,
     formState: { errors, isSubmitting },
   } = useForm<EditFormValues>({
     resolver: zodResolver(editFormSchema),
   });
 
-  const watchAccountId = watch("accountId");
   const watchTransactedAt = watch("transactedAt");
 
   // transaction이 변경될 때 폼 값 초기화
@@ -99,7 +100,7 @@ export function TransactionEditDialog({
         quantity: String(transaction.quantity),
         price: String(transaction.price),
         transactedAt: formattedDate,
-        accountId: transaction.accountId ?? "__none__",
+        accountId: transaction.accountId ?? undefined,
         memo: transaction.memo ?? "",
       });
     }
@@ -112,9 +113,8 @@ export function TransactionEditDialog({
       // transactedAt을 ISO 형식으로 변환
       const transactedAtISO = new Date(data.transactedAt).toISOString();
 
-      // "__none__"은 계좌 없음을 의미
-      const accountId =
-        data.accountId === "__none__" ? null : data.accountId || null;
+      // 빈 값(계좌 없음) 처리
+      const accountId = data.accountId || null;
 
       await updateMutation.mutateAsync({
         id: transaction.id,
@@ -213,28 +213,13 @@ export function TransactionEditDialog({
       </div>
 
       {/* 계좌 */}
-      {accounts && accounts.length > 0 && (
-        <div className="space-y-2">
-          <Label htmlFor="accountId">거래 계좌</Label>
-          <Select
-            value={watchAccountId ?? "__none__"}
-            onValueChange={(value) => setValue("accountId", value)}
-          >
-            <SelectTrigger id="accountId">
-              <SelectValue placeholder="계좌를 선택하세요" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="__none__">계좌 없음</SelectItem>
-              {accounts.map((account) => (
-                <SelectItem key={account.id} value={account.id}>
-                  {account.name}
-                  {account.broker && ` (${account.broker})`}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-      )}
+      <AccountSelector
+        control={control}
+        name="accountId"
+        variant="inline"
+        placeholder="계좌 선택"
+        allowClear={true}
+      />
 
       {/* 메모 */}
       <div className="space-y-2">
@@ -289,47 +274,57 @@ export function TransactionEditDialog({
     );
   }
 
-  // 모바일: Drawer (Bottom Sheet)
+  // 모바일: 전체 화면 Drawer
   return (
     <Drawer open={open} onOpenChange={onOpenChange}>
-      <DrawerContent>
-        <DrawerHeader>
-          <DrawerTitle>거래 수정</DrawerTitle>
-          <DrawerDescription asChild>{descriptionContent}</DrawerDescription>
-        </DrawerHeader>
+      <DrawerContent
+        className="h-[100dvh] max-h-[100dvh] rounded-none border-t-0 p-0 flex flex-col data-[vaul-drawer-direction=bottom]:mt-0 data-[vaul-drawer-direction=bottom]:max-h-[100dvh] data-[vaul-drawer-direction=bottom]:rounded-none data-[vaul-drawer-direction=bottom]:border-t-0"
+        showHandle={false}
+        onOpenAutoFocus={(event) => event.preventDefault()}
+      >
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={() => onOpenChange(false)}
+          className="absolute right-2 top-2 z-10 inline-flex size-11 items-center justify-center rounded-full text-gray-700 transition-colors hover:bg-gray-100"
+        >
+          <XIcon className="size-5" />
+        </Button>
 
-        <div className="overflow-y-auto flex-1 px-4">
+        <div className="flex-1 overflow-y-auto px-4 pt-16 space-y-4">
+          <div className="space-y-1">
+            <h3 className="text-lg font-bold text-gray-900">거래 수정</h3>
+            <div className="text-sm text-gray-500">{descriptionContent}</div>
+          </div>
+
           <form
             id="transaction-edit-form"
             onSubmit={handleSubmit(onSubmit)}
-            className="space-y-4 pb-2"
+            className="space-y-4 pb-[calc(1rem+env(safe-area-inset-bottom))]"
           >
             {infoBanner}
             {formFields}
+
+            <div className="flex gap-2 pt-4">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isSubmitting}
+                className="flex-1 h-12 rounded-xl text-base font-semibold"
+              >
+                취소
+              </Button>
+              <Button
+                type="submit"
+                disabled={isSubmitting}
+                className="flex-1 h-12 rounded-xl text-base font-semibold"
+              >
+                {isSubmitting ? "저장 중..." : "저장"}
+              </Button>
+            </div>
           </form>
         </div>
-
-        <DrawerFooter className="pb-[max(env(safe-area-inset-bottom),1rem)]">
-          <div className="flex gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
-              disabled={isSubmitting}
-              className="flex-1"
-            >
-              취소
-            </Button>
-            <Button
-              type="submit"
-              form="transaction-edit-form"
-              disabled={isSubmitting}
-              className="flex-1"
-            >
-              {isSubmitting ? "저장 중..." : "저장"}
-            </Button>
-          </div>
-        </DrawerFooter>
       </DrawerContent>
     </Drawer>
   );


### PR DESCRIPTION
## 개요
- #353 이슈 해결 (자산 목록 및 가계부 기록 레이아웃 깨짐 현상 수정)
- 가계부 및 주식 거래 기록 수정 다이얼로그의 모바일 화면(isDesktop === false)을 전체화면 Drawer(h-[100dvh])로 리팩토링
- 중첩 Drawer 패턴을 사용하여 가계부 수정 화면 내의 카테고리/자산 선택 피커가 모바일 h-[85dvh] 바텀 시트로 자연스럽게 작동하도록 수정
- 주식 거래 기록 수정의 계좌 선택을 일반 Select 드롭다운에서 공통 AccountSelector 컴포넌트로 교체하여 검색 및 모바일 바텀시트 지원 일관성 유지