### PR TITLE
[codex] Implement stock transaction change requests

### DIFF
--- a/.claude/docs/DATABASE.md
+++ b/.claude/docs/DATABASE.md
@@ -367,6 +367,10 @@ create index accounts_owner_id_idx on public.accounts(owner_id);
 | bank | checking, savings, deposit |
 | investment | stock, cma, isa, pension |
 
+**소유권 규칙**
+
+계좌는 가구 구성원이 조회할 수 있지만, 새 주식 거래나 가계부 기록에 입력값으로 선택할 때는 기록 소유자의 계좌만 사용할 수 있다. 기존 기록 표시를 위해 가구 전체 계좌 이름을 해석하는 것은 허용한다.
+
 ---
 
 ### 7. transactions (거래 기록)
@@ -407,6 +411,10 @@ create index transactions_transacted_at_idx on public.transactions(transacted_at
 | memo | text (nullable) | 메모 |
 | transacted_at | timestamptz | 실제 거래일 |
 | created_at | timestamptz | 기록 생성일 |
+
+**소유권 규칙**
+
+`transactions.owner_id`는 거래 기록 소유자이며, 새 생성/수정 시 `account_id`는 같은 소유자의 계좌여야 한다. 기존 mismatch 데이터는 자동 마이그레이션하지 않는다. Record Change Request 승인도 이 규칙을 따른다.
 
 ---
 
@@ -555,6 +563,10 @@ create index payment_methods_linked_account_id_idx on public.payment_methods(lin
 | created_at | timestamptz | 생성일 |
 | updated_at | timestamptz | 수정일 |
 
+**소유권 규칙**
+
+결제수단은 가구 구성원이 조회할 수 있지만, 새 가계부 기록에 입력값으로 선택할 때는 기록 소유자의 결제수단만 사용할 수 있다. 기존 기록 표시를 위해 가구 전체 결제수단 이름을 해석하는 것은 허용한다.
+
 ---
 
 ### 12. target_allocations (목표 비중)
@@ -665,6 +677,10 @@ create table public.ledger_entries (
 | 이체 결제수단→계좌 (페이 출금) | | ✓ | ✓ | |
 | 이체 결제수단→결제수단 | | ✓ | | ✓ |
 
+**Financial Source 소유권 규칙**
+
+`ledger_entries.owner_id`는 기록 소유자이며, 새 생성/수정 시 `from_*`/`to_*`에 들어가는 계좌와 결제수단은 기록 소유자의 것이어야 한다. `is_shared = true`는 조회 범위만 뜻하며, 다른 구성원의 계좌나 결제수단을 사용할 권한을 뜻하지 않는다. 기존 mismatch 데이터는 자동 마이그레이션하지 않는다.
+
 **RLS 정책 요약**
 
 | 조건 | SELECT 가능 범위 |
@@ -720,6 +736,10 @@ create table public.record_change_requests (
 ```
 
 `target_id`는 polymorphic reference이므로 DB FK로 강제하지 않고 서버 validator가 `target_type`별로 검증한다. `target_owner_id`는 요청 body에서 받지 않고 대상 기록에서 서버가 복사한다.
+
+요청 승인 시 대상 원본 기록이 `target_snapshot`과 일치하지 않으면 `approved`로 전이하지 않는다. 승인은 요청된 변경이 현재 원본에 안전하게 반영된 뒤에만 완료된다.
+
+Record Change Request의 `proposed_changes`에 계좌 또는 결제수단 변경안이 포함될 경우, 해당 Financial Source는 대상 기록 소유자의 것이어야 한다. 기존 mismatch 데이터는 자동 마이그레이션하지 않는다.
 
 **상태 의미**
 

--- a/.claude/docs/NOTIFICATIONS.md
+++ b/.claude/docs/NOTIFICATIONS.md
@@ -28,6 +28,7 @@
 | Default Notification Preference | 사용자가 저장한 override가 없을 때 적용하는 제품 기본값. |
 | Collaboration Notification | 가구 구성원이 공유 재무 데이터를 함께 관리하기 위해 받는 알림. |
 | Record Change Request | 공유 기록의 비소유자가 소유자에게 수정 또는 삭제를 요청하는 원장. 수정안 또는 삭제 사유를 포함하며, User Notification은 이 요청에서 파생된다. |
+| Financial Source | 가계부 기록 또는 주식 거래에 연결되는 계좌 또는 결제수단. 기록의 공개 범위와 별개로 기록 소유자의 Financial Source만 새 입력값으로 선택할 수 있다. |
 
 ---
 
@@ -441,6 +442,16 @@ create unique index record_change_requests_pending_unique
 - 가계부: 제목, 금액, 유형, 카테고리 이름, 공용 여부
 - 주식: 종목명/티커, 매수/매도, 수량, 단가, 계좌 이름
 
+승인 직전에는 대상 원본 기록이 요청 당시 `target_snapshot`과 여전히 일치하는지 확인한다. 요청 생성 이후 대상 기록이 직접 수정되었거나 삭제되었다면 승인을 실패시키고, 소유자에게 새 요청이 필요하다고 안내한다. 이는 가계부와 주식 거래 모두에 적용되는 Record Change Request 공통 규칙이다.
+
+**Financial Source 소유권**
+
+공용 기록 여부는 조회 범위를 뜻하며, 다른 가구 구성원의 계좌나 결제수단을 사용할 권한을 뜻하지 않는다. 새로 생성하거나 수정하는 가계부 기록과 주식 거래는 기록 소유자의 Financial Source만 사용할 수 있다.
+
+조회/표시 화면은 과거 기록을 정확히 보여주기 위해 가구 전체 Financial Source 이름을 해석할 수 있다. 반면 생성/수정/수정 요청 같은 입력 selector는 대상 기록 소유자의 Financial Source로 후보를 제한한다.
+
+기존 데이터에 대해 owner mismatch를 자동 마이그레이션하지 않는다. 이번 규칙은 새 생성, 직접 수정, Record Change Request 승인에 적용한다.
+
 **최소 API**
 
 ```txt
@@ -526,6 +537,8 @@ POST /api/record-change-requests/[id]/resolve
 
 `proposed_changes`가 비어 있으면 수정 요청을 만들지 않고 클라이언트에서 안내한다.
 
+Financial Source 변경안은 대상 기록 소유자의 계좌/결제수단만 선택할 수 있다. 가구 전체 계좌/결제수단은 기록 표시에는 사용할 수 있지만, 요청 입력 후보로는 사용하지 않는다.
+
 **삭제 요청**
 
 삭제 요청 UI는 대상 기록 요약과 삭제 사유 입력을 보여준다. 삭제 사유는 `message`에 저장하고 `proposed_changes`는 빈 object로 둔다. 삭제 요청 승인 시 기존 `deleteLedgerEntryWithBalanceSync` 흐름을 사용해 원본 기록을 hard delete하고 잔액 영향을 되돌린다. 삭제 후에도 요청 상세는 `target_snapshot`으로 요청 당시 기록을 보여준다.
@@ -549,9 +562,7 @@ DB 제약은 #344 추가 마이그레이션에서 기존 `request_type` 포함 p
 - terminal 상태(`approved`, `rejected`, `cancelled`)는 읽기 전용이다.
 - 수정 요청은 변경된 필드만 "현재 값 → 요청 값" 비교로 보여준다.
 - 삭제 요청은 대상 기록 요약과 삭제 사유를 보여준다.
-- 대상 기록이 이미 삭제된 경우 `target_snapshot`으로 요청 당시 정보를 보여주고, 승인은 비활성화하며 거절만 허용한다.
-
-요청 생성 이후 대상 기록이 직접 수정되었을 수 있다. #344에서는 optimistic locking을 도입하지 않고, 현재 기록이 존재하면 현재 값에 요청 변경안을 적용한다. 화면에는 요청 당시 스냅샷과 현재 값이 다를 수 있음을 짧게 안내한다.
+- 대상 기록이 이미 삭제되었거나 `target_snapshot`과 달라진 경우 승인은 비활성화하거나 실패 처리하며, 거절은 허용한다.
 
 **승인/거절 처리**
 
@@ -581,8 +592,81 @@ DB 제약은 #344 추가 마이그레이션에서 기존 `request_type` 포함 p
 
 - Type: AFK
 - Blocked by: Slice 1, Slice 2
-- 범위: 비소유자가 transaction에 수정안 또는 삭제 사유를 보내고, 소유자가 알림에서 확인한다.
-- 완료 기준: 요청 생성 시 거래 소유자에게 알림이 생성되고, 소유자는 요청 상세에서 승인/거절할 수 있다.
+- 범위: 비소유자가 transaction에 수정안 또는 삭제 사유를 보내고, 소유자가 알림에서 확인한 뒤 승인/거절한다.
+- 완료 기준: 요청 생성 시 거래 소유자에게 알림이 생성되고, 소유자는 요청 상세에서 승인/거절할 수 있으며, 승인 시 기존 매도 수량 검증과 소유자 권한 규칙을 깨지 않고 원본 주식 거래에 반영된다.
+
+#### 확정 설계
+
+**대상 조건**
+
+- `target_type = 'stock_transaction'`
+- 대상 transaction이 존재해야 한다.
+- 요청자가 대상 거래를 조회할 수 있어야 한다.
+- 요청자는 대상 거래 소유자가 아니어야 한다.
+- 주식 거래는 가구 구성원이 함께 조회하는 공유 자산 데이터이므로, 비소유자에게 수정/삭제 요청 진입점을 제공한다.
+
+**메뉴 정책**
+
+주식 거래 목록 메뉴는 현재 사용자에 따라 분기한다.
+
+| 현재 사용자 | 메뉴 |
+|-------------|------|
+| 거래 소유자 | 수정, 삭제 |
+| 비소유자 | 수정 요청, 삭제 요청 |
+
+비소유자는 기존 메뉴 아이콘에서 수정 요청/삭제 요청을 시작한다. 가계부 협업 요청과 같은 UX를 사용한다.
+
+**수정 요청**
+
+수정 요청 UI는 기존 주식 거래 수정 폼과 같은 필드를 현재 값으로 채워 보여주되, 제출 버튼은 "수정 요청 보내기"로 둔다. 사용자가 제출하면 원본과 비교해 변경된 필드만 `proposed_changes`에 저장한다.
+
+허용 필드:
+
+- `quantity`
+- `price`
+- `transactedAt`
+- `accountId`
+- `memo`
+
+금지 필드:
+
+- `ticker`: 종목 변경은 삭제 후 재등록 흐름을 따른다.
+- `type`: 매수/매도 변경은 삭제 후 재등록 흐름을 따른다.
+- `ownerId`: 요청으로 거래 소유자를 바꾸지 않는다.
+
+`proposed_changes`가 비어 있으면 수정 요청을 만들지 않고 클라이언트에서 안내한다. `accountId` 변경안은 대상 거래 소유자의 투자 계좌만 선택할 수 있다.
+
+**삭제 요청**
+
+삭제 요청 UI는 대상 거래 요약과 삭제 사유 입력을 보여준다. 삭제 사유는 필수 입력으로 받고 `message`에 저장하며, `proposed_changes`는 빈 object로 둔다.
+
+**요청 상세 화면**
+
+알림 링크의 canonical route는 가계부와 동일하게 `/notifications/requests/[id]`를 사용한다. 요청 상세 route는 공통으로 유지하되, 화면 내부는 target type별 summary 컴포넌트로 분리한다.
+
+- 공통 detail client: 데이터 조회, 권한 계산, 승인/거절/취소 액션, 상태 표시
+- ledger summary: 가계부 snapshot과 변경 필드 표시
+- stock transaction summary: 종목, 매수/매도, 수량, 단가, 거래일, 계좌, 메모 변경 필드 표시
+
+**승인/거절 처리**
+
+주식 거래 요청 승인 적용은 `applyApprovedStockTransactionChangeRequest` 같은 오케스트레이션 함수에서 처리한다.
+
+승인 규칙:
+
+- 승인 직전 현재 transaction이 `target_snapshot`과 일치해야 한다.
+- `update`: 허용된 `proposed_changes` 필드만 기존 `updateTransaction` 흐름에 위임해 적용한다.
+- `delete`: 기존 `deleteTransaction` 흐름에 위임해 hard delete한다.
+- 매도 수량 검증, 거래 소유자 권한, 계좌 소유권 검증은 기존 거래 도메인 함수의 규칙을 재사용한다.
+- 대상 거래 없음 또는 snapshot 불일치: 승인 거부, 거절은 허용.
+
+소유자는 요청안을 수정해서 승인할 수 없다. 요청안이 틀렸다면 소유자가 직접 거래를 수정하고 요청은 거절한다.
+
+**알림 경계**
+
+#346은 요청 생성 시 대상 소유자에게 `stock_transaction_change_request` User Notification을 생성한다. 알림 제목은 요청자, 대상 종목, 요청 타입을 포함한다. 예: "민수가 삼성전자 거래 수정을 요청했습니다".
+
+승인/거절/취소 결과 알림은 #348에서 가계부와 주식 공통으로 처리한다.
 
 ### Slice 6. 주식 거래 변경 알림 (#347)
 
@@ -614,3 +698,6 @@ DB 제약은 #344 추가 마이그레이션에서 기존 `request_type` 포함 p
 3. 요청 상태는 `pending`, `approved`, `rejected`, `cancelled` 네 가지로 시작하고 `expired`는 두지 않는다.
 4. `approved`는 원본 기록 반영 완료를 뜻한다.
 5. 요청은 알림 테이블이 아니라 `record_change_requests`에서 관리한다.
+6. Record Change Request 승인은 대상 원본 기록이 요청 당시 snapshot과 일치할 때만 가능하다.
+7. 생성/수정/요청 승인에서 Financial Source는 기록 소유자의 것만 사용할 수 있다.
+8. 기존 owner mismatch 데이터는 자동 마이그레이션하지 않는다.

--- a/app/(main)/assets/stock/records/page.tsx
+++ b/app/(main)/assets/stock/records/page.tsx
@@ -1,5 +1,5 @@
 import { StockRecordsClient } from "@/components/transactions/records/StockRecordsClient";
-import { formatKst, getKstToday } from "@/lib/date";
+import { getKstToday } from "@/lib/date";
 import { normalizeRecordDate } from "@/lib/stock-records/records";
 import { requireUser } from "@/lib/supabase/auth";
 

--- a/app/(main)/assets/stock/transactions/new/account/page.tsx
+++ b/app/(main)/assets/stock/transactions/new/account/page.tsx
@@ -1,6 +1,6 @@
 import { PageContainer } from "@/components/layout";
 import { MultiTransactionFormWrapper } from "@/components/transactions/MultiTransactionFormWrapper";
-import { formatKst, getKstToday } from "@/lib/date";
+import { getKstToday } from "@/lib/date";
 
 interface NewStockTransactionAccountPageProps {
   searchParams: Promise<{

--- a/app/(main)/assets/stock/transactions/new/daily/page.tsx
+++ b/app/(main)/assets/stock/transactions/new/daily/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react";
 import { PageContainer } from "@/components/layout";
 import { MultiTransactionFormWrapper } from "@/components/transactions/MultiTransactionFormWrapper";
-import { formatKst, getKstToday } from "@/lib/date";
+import { getKstToday } from "@/lib/date";
 import { normalizeRecordDate } from "@/lib/stock-records/records";
 
 interface NewDailyStockTransactionPageProps {

--- a/app/(main)/ledger/records/new/daily/page.tsx
+++ b/app/(main)/ledger/records/new/daily/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react";
 import { PageContainer } from "@/components/layout";
 import { LedgerEntryComposer } from "@/components/ledger/entry-composer/LedgerEntryComposer";
-import { formatKst, getKstToday } from "@/lib/date";
+import { getKstToday } from "@/lib/date";
 
 interface DailyLedgerEntryPageProps {
   searchParams: Promise<{

--- a/app/(main)/ledger/records/page.tsx
+++ b/app/(main)/ledger/records/page.tsx
@@ -1,5 +1,5 @@
 import { LedgerRecordsClient } from "@/components/ledger/records/LedgerRecordsClient";
-import { formatKst, getKstToday } from "@/lib/date";
+import { getKstToday } from "@/lib/date";
 import { normalizeRecordDate } from "@/lib/stock-records/records";
 import { requireUser } from "@/lib/supabase/auth";
 

--- a/components/ledger/LedgerEntryChangeRequestDialog.tsx
+++ b/components/ledger/LedgerEntryChangeRequestDialog.tsx
@@ -95,16 +95,20 @@ export function LedgerEntryChangeRequestDialog({
   const moneySourceOptions = useMemo(
     () => [
       { value: "none", label: "선택 안함" },
-      ...paymentMethods.map((item) => ({
-        value: `pm:${item.id}`,
-        label: item.name,
-      })),
-      ...accounts.map((item) => ({
-        value: `acc:${item.id}`,
-        label: item.name,
-      })),
+      ...paymentMethods
+        .filter((item) => item.ownerId === entry?.ownerId)
+        .map((item) => ({
+          value: `pm:${item.id}`,
+          label: item.name,
+        })),
+      ...accounts
+        .filter((item) => item.ownerId === entry?.ownerId)
+        .map((item) => ({
+          value: `acc:${item.id}`,
+          label: item.name,
+        })),
     ],
-    [accounts, paymentMethods],
+    [accounts, paymentMethods, entry?.ownerId],
   );
 
   if (!entry || !values) return null;
@@ -136,6 +140,11 @@ export function LedgerEntryChangeRequestDialog({
           proposedChanges,
         });
       } else {
+        if (!message.trim()) {
+          toast.error("삭제 사유를 입력해주세요.");
+          return;
+        }
+
         await createMutation.mutateAsync({
           targetType: "ledger_entry",
           targetId: entry.id,

--- a/components/ledger/LedgerEntryEditDialog.tsx
+++ b/components/ledger/LedgerEntryEditDialog.tsx
@@ -28,14 +28,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import {
-  Drawer,
-  DrawerContent,
-  DrawerDescription,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerTitle,
-} from "@/components/ui/drawer";
+import { Drawer, DrawerContent } from "@/components/ui/drawer";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -202,14 +195,6 @@ export function LedgerEntryEditDialog({
   const handleMobileMoneySourceChange = (v: string) => {
     handlePaymentChange(v);
     setMobileView("form");
-  };
-
-  const handleDrawerOpenChange = (nextOpen: boolean) => {
-    if (!nextOpen && mobileView !== "form") {
-      setMobileView("form");
-      return;
-    }
-    onOpenChange(nextOpen);
   };
 
   const moneySourceMode = entry.type === "expense" ? "expense" : "income";
@@ -381,6 +366,7 @@ export function LedgerEntryEditDialog({
               value={paymentValue}
               paymentMethods={paymentMethods}
               accounts={accounts}
+              ownerId={entry.ownerId}
               placeholder={moneySourcePlaceholder}
               onValueChange={handlePaymentChange}
             />
@@ -564,6 +550,7 @@ export function LedgerEntryEditDialog({
               value={paymentValue}
               paymentMethods={paymentMethods}
               accounts={accounts}
+              ownerId={entry.ownerId}
               title={
                 entry.type === "expense" ? "결제 방법 선택" : "입금 계좌 선택"
               }

--- a/components/ledger/LedgerMoneySourceCombobox.tsx
+++ b/components/ledger/LedgerMoneySourceCombobox.tsx
@@ -62,6 +62,7 @@ interface LedgerMoneySourceBaseProps {
   value: string;
   paymentMethods: LedgerMoneySourcePaymentMethod[];
   accounts: LedgerMoneySourceAccount[];
+  ownerId?: string | null;
   includeClearOption?: boolean;
   excludedValues?: string[];
 }
@@ -104,15 +105,22 @@ function useMoneySourceGroups({
   mode,
   paymentMethods,
   accounts,
+  ownerId,
   includeClearOption = true,
   excludedValues = [],
 }: LedgerMoneySourceBaseProps): LedgerMoneySourceGroup[] {
   return useMemo(() => {
     const excluded = new Set(excludedValues);
+    const scopedPaymentMethods = ownerId
+      ? paymentMethods.filter((item) => item.ownerId === ownerId)
+      : paymentMethods;
+    const scopedAccounts = ownerId
+      ? accounts.filter((item) => item.ownerId === ownerId)
+      : accounts;
     return buildLedgerMoneySourceGroups({
       mode,
-      paymentMethods,
-      accounts,
+      paymentMethods: scopedPaymentMethods,
+      accounts: scopedAccounts,
       includeClearOption,
     })
       .map((group) => ({
@@ -120,7 +128,14 @@ function useMoneySourceGroups({
         options: group.options.filter((option) => !excluded.has(option.value)),
       }))
       .filter((group) => group.options.length > 0);
-  }, [mode, paymentMethods, accounts, includeClearOption, excludedValues]);
+  }, [
+    mode,
+    paymentMethods,
+    accounts,
+    ownerId,
+    includeClearOption,
+    excludedValues,
+  ]);
 }
 
 export const LedgerMoneySourceTrigger = forwardRef<
@@ -537,6 +552,7 @@ export function LedgerMoneySourceCombobox({
   value,
   paymentMethods,
   accounts,
+  ownerId,
   includeClearOption = true,
   excludedValues,
   placeholder,
@@ -546,11 +562,15 @@ export function LedgerMoneySourceCombobox({
   const [search, setSearch] = useState("");
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [createInitialName, setCreateInitialName] = useState("");
+  const scopedAccounts = ownerId
+    ? accounts.filter((account) => account.ownerId === ownerId)
+    : accounts;
   const groups = useMoneySourceGroups({
     mode,
     value,
     paymentMethods,
     accounts,
+    ownerId,
     includeClearOption,
     excludedValues,
   });
@@ -622,7 +642,7 @@ export function LedgerMoneySourceCombobox({
         open={createDialogOpen}
         mode={mode}
         initialName={createInitialName}
-        accounts={accounts}
+        accounts={scopedAccounts}
         onOpenChange={setCreateDialogOpen}
         onCreated={onValueChange}
       />
@@ -635,6 +655,7 @@ export function LedgerMoneySourcePickerPanel({
   value,
   paymentMethods,
   accounts,
+  ownerId,
   includeClearOption = true,
   excludedValues,
   searchPlaceholder,
@@ -644,11 +665,15 @@ export function LedgerMoneySourcePickerPanel({
   const [target, setTarget] = useState<MoneySourceCreateTarget | null>(null);
   const shouldReduceMotion = useReducedMotion();
   const [createInitialName, setCreateInitialName] = useState("");
+  const scopedAccounts = ownerId
+    ? accounts.filter((account) => account.ownerId === ownerId)
+    : accounts;
   const groups = useMoneySourceGroups({
     mode,
     value,
     paymentMethods,
     accounts,
+    ownerId,
     includeClearOption,
     excludedValues,
   });
@@ -818,7 +843,7 @@ export function LedgerMoneySourcePickerPanel({
                   initialName={createInitialName}
                   type={target.type}
                   typeLabel={target.label}
-                  accounts={accounts}
+                  accounts={scopedAccounts}
                   onCreated={(paymentMethod) =>
                     onValueChange(`pm:${paymentMethod.id}`)
                   }

--- a/components/ledger/entry-composer/ComposerFormStep.tsx
+++ b/components/ledger/entry-composer/ComposerFormStep.tsx
@@ -29,6 +29,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { useAccounts } from "@/hooks/use-accounts";
 import { useCategories } from "@/hooks/use-categories";
+import { useCurrentUserId } from "@/hooks/use-current-user";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { usePaymentMethods } from "@/hooks/use-payment-methods";
 import { getLedgerMoneySourceValue } from "@/lib/ledger/money-source-options";
@@ -68,6 +69,7 @@ export function ComposerFormStep({
   const { data: incomeCategories = [] } = useCategories("income");
   const { data: paymentMethods = [] } = usePaymentMethods();
   const { data: accounts = [] } = useAccounts();
+  const { userId } = useCurrentUserId();
 
   const itemType = form.watch(`items.${index}.type`);
   const itemIsShared = form.watch(`items.${index}.isShared`);
@@ -230,6 +232,7 @@ export function ComposerFormStep({
                 value={moneySourceValue}
                 paymentMethods={paymentMethods}
                 accounts={accounts}
+                ownerId={userId}
                 placeholder="선택 안함"
                 onValueChange={handleMoneySourceChange}
               />
@@ -311,6 +314,7 @@ export function ComposerFormStep({
                 value={moneySourceValue}
                 paymentMethods={paymentMethods}
                 accounts={accounts}
+                ownerId={userId}
                 title={
                   itemType === "expense" ? "결제 방법 선택" : "입금 계좌 선택"
                 }

--- a/components/ledger/funnel/AddItemsStep.tsx
+++ b/components/ledger/funnel/AddItemsStep.tsx
@@ -19,9 +19,10 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { useAccounts } from "@/hooks/use-accounts";
 import { useCategories } from "@/hooks/use-categories";
+import { useCurrentUserId } from "@/hooks/use-current-user";
 import { usePaymentMethods } from "@/hooks/use-payment-methods";
 import type { LedgerItemFormData } from "@/lib/api/ledger";
-import { formatKst, getKstToday } from "@/lib/date";
+import { getKstToday } from "@/lib/date";
 import { getLedgerMoneySourceValue } from "@/lib/ledger/money-source-options";
 import type { CategoryType } from "@/types";
 
@@ -54,6 +55,7 @@ export function AddItemsStep({ type, onNext }: AddItemsStepProps) {
     useCategories(categoryType);
   const { data: paymentMethods = [] } = usePaymentMethods();
   const { data: accounts = [] } = useAccounts();
+  const { userId } = useCurrentUserId();
 
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),
@@ -218,6 +220,7 @@ export function AddItemsStep({ type, onNext }: AddItemsStepProps) {
                     value={paymentValue}
                     paymentMethods={paymentMethods}
                     accounts={accounts}
+                    ownerId={userId}
                     placeholder="선택 안함"
                     onValueChange={handlePaymentChange}
                   />

--- a/components/ledger/funnel/AddTransferStep.tsx
+++ b/components/ledger/funnel/AddTransferStep.tsx
@@ -10,9 +10,10 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { useAccounts } from "@/hooks/use-accounts";
+import { useCurrentUserId } from "@/hooks/use-current-user";
 import { usePaymentMethods } from "@/hooks/use-payment-methods";
 import type { TransferItemFormData, TransferLocation } from "@/lib/api/ledger";
-import { formatKst, getKstToday } from "@/lib/date";
+import { getKstToday } from "@/lib/date";
 
 const transferFormSchema = z
   .object({
@@ -52,6 +53,7 @@ export function AddTransferStep({
 }: AddTransferStepProps) {
   const { data: accounts = [] } = useAccounts();
   const { data: paymentMethods = [] } = usePaymentMethods();
+  const { userId } = useCurrentUserId();
 
   const form = useForm<TransferFormValues>({
     resolver: zodResolver(transferFormSchema),
@@ -125,6 +127,7 @@ export function AddTransferStep({
                 value={form.watch("fromValue")}
                 paymentMethods={paymentMethods}
                 accounts={accounts}
+                ownerId={userId}
                 includeClearOption={false}
                 excludedValues={toValue ? [toValue] : []}
                 placeholder="선택"
@@ -149,6 +152,7 @@ export function AddTransferStep({
                 value={form.watch("toValue")}
                 paymentMethods={paymentMethods}
                 accounts={accounts}
+                ownerId={userId}
                 includeClearOption={false}
                 excludedValues={fromValue ? [fromValue] : []}
                 placeholder="선택"

--- a/components/notifications/RecordChangeRequestDetailClient.tsx
+++ b/components/notifications/RecordChangeRequestDetailClient.tsx
@@ -33,6 +33,12 @@ function formatValue(value: unknown) {
 }
 
 function getSnapshotTitle(snapshot: Record<string, unknown>) {
+  if (snapshot.targetType === "stock_transaction") {
+    const ticker =
+      typeof snapshot.ticker === "string" ? snapshot.ticker : "주식";
+    return `${ticker} 거래`;
+  }
+
   return (
     (typeof snapshot.title === "string" && snapshot.title) ||
     (typeof snapshot.categoryName === "string" && snapshot.categoryName) ||
@@ -63,7 +69,44 @@ const FIELD_LABELS: Record<string, string> = {
   toPaymentMethodId: "입금 결제수단",
   transactedAt: "날짜",
   memo: "메모",
+  quantity: "수량",
+  price: "단가",
+  accountId: "계좌",
 };
+
+function getSnapshotMeta(snapshot: Record<string, unknown>) {
+  if (snapshot.targetType === "stock_transaction") {
+    return [
+      {
+        label: "거래 유형",
+        value: snapshot.type === "buy" ? "매수" : "매도",
+      },
+      {
+        label: "수량",
+        value:
+          typeof snapshot.quantity === "number"
+            ? `${snapshot.quantity.toLocaleString()}주`
+            : formatValue(snapshot.quantity),
+      },
+      {
+        label: "단가",
+        value: formatValue(snapshot.price),
+      },
+      {
+        label: "거래일",
+        value: formatValue(snapshot.transactedAt).slice(0, 10),
+      },
+    ];
+  }
+
+  return [
+    { label: "요청 당시 금액", value: formatValue(snapshot.amount) },
+    {
+      label: "기록일",
+      value: formatValue(snapshot.transactedAt).slice(0, 10),
+    },
+  ];
+}
 
 export function RecordChangeRequestDetailClient({
   requestId,
@@ -153,16 +196,12 @@ export function RecordChangeRequestDetailClient({
         </div>
 
         <div className="grid grid-cols-2 gap-3 text-sm">
-          <div>
-            <p className="text-muted-foreground">요청 당시 금액</p>
-            <p className="font-semibold">{formatValue(snapshot.amount)}</p>
-          </div>
-          <div>
-            <p className="text-muted-foreground">기록일</p>
-            <p className="font-semibold">
-              {formatValue(snapshot.transactedAt).slice(0, 10)}
-            </p>
-          </div>
+          {getSnapshotMeta(snapshot).map((item) => (
+            <div key={item.label}>
+              <p className="text-muted-foreground">{item.label}</p>
+              <p className="font-semibold">{item.value}</p>
+            </div>
+          ))}
         </div>
       </div>
 

--- a/components/transactions/AccountSelector.tsx
+++ b/components/transactions/AccountSelector.tsx
@@ -54,6 +54,7 @@ interface AccountSelectorProps<T extends FieldValues> {
   variant?: "card" | "inline";
   placeholder?: string;
   allowClear?: boolean;
+  ownerId?: string | null;
   onChange?: (value: string) => void;
 }
 
@@ -303,9 +304,13 @@ export function AccountSelector<T extends FieldValues>({
   variant = "card",
   placeholder,
   allowClear = false,
+  ownerId,
   onChange,
 }: AccountSelectorProps<T>) {
-  const { data: accounts = [], isLoading } = useAccounts();
+  const { data: allAccounts = [], isLoading } = useAccounts();
+  const accounts = ownerId
+    ? allAccounts.filter((account) => account.ownerId === ownerId)
+    : allAccounts;
   const { field } = useController({
     control,
     name,

--- a/components/transactions/MultiTransactionForm.tsx
+++ b/components/transactions/MultiTransactionForm.tsx
@@ -23,12 +23,14 @@ interface MultiTransactionFormProps {
   mode?: "full" | "daily";
   defaultDate?: string;
   defaultAccountId: string;
+  ownerId: string;
 }
 
 export function MultiTransactionForm({
   mode = "full",
   defaultDate,
   defaultAccountId,
+  ownerId,
 }: MultiTransactionFormProps) {
   const router = useRouter();
   const createBatchTransactions = useCreateBatchTransactions();
@@ -147,6 +149,7 @@ export function MultiTransactionForm({
       <div className="w-full h-full">
         <StockComposerListStep
           mode={mode}
+          ownerId={ownerId}
           onEditItem={(index) => setEditIndex(index)}
           onSubmit={(data) => onSubmit(data)}
           isSubmitting={createBatchTransactions.isPending}
@@ -169,6 +172,7 @@ export function MultiTransactionForm({
                   key={editIndex}
                   index={editIndex}
                   mode={mode}
+                  ownerId={ownerId}
                   onBack={() => setEditIndex(null)}
                 />
               </motion.div>
@@ -194,6 +198,7 @@ export function MultiTransactionForm({
                 key={activeEditIndex}
                 index={activeEditIndex}
                 mode={mode}
+                ownerId={ownerId}
                 onBack={() => setEditIndex(null)}
               />
             </DrawerContent>

--- a/components/transactions/MultiTransactionFormWrapper.tsx
+++ b/components/transactions/MultiTransactionFormWrapper.tsx
@@ -46,6 +46,7 @@ export function MultiTransactionFormWrapper({
       mode={mode}
       defaultDate={defaultDate}
       defaultAccountId={selectedDefaultAccountId}
+      ownerId={currentUserId ?? ""}
     />
   );
 }

--- a/components/transactions/StockComposerFormStep.test.tsx
+++ b/components/transactions/StockComposerFormStep.test.tsx
@@ -34,7 +34,12 @@ function renderStep(mode: "full" | "daily") {
 
     return (
       <FormProvider {...form}>
-        <StockComposerFormStep index={0} mode={mode} onBack={vi.fn()} />
+        <StockComposerFormStep
+          index={0}
+          mode={mode}
+          ownerId="user-1"
+          onBack={vi.fn()}
+        />
       </FormProvider>
     );
   }

--- a/components/transactions/StockComposerFormStep.tsx
+++ b/components/transactions/StockComposerFormStep.tsx
@@ -13,12 +13,14 @@ import type { MultiTransactionFormData } from "@/schemas/multi-transaction-form"
 interface StockComposerFormStepProps {
   index: number;
   mode?: "full" | "daily";
+  ownerId: string;
   onBack: () => void;
 }
 
 export function StockComposerFormStep({
   index,
   mode = "full",
+  ownerId,
   onBack,
 }: StockComposerFormStepProps) {
   const form = useFormContext<MultiTransactionFormData>();
@@ -78,6 +80,7 @@ export function StockComposerFormStep({
                 name={`items.${index}.accountId`}
                 variant="inline"
                 placeholder="계좌 선택"
+                ownerId={ownerId}
               />
             </div>
           </div>

--- a/components/transactions/StockComposerListStep.tsx
+++ b/components/transactions/StockComposerListStep.tsx
@@ -21,6 +21,7 @@ import { DEFAULT_TRANSACTION_ITEM } from "@/schemas/multi-transaction-form";
 
 interface StockComposerListStepProps {
   mode?: "full" | "daily";
+  ownerId: string;
   onEditItem: (index: number) => void;
   onSubmit: (data: MultiTransactionFormData) => void;
   isSubmitting: boolean;
@@ -28,6 +29,7 @@ interface StockComposerListStepProps {
 
 export function StockComposerListStep({
   mode = "full",
+  ownerId,
   onEditItem,
   onSubmit,
   isSubmitting,
@@ -92,7 +94,11 @@ export function StockComposerListStep({
             )}
           </div>
 
-          <AccountSelector control={form.control} variant="inline" />
+          <AccountSelector
+            control={form.control}
+            variant="inline"
+            ownerId={ownerId}
+          />
         </div>
 
         {/* 종목 추가 버튼 통합 */}

--- a/components/transactions/TransactionChangeRequestDialog.tsx
+++ b/components/transactions/TransactionChangeRequestDialog.tsx
@@ -1,0 +1,340 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { AlertTriangleIcon, InfoIcon } from "lucide-react";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+import { AccountSelector } from "@/components/transactions/AccountSelector";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { DatePickerInput } from "@/components/ui/date-picker";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { useCreateRecordChangeRequest } from "@/hooks/use-record-change-requests";
+import type { TransactionWithDetails } from "@/lib/api/transaction";
+import { formatCurrency } from "@/lib/utils/format";
+import type { StockTransactionUpdateProposedChanges } from "@/schemas/record-change-request";
+
+type RequestMode = "update" | "delete";
+
+interface TransactionChangeRequestDialogProps {
+  transaction: TransactionWithDetails | null;
+  mode: RequestMode;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const updateRequestFormSchema = z.object({
+  quantity: z
+    .string()
+    .refine((value) => !Number.isNaN(Number(value)) && Number(value) > 0, {
+      message: "수량은 0보다 커야 합니다.",
+    }),
+  price: z
+    .string()
+    .refine((value) => !Number.isNaN(Number(value)) && Number(value) >= 0, {
+      message: "가격은 0 이상이어야 합니다.",
+    }),
+  transactedAt: z.string().min(1, "거래일을 입력해주세요."),
+  accountId: z.string().min(1, "계좌를 선택해주세요."),
+  memo: z.string().max(500, "메모는 500자 이내여야 합니다.").optional(),
+  message: z.string().max(1000, "메시지는 1000자 이내여야 합니다.").optional(),
+});
+
+type UpdateRequestFormValues = z.infer<typeof updateRequestFormSchema>;
+
+function toDateInputValue(value: string) {
+  return new Date(value).toISOString().split("T")[0];
+}
+
+function toIsoDate(value: string) {
+  return new Date(value).toISOString();
+}
+
+function buildProposedChanges(
+  transaction: TransactionWithDetails,
+  values: UpdateRequestFormValues,
+): StockTransactionUpdateProposedChanges {
+  const changes: StockTransactionUpdateProposedChanges = {};
+  const quantity = Number(values.quantity);
+  const price = Number(values.price);
+  const transactedAt = toIsoDate(values.transactedAt);
+  const memo = values.memo || null;
+
+  if (quantity !== transaction.quantity) changes.quantity = quantity;
+  if (price !== transaction.price) changes.price = price;
+  if (transactedAt !== transaction.transactedAt) {
+    changes.transactedAt = transactedAt;
+  }
+  if (values.accountId !== transaction.accountId) {
+    changes.accountId = values.accountId;
+  }
+  if (memo !== transaction.memo) changes.memo = memo;
+
+  return changes;
+}
+
+export function TransactionChangeRequestDialog({
+  transaction,
+  mode,
+  open,
+  onOpenChange,
+}: TransactionChangeRequestDialogProps) {
+  const createMutation = useCreateRecordChangeRequest();
+  const form = useForm<UpdateRequestFormValues>({
+    resolver: zodResolver(updateRequestFormSchema),
+  });
+
+  useEffect(() => {
+    if (!transaction || !open) return;
+
+    form.reset({
+      quantity: String(transaction.quantity),
+      price: String(transaction.price),
+      transactedAt: toDateInputValue(transaction.transactedAt),
+      accountId: transaction.accountId ?? "",
+      memo: transaction.memo ?? "",
+      message: "",
+    });
+  }, [form, transaction, open]);
+
+  if (!transaction) return null;
+
+  const isUpdate = mode === "update";
+  const typeLabel = transaction.type === "buy" ? "매수" : "매도";
+  const typeVariant = transaction.type === "buy" ? "default" : "secondary";
+  const watchTransactedAt = form.watch("transactedAt");
+
+  const handleUpdateSubmit = form.handleSubmit(async (values) => {
+    const proposedChanges = buildProposedChanges(transaction, values);
+
+    if (Object.keys(proposedChanges).length === 0) {
+      toast.error("변경할 항목을 하나 이상 입력해주세요.");
+      return;
+    }
+
+    try {
+      await createMutation.mutateAsync({
+        targetType: "stock_transaction",
+        targetId: transaction.id,
+        requestType: "update",
+        message: values.message?.trim() || undefined,
+        proposedChanges,
+      });
+      toast.success("요청을 보냈습니다.");
+      onOpenChange(false);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "요청 생성에 실패했습니다.",
+      );
+    }
+  });
+
+  const handleDeleteSubmit = async () => {
+    const message = form.getValues("message")?.trim();
+    if (!message) {
+      toast.error("삭제 사유를 입력해주세요.");
+      return;
+    }
+
+    try {
+      await createMutation.mutateAsync({
+        targetType: "stock_transaction",
+        targetId: transaction.id,
+        requestType: "delete",
+        message,
+        proposedChanges: {},
+      });
+      toast.success("요청을 보냈습니다.");
+      onOpenChange(false);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "요청 생성에 실패했습니다.",
+      );
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            {!isUpdate && (
+              <AlertTriangleIcon className="h-5 w-5 text-destructive" />
+            )}
+            {isUpdate ? "거래 수정 요청" : "거래 삭제 요청"}
+          </DialogTitle>
+          <DialogDescription>
+            거래 소유자에게 요청 내용이 전달됩니다.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="rounded-md border p-4 space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="font-medium">{transaction.stockName}</span>
+            <Badge variant={typeVariant}>{typeLabel}</Badge>
+          </div>
+          <div className="space-y-1 text-muted-foreground text-sm">
+            <div className="flex justify-between">
+              <span>수량</span>
+              <span>{transaction.quantity.toLocaleString()}주</span>
+            </div>
+            <div className="flex justify-between">
+              <span>단가</span>
+              <span>
+                {formatCurrency(transaction.price, transaction.currency)}
+              </span>
+            </div>
+            <div className="flex justify-between">
+              <span>소유자</span>
+              <span>{transaction.owner.name}</span>
+            </div>
+          </div>
+        </div>
+
+        {isUpdate ? (
+          <form onSubmit={handleUpdateSubmit} className="space-y-4">
+            <div className="flex items-start gap-2 rounded-md bg-muted/50 p-3 text-muted-foreground text-sm">
+              <InfoIcon className="mt-0.5 h-4 w-4 shrink-0" />
+              <p>종목이나 매수/매도 유형 변경은 삭제 요청으로 처리해주세요.</p>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-2">
+                <Label htmlFor="request-quantity">수량</Label>
+                <Input
+                  id="request-quantity"
+                  type="number"
+                  inputMode="numeric"
+                  step="any"
+                  min="0"
+                  {...form.register("quantity")}
+                />
+                {form.formState.errors.quantity && (
+                  <p className="text-destructive text-sm">
+                    {form.formState.errors.quantity.message}
+                  </p>
+                )}
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="request-price">단가</Label>
+                <Input
+                  id="request-price"
+                  type="number"
+                  inputMode="decimal"
+                  step="any"
+                  min="0"
+                  {...form.register("price")}
+                />
+                {form.formState.errors.price && (
+                  <p className="text-destructive text-sm">
+                    {form.formState.errors.price.message}
+                  </p>
+                )}
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="request-transacted-at">거래일</Label>
+              <DatePickerInput
+                id="request-transacted-at"
+                value={watchTransactedAt ?? ""}
+                onChange={(value) =>
+                  form.setValue("transactedAt", value, {
+                    shouldValidate: true,
+                  })
+                }
+              />
+            </div>
+
+            <AccountSelector
+              control={form.control}
+              name="accountId"
+              variant="inline"
+              placeholder="계좌 선택"
+              ownerId={transaction.owner.id}
+            />
+
+            <div className="space-y-2">
+              <Label htmlFor="request-memo">메모</Label>
+              <Textarea
+                id="request-memo"
+                rows={2}
+                className="resize-none"
+                {...form.register("memo")}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="request-message">요청 메시지 (선택)</Label>
+              <Textarea
+                id="request-message"
+                rows={3}
+                className="resize-none"
+                placeholder="소유자가 확인할 수 있는 설명을 남겨주세요."
+                {...form.register("message")}
+              />
+            </div>
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={createMutation.isPending}
+              >
+                취소
+              </Button>
+              <Button type="submit" disabled={createMutation.isPending}>
+                {createMutation.isPending ? "요청 중..." : "요청 보내기"}
+              </Button>
+            </DialogFooter>
+          </form>
+        ) : (
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="delete-request-message">삭제 사유</Label>
+              <Textarea
+                id="delete-request-message"
+                rows={3}
+                className="resize-none"
+                placeholder="삭제가 필요한 이유를 입력해주세요."
+                {...form.register("message")}
+              />
+            </div>
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={createMutation.isPending}
+              >
+                취소
+              </Button>
+              <Button
+                type="button"
+                onClick={handleDeleteSubmit}
+                disabled={createMutation.isPending}
+              >
+                {createMutation.isPending ? "요청 중..." : "요청 보내기"}
+              </Button>
+            </DialogFooter>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/transactions/TransactionEditDialog.tsx
+++ b/components/transactions/TransactionEditDialog.tsx
@@ -18,25 +18,10 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import {
-  Drawer,
-  DrawerContent,
-  DrawerDescription,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerTitle,
-} from "@/components/ui/drawer";
+import { Drawer, DrawerContent } from "@/components/ui/drawer";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
-import { useAccounts } from "@/hooks/use-accounts";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { useUpdateTransaction } from "@/hooks/use-transaction";
 import type { TransactionWithDetails } from "@/lib/api/transaction";
@@ -72,7 +57,6 @@ export function TransactionEditDialog({
   onOpenChange,
 }: TransactionEditDialogProps) {
   const updateMutation = useUpdateTransaction();
-  const { data: accounts } = useAccounts();
   const isDesktop = useMediaQuery("(min-width: 768px)");
 
   const {
@@ -219,6 +203,7 @@ export function TransactionEditDialog({
         variant="inline"
         placeholder="계좌 선택"
         allowClear={true}
+        ownerId={transaction.owner.id}
       />
 
       {/* 메모 */}

--- a/components/transactions/TransactionTable.tsx
+++ b/components/transactions/TransactionTable.tsx
@@ -23,7 +23,6 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import type { TransactionWithDetails } from "@/lib/api/transaction";
-import { cn } from "@/lib/utils/cn";
 import {
   formatCompactCurrency,
   formatCurrency,

--- a/components/transactions/records/StockRecordDayList.test.tsx
+++ b/components/transactions/records/StockRecordDayList.test.tsx
@@ -11,6 +11,10 @@ vi.mock("@/components/transactions/TransactionDeleteDialog", () => ({
   TransactionDeleteDialog: () => null,
 }));
 
+vi.mock("@/components/transactions/TransactionChangeRequestDialog", () => ({
+  TransactionChangeRequestDialog: () => null,
+}));
+
 const transaction: TransactionWithDetails = {
   id: "tx-1",
   ticker: "LONG",

--- a/components/transactions/records/StockRecordDayList.tsx
+++ b/components/transactions/records/StockRecordDayList.tsx
@@ -9,6 +9,7 @@ import {
   Wallet,
 } from "lucide-react";
 import { useState } from "react";
+import { TransactionChangeRequestDialog } from "@/components/transactions/TransactionChangeRequestDialog";
 import { TransactionDeleteDialog } from "@/components/transactions/TransactionDeleteDialog";
 import { TransactionEditDialog } from "@/components/transactions/TransactionEditDialog";
 import { Badge } from "@/components/ui/badge";
@@ -25,7 +26,6 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import type { TransactionWithDetails } from "@/lib/api/transaction";
-import { cn } from "@/lib/utils/cn";
 import {
   formatCompactCurrency,
   formatCurrency,
@@ -50,6 +50,10 @@ export function StockRecordDayList({
   const [deleteTransaction, setDeleteTransaction] =
     useState<TransactionWithDetails | null>(null);
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const [requestTransaction, setRequestTransaction] =
+    useState<TransactionWithDetails | null>(null);
+  const [requestMode, setRequestMode] = useState<"update" | "delete">("update");
+  const [isRequestOpen, setIsRequestOpen] = useState(false);
 
   return (
     <>
@@ -77,41 +81,67 @@ export function StockRecordDayList({
                   className="group relative flex min-h-[72px] flex-col justify-center border-gray-100 border-t px-4 py-3.5 first:border-t-0 sm:px-5"
                 >
                   <div className="absolute right-2 top-1/2 z-10 -translate-y-1/2">
-                    {isOwner && (
-                      <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="size-7 text-gray-400 hover:text-gray-600"
-                          >
-                            <MoreVertical className="size-4" />
-                            <span className="sr-only">메뉴 열기</span>
-                          </Button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end">
-                          <DropdownMenuItem
-                            onClick={() => {
-                              setEditTransaction(transaction);
-                              setIsEditOpen(true);
-                            }}
-                          >
-                            <Pencil className="mr-2 size-4" />
-                            수정
-                          </DropdownMenuItem>
-                          <DropdownMenuItem
-                            onClick={() => {
-                              setDeleteTransaction(transaction);
-                              setIsDeleteOpen(true);
-                            }}
-                            className="text-destructive focus:text-destructive"
-                          >
-                            <Trash2 className="mr-2 size-4" />
-                            삭제
-                          </DropdownMenuItem>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-                    )}
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="size-7 text-gray-400 hover:text-gray-600"
+                        >
+                          <MoreVertical className="size-4" />
+                          <span className="sr-only">메뉴 열기</span>
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        {isOwner ? (
+                          <>
+                            <DropdownMenuItem
+                              onClick={() => {
+                                setEditTransaction(transaction);
+                                setIsEditOpen(true);
+                              }}
+                            >
+                              <Pencil className="mr-2 size-4" />
+                              수정
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              onClick={() => {
+                                setDeleteTransaction(transaction);
+                                setIsDeleteOpen(true);
+                              }}
+                              className="text-destructive focus:text-destructive"
+                            >
+                              <Trash2 className="mr-2 size-4" />
+                              삭제
+                            </DropdownMenuItem>
+                          </>
+                        ) : (
+                          <>
+                            <DropdownMenuItem
+                              onClick={() => {
+                                setRequestTransaction(transaction);
+                                setRequestMode("update");
+                                setIsRequestOpen(true);
+                              }}
+                            >
+                              <Pencil className="mr-2 size-4" />
+                              수정 요청
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              onClick={() => {
+                                setRequestTransaction(transaction);
+                                setRequestMode("delete");
+                                setIsRequestOpen(true);
+                              }}
+                              className="text-destructive focus:text-destructive"
+                            >
+                              <Trash2 className="mr-2 size-4" />
+                              삭제 요청
+                            </DropdownMenuItem>
+                          </>
+                        )}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
                   </div>
 
                   <div className="flex min-w-0 flex-col gap-1 pr-6">
@@ -194,6 +224,12 @@ export function StockRecordDayList({
         transaction={deleteTransaction}
         open={isDeleteOpen}
         onOpenChange={setIsDeleteOpen}
+      />
+      <TransactionChangeRequestDialog
+        transaction={requestTransaction}
+        mode={requestMode}
+        open={isRequestOpen}
+        onOpenChange={setIsRequestOpen}
       />
     </>
   );

--- a/hooks/use-record-change-requests.ts
+++ b/hooks/use-record-change-requests.ts
@@ -123,6 +123,9 @@ export function useResolveRecordChangeRequest() {
       queryClient.invalidateQueries({ queryKey: queries.ledgerEntries._def });
       queryClient.invalidateQueries({ queryKey: queries.accounts._def });
       queryClient.invalidateQueries({ queryKey: queries.paymentMethods._def });
+      queryClient.invalidateQueries({ queryKey: queries.transactions._def });
+      queryClient.invalidateQueries({ queryKey: queries.holdings._def });
+      queryClient.invalidateQueries({ queryKey: queries.dashboard._def });
     },
   });
 }

--- a/lib/api/ledger.test.ts
+++ b/lib/api/ledger.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
+import { APIError } from "./error";
 import {
+  assertLedgerFinancialSourceOwnership,
   buildLedgerEntryPayload,
   buildTransferLedgerEntryPayload,
   calculateLedgerSummary,
@@ -212,6 +214,69 @@ describe("getLedgerBalanceEffects", () => {
     expect(effects).toEqual([
       { table: "payment_methods", id: "pm-1", delta: -12000 },
     ]);
+  });
+});
+
+describe("assertLedgerFinancialSourceOwnership", () => {
+  function createFinancialSourceSupabaseMock({
+    accounts = [],
+    paymentMethods = [],
+  }: {
+    accounts?: Array<{ id: string; owner_id: string }>;
+    paymentMethods?: Array<{ id: string; owner_id: string }>;
+  }) {
+    const createBuilder = (rows: Array<{ id: string; owner_id: string }>) => ({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      in: vi.fn().mockResolvedValue({ data: rows, error: null }),
+    });
+    const accountsBuilder = createBuilder(accounts);
+    const paymentMethodsBuilder = createBuilder(paymentMethods);
+
+    return {
+      from: vi.fn((table: string) =>
+        table === "accounts" ? accountsBuilder : paymentMethodsBuilder,
+      ),
+      accountsBuilder,
+      paymentMethodsBuilder,
+    };
+  }
+
+  it("기록 소유자의 계좌와 결제수단이면 허용한다", async () => {
+    const supabase = createFinancialSourceSupabaseMock({
+      accounts: [{ id: "acc-1", owner_id: "user-1" }],
+      paymentMethods: [{ id: "pm-1", owner_id: "user-1" }],
+    });
+
+    await expect(
+      assertLedgerFinancialSourceOwnership(supabase as never, {
+        householdId: "household-1",
+        ownerId: "user-1",
+        accountIds: ["acc-1"],
+        paymentMethodIds: ["pm-1"],
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("다른 구성원의 Financial Source이면 거부한다", async () => {
+    const supabase = createFinancialSourceSupabaseMock({
+      accounts: [{ id: "acc-1", owner_id: "other-user" }],
+    });
+
+    await expect(
+      assertLedgerFinancialSourceOwnership(supabase as never, {
+        householdId: "household-1",
+        ownerId: "user-1",
+        accountIds: ["acc-1"],
+        paymentMethodIds: [],
+      }),
+    ).rejects.toMatchObject(
+      new APIError(
+        "LEDGER_FINANCIAL_SOURCE_FORBIDDEN",
+        "본인의 계좌 또는 결제수단만 기록에 사용할 수 있습니다.",
+        403,
+      ),
+    );
   });
 });
 

--- a/lib/api/ledger.ts
+++ b/lib/api/ledger.ts
@@ -170,6 +170,72 @@ export interface UpdateLedgerEntryParams {
   memo?: string | null;
 }
 
+interface LedgerFinancialSourceOwnershipInput {
+  householdId: string;
+  ownerId: string;
+  accountIds?: Array<string | null | undefined>;
+  paymentMethodIds?: Array<string | null | undefined>;
+}
+
+function uniqueDefined(values: Array<string | null | undefined>) {
+  return [...new Set(values.filter(Boolean) as string[])];
+}
+
+export async function assertLedgerFinancialSourceOwnership(
+  supabase: SupabaseClient<Database>,
+  input: LedgerFinancialSourceOwnershipInput,
+): Promise<void> {
+  const accountIds = uniqueDefined(input.accountIds ?? []);
+  const paymentMethodIds = uniqueDefined(input.paymentMethodIds ?? []);
+
+  const [accountsResult, paymentMethodsResult] = await Promise.all([
+    accountIds.length > 0
+      ? supabase
+          .from("accounts")
+          .select("id, owner_id")
+          .eq("household_id", input.householdId)
+          .in("id", accountIds)
+      : Promise.resolve({ data: [], error: null }),
+    paymentMethodIds.length > 0
+      ? supabase
+          .from("payment_methods")
+          .select("id, owner_id")
+          .eq("household_id", input.householdId)
+          .in("id", paymentMethodIds)
+      : Promise.resolve({ data: [], error: null }),
+  ]);
+
+  if (accountsResult.error || paymentMethodsResult.error) {
+    throw new APIError(
+      "LEDGER_FINANCIAL_SOURCE_FETCH_ERROR",
+      "계좌 또는 결제수단 확인에 실패했습니다.",
+      500,
+    );
+  }
+
+  const accountMap = new Map(
+    (accountsResult.data ?? []).map((row) => [row.id, row.owner_id]),
+  );
+  const paymentMethodMap = new Map(
+    (paymentMethodsResult.data ?? []).map((row) => [row.id, row.owner_id]),
+  );
+
+  const hasInvalidAccount = accountIds.some(
+    (id) => accountMap.get(id) !== input.ownerId,
+  );
+  const hasInvalidPaymentMethod = paymentMethodIds.some(
+    (id) => paymentMethodMap.get(id) !== input.ownerId,
+  );
+
+  if (hasInvalidAccount || hasInvalidPaymentMethod) {
+    throw new APIError(
+      "LEDGER_FINANCIAL_SOURCE_FORBIDDEN",
+      "본인의 계좌 또는 결제수단만 기록에 사용할 수 있습니다.",
+      403,
+    );
+  }
+}
+
 export interface LedgerBalanceEffectInput {
   type: LedgerEntryType;
   amount: number;
@@ -738,6 +804,13 @@ export async function createLedgerEntryWithBalanceSync(
   supabase: SupabaseClient<Database>,
   params: CreateLedgerEntryParams,
 ): Promise<LedgerEntry> {
+  await assertLedgerFinancialSourceOwnership(supabase, {
+    householdId: params.householdId,
+    ownerId: params.ownerId,
+    accountIds: [params.fromAccountId, params.toAccountId],
+    paymentMethodIds: [params.fromPaymentMethodId, params.toPaymentMethodId],
+  });
+
   const effects = getLedgerBalanceEffects(toBalanceEffectInput(params));
 
   await applyLedgerBalanceEffects(
@@ -897,6 +970,13 @@ export async function updateLedgerEntryWithBalanceSync(
     params.toPaymentMethodId !== undefined
       ? params.toPaymentMethodId
       : existing.to_payment_method_id;
+
+  await assertLedgerFinancialSourceOwnership(supabase, {
+    householdId: existing.household_id,
+    ownerId,
+    accountIds: [nextFromAccountId, nextToAccountId],
+    paymentMethodIds: [nextFromPaymentMethodId, nextToPaymentMethodId],
+  });
 
   const oldEffects = getLedgerBalanceEffects({
     type: existing.type,

--- a/lib/api/record-change-requests.test.ts
+++ b/lib/api/record-change-requests.test.ts
@@ -3,6 +3,7 @@ import {
   deleteLedgerEntryWithBalanceSync,
   updateLedgerEntryWithBalanceSync,
 } from "@/lib/api/ledger";
+import { deleteTransaction, updateTransaction } from "@/lib/api/transaction";
 import type { RecordChangeRequest } from "@/types";
 import { APIError } from "./error";
 import {
@@ -13,6 +14,7 @@ import {
   getRecordChangeRequestListQuery,
   validateLedgerRecordChangeRequestInput,
   validateRecordChangeRequestTarget,
+  validateStockTransactionRecordChangeRequestInput,
 } from "./record-change-requests";
 
 vi.mock("@/lib/api/ledger", () => ({
@@ -20,6 +22,11 @@ vi.mock("@/lib/api/ledger", () => ({
   updateLedgerEntryWithBalanceSync: vi
     .fn()
     .mockResolvedValue({ id: "entry-1" }),
+}));
+
+vi.mock("@/lib/api/transaction", () => ({
+  deleteTransaction: vi.fn().mockResolvedValue(undefined),
+  updateTransaction: vi.fn().mockResolvedValue({ id: "tx-1" }),
 }));
 
 const sharedLedgerEntry = {
@@ -176,6 +183,41 @@ describe("validateLedgerRecordChangeRequestInput", () => {
   });
 });
 
+describe("validateStockTransactionRecordChangeRequestInput", () => {
+  it("주식 거래 수정 요청에서 허용되지 않은 변경 필드를 거부한다", () => {
+    expect(() =>
+      validateStockTransactionRecordChangeRequestInput({
+        targetType: "stock_transaction",
+        targetId: "00000000-0000-4000-8000-000000000001",
+        requestType: "update",
+        proposedChanges: { ticker: "AAPL" },
+      }),
+    ).toThrow(APIError);
+  });
+
+  it("주식 거래 수정 요청에서 빈 변경안을 거부한다", () => {
+    expect(() =>
+      validateStockTransactionRecordChangeRequestInput({
+        targetType: "stock_transaction",
+        targetId: "00000000-0000-4000-8000-000000000001",
+        requestType: "update",
+        proposedChanges: {},
+      }),
+    ).toThrow(APIError);
+  });
+
+  it("주식 거래 삭제 요청은 삭제 사유가 필요하다", () => {
+    expect(() =>
+      validateStockTransactionRecordChangeRequestInput({
+        targetType: "stock_transaction",
+        targetId: "00000000-0000-4000-8000-000000000001",
+        requestType: "delete",
+        proposedChanges: {},
+      }),
+    ).toThrow(APIError);
+  });
+});
+
 describe("buildRecordChangeRequestInsert", () => {
   it("request body의 owner 값 없이 서버 검증 결과로 insert payload를 만든다", () => {
     const result = buildRecordChangeRequestInsert({
@@ -296,6 +338,116 @@ describe("applyApprovedRecordChangeRequest", () => {
       {},
       "entry-1",
       "owner-1",
+    );
+  });
+
+  function createStockApplySupabaseMock(row: unknown) {
+    const builder = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: row, error: null }),
+    };
+
+    return {
+      from: vi.fn(() => builder),
+      builder,
+    };
+  }
+
+  const stockRequest = {
+    id: "request-1",
+    household_id: "household-1",
+    requester_id: "requester-1",
+    target_owner_id: "owner-1",
+    target_type: "stock_transaction",
+    target_id: "tx-1",
+    request_type: "update",
+    proposed_changes: {
+      quantity: 12,
+      price: 71000,
+      transactedAt: "2026-06-02T00:00:00.000Z",
+      accountId: "00000000-0000-4000-8000-000000000002",
+      memo: "정정",
+    },
+    target_snapshot: {
+      targetType: "stock_transaction",
+      ticker: "005930",
+      type: "buy",
+      quantity: 10,
+      price: 70000,
+      transactedAt: "2026-06-01T00:00:00.000Z",
+      accountId: "00000000-0000-4000-8000-000000000001",
+    },
+  } as unknown as RecordChangeRequest;
+
+  const currentStockTransaction = {
+    id: "tx-1",
+    household_id: "household-1",
+    owner_id: "owner-1",
+    ticker: "005930",
+    type: "buy",
+    quantity: 10,
+    price: 70000,
+    transacted_at: "2026-06-01T00:00:00.000Z",
+    account_id: "00000000-0000-4000-8000-000000000001",
+    memo: null,
+  };
+
+  it("주식 거래 수정 요청 승인 시 기존 거래 수정 함수에 위임한다", async () => {
+    const supabase = createStockApplySupabaseMock(currentStockTransaction);
+
+    await applyApprovedRecordChangeRequest(supabase as never, stockRequest);
+
+    expect(updateTransaction).toHaveBeenCalledWith(
+      supabase,
+      "tx-1",
+      "household-1",
+      "owner-1",
+      {
+        quantity: 12,
+        price: 71000,
+        transactedAt: "2026-06-02T00:00:00.000Z",
+        accountId: "00000000-0000-4000-8000-000000000002",
+        memo: "정정",
+      },
+    );
+  });
+
+  it("주식 거래 삭제 요청 승인 시 기존 거래 삭제 함수에 위임한다", async () => {
+    const supabase = createStockApplySupabaseMock(currentStockTransaction);
+
+    await applyApprovedRecordChangeRequest(
+      supabase as never,
+      {
+        ...stockRequest,
+        request_type: "delete",
+        proposed_changes: {},
+        message: "중복 거래",
+      } as unknown as RecordChangeRequest,
+    );
+
+    expect(deleteTransaction).toHaveBeenCalledWith(
+      supabase,
+      "tx-1",
+      "household-1",
+      "owner-1",
+    );
+  });
+
+  it("주식 거래가 요청 이후 변경되었으면 승인을 거부한다", async () => {
+    const supabase = createStockApplySupabaseMock({
+      ...currentStockTransaction,
+      quantity: 8,
+    });
+
+    await expect(
+      applyApprovedRecordChangeRequest(supabase as never, stockRequest),
+    ).rejects.toMatchObject(
+      new APIError(
+        "RECORD_CHANGE_REQUEST_TARGET_STALE",
+        "요청 이후 대상 기록이 변경되었습니다. 새 요청이 필요합니다.",
+        409,
+      ),
     );
   });
 });

--- a/lib/api/record-change-requests.ts
+++ b/lib/api/record-change-requests.ts
@@ -5,12 +5,16 @@ import {
   updateLedgerEntryWithBalanceSync,
 } from "@/lib/api/ledger";
 import { createUserNotification } from "@/lib/api/notifications";
+import { deleteTransaction, updateTransaction } from "@/lib/api/transaction";
 import type {
   CreateRecordChangeRequestInput,
   ListRecordChangeRequestsInput,
   ResolveRecordChangeRequestInput,
 } from "@/schemas/record-change-request";
-import { ledgerRecordUpdateProposedChangesSchema } from "@/schemas/record-change-request";
+import {
+  ledgerRecordUpdateProposedChangesSchema,
+  stockTransactionUpdateProposedChangesSchema,
+} from "@/schemas/record-change-request";
 import type { Database, Json, RecordChangeRequest } from "@/types";
 
 export interface ValidatedRecordChangeRequestTarget {
@@ -50,6 +54,7 @@ interface StockTransactionTargetRow {
   price: number | string;
   transacted_at: string;
   account_id: string | null;
+  memo: string | null;
   profiles: { name: string | null } | null;
 }
 
@@ -60,11 +65,14 @@ type RequestActionRow = Pick<
 
 type ApprovableRecordChangeRequest = Pick<
   RecordChangeRequest,
+  | "household_id"
+  | "message"
   | "target_owner_id"
   | "target_type"
   | "target_id"
   | "request_type"
   | "proposed_changes"
+  | "target_snapshot"
 >;
 
 function toJsonObject(value: Record<string, unknown>): Json {
@@ -189,6 +197,7 @@ export async function validateRecordChangeRequestTarget(
       price,
       transacted_at,
       account_id,
+      memo,
       profiles!transactions_owner_id_fkey(name)
     `)
     .eq("id", input.targetId)
@@ -224,6 +233,7 @@ export async function validateRecordChangeRequestTarget(
       quantity: Number(row.quantity),
       price: Number(row.price),
       accountId: row.account_id,
+      memo: row.memo,
     },
   };
 }
@@ -248,12 +258,63 @@ export function validateLedgerRecordChangeRequestInput(
   }
 }
 
+export function validateStockTransactionRecordChangeRequestInput(
+  input: CreateRecordChangeRequestInput,
+) {
+  if (input.targetType !== "stock_transaction") {
+    return;
+  }
+
+  if (input.requestType === "delete") {
+    if (!input.message?.trim()) {
+      throw new APIError(
+        "RECORD_CHANGE_REQUEST_MESSAGE_REQUIRED",
+        "삭제 요청 사유를 입력해주세요.",
+        400,
+      );
+    }
+    return;
+  }
+
+  const result = stockTransactionUpdateProposedChangesSchema.safeParse(
+    input.proposedChanges,
+  );
+
+  if (!result.success) {
+    throw new APIError(
+      "RECORD_CHANGE_REQUEST_PROPOSED_CHANGES_INVALID",
+      result.error.issues[0]?.message ?? "유효하지 않은 수정 요청입니다.",
+      400,
+    );
+  }
+}
+
+async function buildStockTransactionRequestNotificationTitle(
+  supabase: SupabaseClient<Database>,
+  requesterId: string,
+  requestType: "update" | "delete",
+  targetSnapshot: Record<string, unknown>,
+) {
+  const { data } = await supabase
+    .from("profiles")
+    .select("name")
+    .eq("id", requesterId)
+    .single();
+  const requesterName = data?.name ?? "가구 구성원";
+  const ticker =
+    typeof targetSnapshot.ticker === "string" ? targetSnapshot.ticker : "주식";
+  const action = requestType === "update" ? "수정" : "삭제";
+
+  return `${requesterName}님이 ${ticker} 거래 ${action}을 요청했습니다`;
+}
+
 export async function createRecordChangeRequest(
   supabase: SupabaseClient<Database>,
   requesterId: string,
   input: CreateRecordChangeRequestInput,
 ): Promise<RecordChangeRequest> {
   validateLedgerRecordChangeRequestInput(input);
+  validateStockTransactionRecordChangeRequestInput(input);
 
   const validatedTarget = await validateRecordChangeRequestTarget(
     supabase,
@@ -283,6 +344,16 @@ export async function createRecordChangeRequest(
     throw error;
   }
 
+  const notificationTitle =
+    input.targetType === "stock_transaction"
+      ? await buildStockTransactionRequestNotificationTitle(
+          supabase,
+          requesterId,
+          input.requestType,
+          validatedTarget.targetSnapshot,
+        )
+      : "수정/삭제 요청이 도착했습니다";
+
   await createUserNotification({
     recipientId: validatedTarget.targetOwnerId,
     householdId: validatedTarget.householdId,
@@ -290,7 +361,7 @@ export async function createRecordChangeRequest(
       input.targetType === "ledger_entry"
         ? "ledger_record_change_request"
         : "stock_transaction_change_request",
-    title: "수정/삭제 요청이 도착했습니다",
+    title: notificationTitle,
     body: input.message ?? null,
     link: {
       kind: "record_change_request_detail",
@@ -417,10 +488,105 @@ export async function applyApprovedRecordChangeRequest(
     return;
   }
 
-  throw new APIError(
-    "RECORD_CHANGE_REQUEST_APPLY_NOT_IMPLEMENTED",
-    "요청 승인 반영은 대상 도메인 구현에서 처리해야 합니다.",
-    501,
+  await applyApprovedStockTransactionChangeRequest(supabase, request);
+}
+
+interface CurrentStockTransactionRow {
+  id: string;
+  household_id: string;
+  owner_id: string;
+  ticker: string;
+  type: string;
+  quantity: number | string;
+  price: number | string;
+  transacted_at: string;
+  account_id: string | null;
+  memo: string | null;
+}
+
+function toRecord(value: Json): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  return value as Record<string, unknown>;
+}
+
+function assertStockTransactionSnapshotMatches(
+  current: CurrentStockTransactionRow,
+  snapshot: Record<string, unknown>,
+) {
+  const matches =
+    snapshot.targetType === "stock_transaction" &&
+    snapshot.ticker === current.ticker &&
+    snapshot.type === current.type &&
+    Number(snapshot.quantity) === Number(current.quantity) &&
+    Number(snapshot.price) === Number(current.price) &&
+    snapshot.transactedAt === current.transacted_at &&
+    (snapshot.accountId ?? null) === current.account_id &&
+    (snapshot.memo ?? null) === current.memo;
+
+  if (!matches) {
+    throw new APIError(
+      "RECORD_CHANGE_REQUEST_TARGET_STALE",
+      "요청 이후 대상 기록이 변경되었습니다. 새 요청이 필요합니다.",
+      409,
+    );
+  }
+}
+
+export async function applyApprovedStockTransactionChangeRequest(
+  supabase: SupabaseClient<Database>,
+  request: ApprovableRecordChangeRequest,
+): Promise<void> {
+  const { data, error } = await supabase
+    .from("transactions")
+    .select(
+      "id, household_id, owner_id, ticker, type, quantity, price, transacted_at, account_id, memo",
+    )
+    .eq("id", request.target_id)
+    .eq("household_id", request.household_id)
+    .single();
+
+  if (error || !data) {
+    throw new APIError(
+      "RECORD_CHANGE_REQUEST_TARGET_NOT_FOUND",
+      "요청 대상 기록을 찾을 수 없습니다.",
+      404,
+    );
+  }
+
+  const current = data as unknown as CurrentStockTransactionRow;
+
+  if (current.owner_id !== request.target_owner_id) {
+    throw new APIError(
+      "RECORD_CHANGE_REQUEST_TARGET_STALE",
+      "요청 이후 대상 기록이 변경되었습니다. 새 요청이 필요합니다.",
+      409,
+    );
+  }
+
+  assertStockTransactionSnapshotMatches(
+    current,
+    toRecord(request.target_snapshot),
+  );
+
+  if (request.request_type === "delete") {
+    await deleteTransaction(
+      supabase,
+      request.target_id,
+      request.household_id,
+      request.target_owner_id,
+    );
+    return;
+  }
+
+  const proposedChanges = stockTransactionUpdateProposedChangesSchema.parse(
+    request.proposed_changes,
+  );
+  await updateTransaction(
+    supabase,
+    request.target_id,
+    request.household_id,
+    request.target_owner_id,
+    proposedChanges,
   );
 }
 

--- a/lib/api/transaction.test.ts
+++ b/lib/api/transaction.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { getTransactions } from "./transaction";
+import { APIError } from "./error";
+import {
+  assertTransactionAccountOwnership,
+  getTransactions,
+} from "./transaction";
 
 function createTransactionsSupabaseMock() {
   const transactionRows = [
@@ -73,5 +77,60 @@ describe("getTransactions", () => {
     });
 
     expect(result.data[0].accountName).toBe("삼성증권");
+  });
+});
+
+describe("assertTransactionAccountOwnership", () => {
+  function createAccountOwnershipSupabaseMock(row: unknown) {
+    const builder = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: row, error: null }),
+    };
+
+    return {
+      from: vi.fn(() => builder),
+      builder,
+    };
+  }
+
+  it("거래 소유자의 계좌이면 허용한다", async () => {
+    const supabase = createAccountOwnershipSupabaseMock({
+      id: "account-1",
+      household_id: "household-1",
+      owner_id: "user-1",
+    });
+
+    await expect(
+      assertTransactionAccountOwnership(
+        supabase as never,
+        "household-1",
+        "user-1",
+        "account-1",
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("다른 구성원의 계좌이면 거부한다", async () => {
+    const supabase = createAccountOwnershipSupabaseMock({
+      id: "account-1",
+      household_id: "household-1",
+      owner_id: "other-user",
+    });
+
+    await expect(
+      assertTransactionAccountOwnership(
+        supabase as never,
+        "household-1",
+        "user-1",
+        "account-1",
+      ),
+    ).rejects.toMatchObject(
+      new APIError(
+        "TRANSACTION_ACCOUNT_FORBIDDEN",
+        "본인의 계좌만 거래에 사용할 수 있습니다.",
+        403,
+      ),
+    );
   });
 });

--- a/lib/api/transaction.ts
+++ b/lib/api/transaction.ts
@@ -57,6 +57,13 @@ export async function createTransaction(
     stock,
   } = params;
 
+  await assertTransactionAccountOwnership(
+    supabase,
+    householdId,
+    ownerId,
+    accountId,
+  );
+
   // 1. household_stock_settings UPSERT (첫 거래 시 자동 생성)
   // risk_level은 null로 저장 → asset_type 기반 기본값 사용 (Application 레벨)
   const { error: settingsError } = await supabase
@@ -351,6 +358,38 @@ export interface UpdateTransactionParams {
   accountId?: string | null;
 }
 
+export async function assertTransactionAccountOwnership(
+  supabase: SupabaseClient<Database>,
+  householdId: string,
+  ownerId: string,
+  accountId: string | null | undefined,
+): Promise<void> {
+  if (!accountId) return;
+
+  const { data, error } = await supabase
+    .from("accounts")
+    .select("id, household_id, owner_id")
+    .eq("id", accountId)
+    .eq("household_id", householdId)
+    .single();
+
+  if (error || !data) {
+    throw new APIError(
+      "TRANSACTION_ACCOUNT_NOT_FOUND",
+      "거래에 사용할 계좌를 찾을 수 없습니다.",
+      404,
+    );
+  }
+
+  if (data.owner_id !== ownerId) {
+    throw new APIError(
+      "TRANSACTION_ACCOUNT_FORBIDDEN",
+      "본인의 계좌만 거래에 사용할 수 있습니다.",
+      403,
+    );
+  }
+}
+
 /**
  * 단일 거래 조회
  */
@@ -401,14 +440,20 @@ export async function updateTransaction(
     throw new APIError("FORBIDDEN", "본인의 거래만 수정할 수 있습니다.", 403);
   }
 
+  const targetAccountId =
+    params.accountId !== undefined
+      ? params.accountId
+      : existingTransaction.account_id;
+  await assertTransactionAccountOwnership(
+    supabase,
+    householdId,
+    userId,
+    targetAccountId,
+  );
+
   // 3. 매도 거래 수정 시 해당 계좌의 보유 수량 재검증
   if (existingTransaction.type === "sell" && params.quantity !== undefined) {
     // 계좌가 변경되는 경우 새 계좌의 보유 수량 확인, 아니면 기존 계좌
-    const targetAccountId =
-      params.accountId !== undefined
-        ? params.accountId
-        : existingTransaction.account_id;
-
     if (targetAccountId) {
       const currentQuantity = await getHoldingQuantity(
         supabase,
@@ -537,6 +582,22 @@ export async function createBatchTransactions(
   params: CreateBatchTransactionsParams,
 ): Promise<Transaction[]> {
   const { householdId, ownerId, type, transactedAt, accountId, items } = params;
+
+  const accountIds = [
+    ...new Set(
+      [accountId, ...items.map((item) => item.accountId)].filter(
+        Boolean,
+      ) as string[],
+    ),
+  ];
+  for (const targetAccountId of accountIds) {
+    await assertTransactionAccountOwnership(
+      supabase,
+      householdId,
+      ownerId,
+      targetAccountId,
+    );
+  }
 
   // 1. 종목별 stock_settings UPSERT (중복 제거)
   const uniqueTickersMap = new Map<string, BatchTransactionItem>();

--- a/lib/ledger/money-source-options.ts
+++ b/lib/ledger/money-source-options.ts
@@ -6,6 +6,7 @@ export type LedgerMoneySourceKind = "none" | "paymentMethod" | "account";
 export interface LedgerMoneySourcePaymentMethod {
   id: string;
   name: string;
+  ownerId?: string;
   ownerName: string;
   type: PaymentMethodType;
   issuer: string | null;
@@ -15,6 +16,7 @@ export interface LedgerMoneySourcePaymentMethod {
 export interface LedgerMoneySourceAccount {
   id: string;
   name: string;
+  ownerId?: string;
   ownerName: string;
   broker: string | null;
   lastFour: string | null;

--- a/schemas/record-change-request.ts
+++ b/schemas/record-change-request.ts
@@ -60,6 +60,38 @@ export type LedgerRecordUpdateProposedChanges = z.infer<
   typeof ledgerRecordUpdateProposedChangesSchema
 >;
 
+export const stockTransactionUpdateProposedChangesSchema = z
+  .object({
+    quantity: z
+      .number()
+      .positive("수량은 0보다 커야 합니다.")
+      .max(999999999, "수량이 너무 큽니다.")
+      .optional(),
+    price: z
+      .number()
+      .min(0, "가격은 0 이상이어야 합니다.")
+      .max(999999999999, "가격이 너무 큽니다.")
+      .optional(),
+    transactedAt: z
+      .string()
+      .datetime("올바른 날짜 형식이 아닙니다.")
+      .optional(),
+    accountId: z.uuid("유효한 계좌 ID가 아닙니다.").optional(),
+    memo: z
+      .string()
+      .max(500, "메모는 500자 이내여야 합니다.")
+      .nullable()
+      .optional(),
+  })
+  .strict()
+  .refine((value) => Object.keys(value).length > 0, {
+    message: "변경할 항목을 하나 이상 입력해주세요.",
+  });
+
+export type StockTransactionUpdateProposedChanges = z.infer<
+  typeof stockTransactionUpdateProposedChangesSchema
+>;
+
 export const createRecordChangeRequestSchema = z.object({
   targetType: recordChangeRequestTargetTypeSchema,
   targetId: z.uuid("유효한 대상 ID가 아닙니다."),


### PR DESCRIPTION
## Summary

Implements #346.

- Add stock transaction update/delete request entrypoints and dialog for non-owners.
- Apply approved stock requests through stale snapshot validation and existing transaction update/delete logic.
- Restrict account/payment-method write selectors and server writes to the record owner's Financial Sources for stock and ledger flows.
- Add stock summaries to the common request detail view and update notification/domain docs.

## Validation

- pnpm check
- pnpm type-check
- pnpm test
- pnpm build
