### PR TITLE
[codex] Add stock transaction notifications

### DIFF
--- a/.claude/docs/NOTIFICATIONS.md
+++ b/.claude/docs/NOTIFICATIONS.md
@@ -675,6 +675,83 @@ DB 제약은 #344 추가 마이그레이션에서 기존 `request_type` 포함 p
 - 범위: transaction 생성/수정/삭제 시 작성자를 제외한 구성원에게 알림을 만든다. 생성 알림은 기본 off 또는 조건부로 둔다.
 - 완료 기준: 거래 수정/삭제는 기본 알림으로 전달되고, 새 거래 추가 알림은 사용자별 설정을 켰을 때만 전달된다.
 
+#### 확정 설계
+
+**범위 경계**
+
+#347은 사용자가 주식 거래 API에서 직접 생성/수정/삭제한 거래 원장 변경만 다룬다. #346의 Record Change Request 승인으로 `updateTransaction` 또는 `deleteTransaction`이 호출되어 원본 거래가 바뀌더라도 #347에서 별도 `stock_transaction_changed` 알림을 만들지 않는다. 요청 승인/거절/취소 결과 알림은 #348에서 처리한다.
+
+**알림 생성 위치**
+
+주식 거래 알림은 별도 helper에서 fan-out한다.
+
+```txt
+lib/api/stock-transaction-notifications.ts
+```
+
+거래 API route는 원본 작업 성공 후 helper를 best effort로 호출한다.
+
+- `POST /api/transactions`: 단건 생성 알림
+- `POST /api/transactions/batch`: batch 생성 요약 알림
+- `PATCH /api/transactions/[id]`: 수정 알림
+- `DELETE /api/transactions/[id]`: 삭제 알림
+
+알림 생성 실패는 원본 거래 생성/수정/삭제를 실패시키지 않는다. 실패하면 서버 로그에 남긴다.
+
+**수신자와 Preference**
+
+수신자는 작성자를 제외한 같은 가구 구성원이다. User Notification 생성은 기존 `createUserNotification`을 사용하므로 사용자별 Notification Preference를 따른다.
+
+| Notification Type | 기본값 | 사용 시점 |
+|-------------------|:------:|-----------|
+| `stock_transaction_created` | in-app off | 단건/batch 거래 생성 |
+| `stock_transaction_changed` | in-app on | 거래 수정/삭제 |
+
+**링크 정책**
+
+모든 주식 거래 변경 알림은 `stock_record_date` 링크를 사용한다.
+
+| 이벤트 | 링크 날짜 |
+|--------|-----------|
+| 단건 생성 | 생성된 거래의 `transacted_at` |
+| batch 생성 | 생성된 거래 중 가장 최신 `transacted_at` |
+| 수정 | 수정 후 거래의 `transacted_at` |
+| 삭제 | 삭제 전 거래의 `transacted_at` |
+
+현재 앱의 canonical route는 `/assets/stock/records?date=YYYY-MM-DD`이다. 종목별 또는 계좌별 링크 kind는 #347 범위에서 추가하지 않는다.
+
+**문구 정책**
+
+알림 문구는 가구 구성원이 이미 조회할 수 있는 최소 거래 맥락만 포함한다. 단건/수정/삭제는 종목, 매수/매도, 수량 정도를 포함하고, batch는 거래별 상세 없이 건수 요약만 포함한다. 단가, 총액, 수정 전후 diff는 #347 범위에서 알림 본문에 넣지 않는다.
+
+예시:
+
+- 제목: `새 주식 거래가 추가되었습니다`
+- 본문: `홍길동님이 AAPL 매수 3주를 추가했습니다.`
+- 제목: `주식 거래 5건이 추가되었습니다`
+- 본문: `홍길동님이 2026-06-03 기준 주식 거래 5건을 추가했습니다.`
+- 제목: `주식 거래가 수정되었습니다`
+- 본문: `홍길동님이 AAPL 매수 기록을 수정했습니다.`
+- 제목: `주식 거래가 삭제되었습니다`
+- 본문: `홍길동님이 AAPL 매수 기록을 삭제했습니다.`
+
+**Dedupe**
+
+단건 생성, 수정, 삭제는 대상 거래 id를 기반으로 dedupe key를 만든다. 같은 거래가 여러 번 수정될 수 있으므로 수정 dedupe key에는 수정 후 `updated_at` 또는 helper 호출 시각처럼 이벤트를 구분할 값을 포함한다.
+
+Batch 생성 API에는 별도 batch id가 없으므로 생성된 거래 id 목록을 사용한다.
+
+```txt
+stock_transaction_created:{transactionId}
+stock_transaction_batch_created:{actorId}:{transactionId1,transactionId2,...}
+stock_transaction_updated:{transactionId}:{updatedAt}
+stock_transaction_deleted:{transactionId}
+```
+
+**삭제 전 거래 정보**
+
+삭제 알림은 삭제 전 거래일과 거래 요약이 필요하다. `deleteTransaction`은 이미 삭제 전 거래를 조회하므로, 삭제 성공 후 삭제된 transaction row를 반환하도록 변경한다. 기존 호출부가 반환값을 무시해도 동작은 깨지지 않는다.
+
 ### Slice 7. 요청 처리 결과와 초대 수락 확인 알림 (#348)
 
 - Type: AFK
@@ -701,3 +778,5 @@ DB 제약은 #344 추가 마이그레이션에서 기존 `request_type` 포함 p
 6. Record Change Request 승인은 대상 원본 기록이 요청 당시 snapshot과 일치할 때만 가능하다.
 7. 생성/수정/요청 승인에서 Financial Source는 기록 소유자의 것만 사용할 수 있다.
 8. 기존 owner mismatch 데이터는 자동 마이그레이션하지 않는다.
+9. 주식 거래 변경 알림(#347)은 직접 거래 API에서 발생한 생성/수정/삭제만 다루며, Record Change Request 승인 결과 알림은 #348에서 다룬다.
+10. 주식 거래 변경 알림 링크는 `stock_record_date`로 통일한다.

--- a/app/api/transactions/[id]/route.ts
+++ b/app/api/transactions/[id]/route.ts
@@ -2,6 +2,10 @@ import { NextResponse } from "next/server";
 import { APIError, toErrorResponse } from "@/lib/api/error";
 import { getUserHouseholdId } from "@/lib/api/invitation";
 import {
+  notifyStockTransactionDeleted,
+  notifyStockTransactionUpdated,
+} from "@/lib/api/stock-transaction-notifications";
+import {
   deleteTransaction,
   getTransactionById,
   updateTransaction,
@@ -129,6 +133,11 @@ export async function PATCH(request: Request, { params }: RouteParams) {
       },
     );
 
+    await notifyStockTransactionUpdated(supabase, {
+      actorId: user.id,
+      transaction,
+    });
+
     return NextResponse.json({ data: transaction });
   } catch (error) {
     if (error instanceof APIError) {
@@ -181,7 +190,17 @@ export async function DELETE(_request: Request, { params }: RouteParams) {
     }
 
     // 거래 삭제
-    await deleteTransaction(supabase, id, householdId, user.id);
+    const transaction = await deleteTransaction(
+      supabase,
+      id,
+      householdId,
+      user.id,
+    );
+
+    await notifyStockTransactionDeleted(supabase, {
+      actorId: user.id,
+      transaction,
+    });
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/app/api/transactions/batch/route.ts
+++ b/app/api/transactions/batch/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { APIError, toErrorResponse } from "@/lib/api/error";
 import { getUserHouseholdId } from "@/lib/api/invitation";
+import { notifyBatchStockTransactionsCreated } from "@/lib/api/stock-transaction-notifications";
 import { createBatchTransactions } from "@/lib/api/transaction";
 import { createClient } from "@/lib/supabase/server";
 import { createBatchTransactionSchema } from "@/schemas/transaction";
@@ -70,6 +71,12 @@ export async function POST(request: Request) {
           assetType: item.stock.assetType,
         },
       })),
+    });
+
+    await notifyBatchStockTransactionsCreated(supabase, {
+      actorId: user.id,
+      householdId,
+      transactions,
     });
 
     return NextResponse.json(

--- a/app/api/transactions/notifications.test.ts
+++ b/app/api/transactions/notifications.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getUserHouseholdId } from "@/lib/api/invitation";
+import {
+  notifyBatchStockTransactionsCreated,
+  notifyStockTransactionCreated,
+  notifyStockTransactionDeleted,
+  notifyStockTransactionUpdated,
+} from "@/lib/api/stock-transaction-notifications";
+import {
+  createBatchTransactions,
+  createTransaction,
+  deleteTransaction,
+  updateTransaction,
+} from "@/lib/api/transaction";
+import { createClient } from "@/lib/supabase/server";
+import {
+  DELETE as deleteTransactionRoute,
+  PATCH as patchTransactionRoute,
+} from "./[id]/route";
+import { POST as postBatchTransactions } from "./batch/route";
+import { POST as postTransaction } from "./route";
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock("@/lib/api/invitation", () => ({
+  getUserHouseholdId: vi.fn(),
+}));
+
+vi.mock("@/lib/api/transaction", () => ({
+  createTransaction: vi.fn(),
+  createBatchTransactions: vi.fn(),
+  updateTransaction: vi.fn(),
+  deleteTransaction: vi.fn(),
+  getTransactionById: vi.fn(),
+}));
+
+vi.mock("@/lib/api/stock-transaction-notifications", () => ({
+  notifyStockTransactionCreated: vi.fn().mockResolvedValue(undefined),
+  notifyBatchStockTransactionsCreated: vi.fn().mockResolvedValue(undefined),
+  notifyStockTransactionUpdated: vi.fn().mockResolvedValue(undefined),
+  notifyStockTransactionDeleted: vi.fn().mockResolvedValue(undefined),
+}));
+
+const createClientMock = vi.mocked(createClient);
+const getUserHouseholdIdMock = vi.mocked(getUserHouseholdId);
+const createTransactionMock = vi.mocked(createTransaction);
+const createBatchTransactionsMock = vi.mocked(createBatchTransactions);
+const updateTransactionMock = vi.mocked(updateTransaction);
+const deleteTransactionMock = vi.mocked(deleteTransaction);
+const notifyStockTransactionCreatedMock = vi.mocked(
+  notifyStockTransactionCreated,
+);
+const notifyBatchStockTransactionsCreatedMock = vi.mocked(
+  notifyBatchStockTransactionsCreated,
+);
+const notifyStockTransactionUpdatedMock = vi.mocked(
+  notifyStockTransactionUpdated,
+);
+const notifyStockTransactionDeletedMock = vi.mocked(
+  notifyStockTransactionDeleted,
+);
+
+const user = { id: "00000000-0000-4000-8000-000000000001" };
+const householdId = "00000000-0000-4000-8000-000000000010";
+const accountId = "00000000-0000-4000-8000-000000000020";
+const transactionId = "00000000-0000-4000-8000-000000000030";
+
+const transaction = {
+  id: transactionId,
+  household_id: householdId,
+  owner_id: user.id,
+  ticker: "AAPL",
+  type: "buy" as const,
+  quantity: 3,
+  price: 195.5,
+  transacted_at: "2026-06-03T03:00:00.000Z",
+  memo: null,
+  account_id: accountId,
+  created_at: "2026-06-03T03:10:00.000Z",
+};
+
+function createSupabaseMock() {
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user }, error: null }),
+    },
+  };
+}
+
+function createJsonRequest(body: unknown): Request {
+  return new Request("http://localhost/api/transactions", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+describe("transaction routes stock notifications", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createClientMock.mockResolvedValue(createSupabaseMock() as never);
+    getUserHouseholdIdMock.mockResolvedValue(householdId);
+  });
+
+  it("단건 거래 생성 성공 후 생성 알림 helper를 호출한다", async () => {
+    createTransactionMock.mockResolvedValue(transaction);
+
+    await postTransaction(
+      createJsonRequest({
+        ticker: "AAPL",
+        type: "buy",
+        quantity: 3,
+        price: 195.5,
+        transactedAt: "2026-06-03T03:00:00.000Z",
+        accountId,
+        stock: {
+          name: "Apple",
+          market: "US",
+          currency: "USD",
+          assetType: "equity",
+        },
+      }),
+    );
+
+    expect(notifyStockTransactionCreatedMock).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        actorId: user.id,
+        householdId,
+        transaction,
+      },
+    );
+  });
+
+  it("batch 거래 생성 성공 후 batch 생성 알림 helper를 호출한다", async () => {
+    createBatchTransactionsMock.mockResolvedValue([transaction]);
+
+    await postBatchTransactions(
+      createJsonRequest({
+        type: "buy",
+        transactedAt: "2026-06-03T03:00:00.000Z",
+        accountId,
+        items: [
+          {
+            ticker: "AAPL",
+            quantity: 3,
+            price: 195.5,
+            stock: {
+              name: "Apple",
+              market: "US",
+              currency: "USD",
+              assetType: "equity",
+            },
+          },
+        ],
+      }),
+    );
+
+    expect(notifyBatchStockTransactionsCreatedMock).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        actorId: user.id,
+        householdId,
+        transactions: [transaction],
+      },
+    );
+  });
+
+  it("거래 수정 성공 후 수정 알림 helper를 호출한다", async () => {
+    updateTransactionMock.mockResolvedValue(transaction);
+
+    await patchTransactionRoute(createJsonRequest({ quantity: 4 }), {
+      params: Promise.resolve({ id: transactionId }),
+    });
+
+    expect(notifyStockTransactionUpdatedMock).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        actorId: user.id,
+        transaction,
+      },
+    );
+  });
+
+  it("거래 삭제 성공 후 삭제 알림 helper를 호출한다", async () => {
+    deleteTransactionMock.mockResolvedValue(transaction);
+
+    await deleteTransactionRoute(new Request("http://localhost"), {
+      params: Promise.resolve({ id: transactionId }),
+    });
+
+    expect(notifyStockTransactionDeletedMock).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        actorId: user.id,
+        transaction,
+      },
+    );
+  });
+});

--- a/app/api/transactions/route.ts
+++ b/app/api/transactions/route.ts
@@ -2,6 +2,7 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { APIError, toErrorResponse } from "@/lib/api/error";
 import { getUserHouseholdId } from "@/lib/api/invitation";
+import { notifyStockTransactionCreated } from "@/lib/api/stock-transaction-notifications";
 import {
   createTransaction,
   getTransactions,
@@ -157,6 +158,12 @@ export async function POST(request: Request) {
         currency: input.stock.currency,
         assetType: input.stock.assetType,
       },
+    });
+
+    await notifyStockTransactionCreated(supabase, {
+      actorId: user.id,
+      householdId,
+      transaction,
     });
 
     return NextResponse.json({ data: transaction }, { status: 201 });

--- a/lib/api/stock-transaction-notifications.test.ts
+++ b/lib/api/stock-transaction-notifications.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createUserNotification } from "@/lib/api/notifications";
+import {
+  notifyBatchStockTransactionsCreated,
+  notifyStockTransactionCreated,
+  notifyStockTransactionDeleted,
+  notifyStockTransactionUpdated,
+} from "./stock-transaction-notifications";
+
+vi.mock("@/lib/api/notifications", () => ({
+  createUserNotification: vi.fn().mockResolvedValue({ id: "notification-1" }),
+}));
+
+const createUserNotificationMock = vi.mocked(createUserNotification);
+
+const transaction = {
+  id: "00000000-0000-4000-8000-000000000201",
+  household_id: "household-1",
+  owner_id: "owner-1",
+  ticker: "AAPL",
+  type: "buy" as const,
+  quantity: 3,
+  price: 195.5,
+  transacted_at: "2026-06-03T03:00:00.000Z",
+  memo: null,
+  account_id: "account-1",
+  created_at: "2026-06-03T03:10:00.000Z",
+};
+
+function createStockNotificationSupabaseMock() {
+  const householdMembersBuilder = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    neq: vi.fn().mockResolvedValue({
+      data: [{ user_id: "member-1" }, { user_id: "member-2" }],
+      error: null,
+    }),
+  };
+  const profilesBuilder = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue({
+      data: { name: "홍길동" },
+      error: null,
+    }),
+  };
+
+  return {
+    from: vi.fn((table: string) => {
+      if (table === "household_members") return householdMembersBuilder;
+      if (table === "profiles") return profilesBuilder;
+      throw new Error(`Unexpected table: ${table}`);
+    }),
+    householdMembersBuilder,
+    profilesBuilder,
+  };
+}
+
+describe("stock transaction notification helpers", () => {
+  beforeEach(() => {
+    createUserNotificationMock.mockClear();
+    vi.useRealTimers();
+  });
+
+  it("단건 생성은 작성자를 제외한 가구 구성원에게 생성 알림을 만든다", async () => {
+    const supabase = createStockNotificationSupabaseMock();
+
+    await notifyStockTransactionCreated(supabase as never, {
+      actorId: "owner-1",
+      householdId: "household-1",
+      transaction,
+    });
+
+    expect(supabase.from).toHaveBeenCalledWith("household_members");
+    expect(supabase.householdMembersBuilder.neq).toHaveBeenCalledWith(
+      "user_id",
+      "owner-1",
+    );
+    expect(createUserNotificationMock).toHaveBeenCalledTimes(2);
+    expect(createUserNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recipientId: "member-1",
+        householdId: "household-1",
+        type: "stock_transaction_created",
+        title: "새 주식 거래가 추가되었습니다",
+        body: "홍길동님이 AAPL 매수 3주를 추가했습니다.",
+        link: {
+          kind: "stock_record_date",
+          params: { date: "2026-06-03" },
+        },
+        source: {
+          type: "stock_transaction",
+          id: "00000000-0000-4000-8000-000000000201",
+        },
+        dedupeKey:
+          "stock_transaction_created:00000000-0000-4000-8000-000000000201",
+      }),
+    );
+  });
+
+  it("batch 생성은 가장 최신 거래일로 이동하는 수신자별 요약 알림 1개를 만든다", async () => {
+    const supabase = createStockNotificationSupabaseMock();
+
+    await notifyBatchStockTransactionsCreated(supabase as never, {
+      actorId: "owner-1",
+      householdId: "household-1",
+      transactions: [
+        {
+          ...transaction,
+          id: "00000000-0000-4000-8000-000000000202",
+          transacted_at: "2026-06-01T03:00:00.000Z",
+        },
+        transaction,
+      ],
+    });
+
+    expect(createUserNotificationMock).toHaveBeenCalledTimes(2);
+    expect(createUserNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recipientId: "member-1",
+        type: "stock_transaction_created",
+        title: "주식 거래 2건이 추가되었습니다",
+        body: "홍길동님이 2026-06-03 기준 주식 거래 2건을 추가했습니다.",
+        link: {
+          kind: "stock_record_date",
+          params: { date: "2026-06-03" },
+        },
+        source: null,
+        dedupeKey:
+          "stock_transaction_batch_created:owner-1:00000000-0000-4000-8000-000000000202,00000000-0000-4000-8000-000000000201",
+      }),
+    );
+  });
+
+  it("수정 알림은 수정 후 거래일로 이동한다", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-05T00:00:00.000Z"));
+    const supabase = createStockNotificationSupabaseMock();
+
+    await notifyStockTransactionUpdated(supabase as never, {
+      actorId: "owner-1",
+      transaction: {
+        ...transaction,
+        quantity: 5,
+        transacted_at: "2026-06-04T03:00:00.000Z",
+      },
+    });
+
+    expect(createUserNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "stock_transaction_changed",
+        title: "주식 거래가 수정되었습니다",
+        body: "홍길동님이 AAPL 매수 기록을 수정했습니다.",
+        link: {
+          kind: "stock_record_date",
+          params: { date: "2026-06-04" },
+        },
+        dedupeKey:
+          "stock_transaction_updated:00000000-0000-4000-8000-000000000201:1780617600000",
+      }),
+    );
+  });
+
+  it("삭제 알림은 삭제 전 거래일로 이동한다", async () => {
+    const supabase = createStockNotificationSupabaseMock();
+
+    await notifyStockTransactionDeleted(supabase as never, {
+      actorId: "owner-1",
+      transaction,
+    });
+
+    expect(createUserNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "stock_transaction_changed",
+        title: "주식 거래가 삭제되었습니다",
+        body: "홍길동님이 AAPL 매수 기록을 삭제했습니다.",
+        link: {
+          kind: "stock_record_date",
+          params: { date: "2026-06-03" },
+        },
+        source: {
+          type: "stock_transaction",
+          id: "00000000-0000-4000-8000-000000000201",
+        },
+        dedupeKey:
+          "stock_transaction_deleted:00000000-0000-4000-8000-000000000201",
+      }),
+    );
+  });
+
+  it("알림 생성 실패는 원본 작업으로 전파하지 않는다", async () => {
+    const supabase = createStockNotificationSupabaseMock();
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    createUserNotificationMock.mockRejectedValueOnce(
+      new Error("notification insert failed"),
+    );
+
+    await expect(
+      notifyStockTransactionCreated(supabase as never, {
+        actorId: "owner-1",
+        householdId: "household-1",
+        transaction,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Stock transaction notification creation error (created):",
+      expect.any(Error),
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/lib/api/stock-transaction-notifications.ts
+++ b/lib/api/stock-transaction-notifications.ts
@@ -1,0 +1,233 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { formatKst } from "@/lib/date";
+import type { Database, Transaction } from "@/types";
+import { createUserNotification } from "./notifications";
+
+type StockNotificationTransaction = Pick<
+  Transaction,
+  | "id"
+  | "household_id"
+  | "owner_id"
+  | "ticker"
+  | "type"
+  | "quantity"
+  | "transacted_at"
+>;
+
+interface StockNotificationBaseInput {
+  actorId: string;
+}
+
+interface StockTransactionCreatedInput extends StockNotificationBaseInput {
+  householdId: string;
+  transaction: StockNotificationTransaction;
+}
+
+interface BatchStockTransactionsCreatedInput
+  extends StockNotificationBaseInput {
+  householdId: string;
+  transactions: StockNotificationTransaction[];
+}
+
+interface StockTransactionChangedInput extends StockNotificationBaseInput {
+  transaction: StockNotificationTransaction;
+}
+
+async function getHouseholdNotificationRecipients(
+  supabase: SupabaseClient<Database>,
+  householdId: string,
+  actorId: string,
+): Promise<string[]> {
+  const { data, error } = await supabase
+    .from("household_members")
+    .select("user_id")
+    .eq("household_id", householdId)
+    .neq("user_id", actorId);
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []).map((member) => member.user_id);
+}
+
+async function getActorName(
+  supabase: SupabaseClient<Database>,
+  actorId: string,
+): Promise<string> {
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("name")
+    .eq("id", actorId)
+    .maybeSingle();
+
+  if (error) {
+    throw error;
+  }
+
+  return data?.name || "가구 구성원";
+}
+
+function getStockTransactionDate(
+  transaction: StockNotificationTransaction,
+): string {
+  return formatKst(transaction.transacted_at);
+}
+
+function getTransactionTypeLabel(type: Transaction["type"]): string {
+  return type === "buy" ? "매수" : "매도";
+}
+
+function formatQuantity(quantity: number): string {
+  return quantity.toLocaleString("ko-KR");
+}
+
+async function createStockTransactionNotifications(
+  supabase: SupabaseClient<Database>,
+  input: {
+    actorId: string;
+    householdId: string;
+    type: "stock_transaction_created" | "stock_transaction_changed";
+    title: string;
+    body: string;
+    date: string;
+    source: {
+      type: "stock_transaction";
+      id: string;
+    } | null;
+    dedupeKey: string;
+  },
+): Promise<void> {
+  const [recipients, actorName] = await Promise.all([
+    getHouseholdNotificationRecipients(
+      supabase,
+      input.householdId,
+      input.actorId,
+    ),
+    getActorName(supabase, input.actorId),
+  ]);
+
+  await Promise.all(
+    recipients.map((recipientId) =>
+      createUserNotification({
+        recipientId,
+        householdId: input.householdId,
+        type: input.type,
+        title: input.title,
+        body: input.body.replace("{actorName}", actorName),
+        link: {
+          kind: "stock_record_date",
+          params: { date: input.date },
+        },
+        source: input.source,
+        dedupeKey: input.dedupeKey,
+      }),
+    ),
+  );
+}
+
+async function runBestEffort(
+  operation: () => Promise<void>,
+  context: string,
+): Promise<void> {
+  try {
+    await operation();
+  } catch (error) {
+    console.error(
+      `Stock transaction notification creation error (${context}):`,
+      error,
+    );
+  }
+}
+
+export async function notifyStockTransactionCreated(
+  supabase: SupabaseClient<Database>,
+  input: StockTransactionCreatedInput,
+): Promise<void> {
+  await runBestEffort(
+    () =>
+      createStockTransactionNotifications(supabase, {
+        actorId: input.actorId,
+        householdId: input.householdId,
+        type: "stock_transaction_created",
+        title: "새 주식 거래가 추가되었습니다",
+        body: `{actorName}님이 ${input.transaction.ticker} ${getTransactionTypeLabel(input.transaction.type)} ${formatQuantity(input.transaction.quantity)}주를 추가했습니다.`,
+        date: getStockTransactionDate(input.transaction),
+        source: { type: "stock_transaction", id: input.transaction.id },
+        dedupeKey: `stock_transaction_created:${input.transaction.id}`,
+      }),
+    "created",
+  );
+}
+
+export async function notifyBatchStockTransactionsCreated(
+  supabase: SupabaseClient<Database>,
+  input: BatchStockTransactionsCreatedInput,
+): Promise<void> {
+  if (input.transactions.length === 0) return;
+
+  const latestTransaction = [...input.transactions].sort((a, b) =>
+    b.transacted_at.localeCompare(a.transacted_at),
+  )[0];
+  if (!latestTransaction) return;
+
+  const latestDate = getStockTransactionDate(latestTransaction);
+  const count = input.transactions.length;
+
+  await runBestEffort(
+    () =>
+      createStockTransactionNotifications(supabase, {
+        actorId: input.actorId,
+        householdId: input.householdId,
+        type: "stock_transaction_created",
+        title: `주식 거래 ${count}건이 추가되었습니다`,
+        body: `{actorName}님이 ${latestDate} 기준 주식 거래 ${count}건을 추가했습니다.`,
+        date: latestDate,
+        source: null,
+        dedupeKey: `stock_transaction_batch_created:${input.actorId}:${input.transactions
+          .map((transaction) => transaction.id)
+          .join(",")}`,
+      }),
+    "batch-created",
+  );
+}
+
+export async function notifyStockTransactionUpdated(
+  supabase: SupabaseClient<Database>,
+  input: StockTransactionChangedInput,
+): Promise<void> {
+  await runBestEffort(
+    () =>
+      createStockTransactionNotifications(supabase, {
+        actorId: input.actorId,
+        householdId: input.transaction.household_id,
+        type: "stock_transaction_changed",
+        title: "주식 거래가 수정되었습니다",
+        body: `{actorName}님이 ${input.transaction.ticker} ${getTransactionTypeLabel(input.transaction.type)} 기록을 수정했습니다.`,
+        date: getStockTransactionDate(input.transaction),
+        source: { type: "stock_transaction", id: input.transaction.id },
+        dedupeKey: `stock_transaction_updated:${input.transaction.id}:${Date.now()}`,
+      }),
+    "updated",
+  );
+}
+
+export async function notifyStockTransactionDeleted(
+  supabase: SupabaseClient<Database>,
+  input: StockTransactionChangedInput,
+): Promise<void> {
+  await runBestEffort(
+    () =>
+      createStockTransactionNotifications(supabase, {
+        actorId: input.actorId,
+        householdId: input.transaction.household_id,
+        type: "stock_transaction_changed",
+        title: "주식 거래가 삭제되었습니다",
+        body: `{actorName}님이 ${input.transaction.ticker} ${getTransactionTypeLabel(input.transaction.type)} 기록을 삭제했습니다.`,
+        date: getStockTransactionDate(input.transaction),
+        source: { type: "stock_transaction", id: input.transaction.id },
+        dedupeKey: `stock_transaction_deleted:${input.transaction.id}`,
+      }),
+    "deleted",
+  );
+}

--- a/lib/api/transaction.test.ts
+++ b/lib/api/transaction.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { APIError } from "./error";
 import {
   assertTransactionAccountOwnership,
+  deleteTransaction,
   getTransactions,
 } from "./transaction";
 
@@ -132,5 +133,53 @@ describe("assertTransactionAccountOwnership", () => {
         403,
       ),
     );
+  });
+});
+
+describe("deleteTransaction", () => {
+  it("삭제 성공 후 삭제 전 거래 row를 반환한다", async () => {
+    const transaction = {
+      id: "tx-1",
+      household_id: "household-1",
+      owner_id: "user-1",
+      ticker: "AAPL",
+      type: "buy" as const,
+      quantity: 3,
+      price: 195.5,
+      transacted_at: "2026-06-03T03:00:00.000Z",
+      memo: null,
+      account_id: "account-1",
+      created_at: "2026-06-03T03:10:00.000Z",
+    };
+    const selectBuilder = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: transaction, error: null }),
+    };
+    const deleteBuilder = {
+      delete: vi.fn(),
+      eq: vi.fn(),
+    };
+    deleteBuilder.delete.mockReturnValue(deleteBuilder);
+    deleteBuilder.eq
+      .mockReturnValueOnce(deleteBuilder)
+      .mockReturnValueOnce(deleteBuilder)
+      .mockResolvedValueOnce({ error: null });
+    const supabase = {
+      from: vi
+        .fn()
+        .mockReturnValueOnce(selectBuilder)
+        .mockReturnValueOnce(deleteBuilder),
+    };
+
+    const result = await deleteTransaction(
+      supabase as never,
+      "tx-1",
+      "household-1",
+      "user-1",
+    );
+
+    expect(result).toEqual(transaction);
+    expect(deleteBuilder.delete).toHaveBeenCalled();
   });
 });

--- a/lib/api/transaction.ts
+++ b/lib/api/transaction.ts
@@ -516,7 +516,7 @@ export async function deleteTransaction(
   transactionId: string,
   householdId: string,
   userId: string,
-): Promise<void> {
+): Promise<Transaction> {
   // 1. 기존 거래 조회 (존재 여부 확인)
   const existingTransaction = await getTransactionById(
     supabase,
@@ -541,6 +541,8 @@ export async function deleteTransaction(
     console.error("Transaction delete error:", error);
     throw new APIError("TRANSACTION_ERROR", "거래 삭제에 실패했습니다.", 500);
   }
+
+  return existingTransaction;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- add preference-aware stock transaction notification fan-out for direct create/update/delete APIs
- link stock notifications to the stock record date and keep batch creation as one summary notification
- return deleted transaction rows so delete notifications can use the pre-delete snapshot
- document the #347 scope boundary from #346/#348

## Validation
- pnpm test
- pnpm type-check
- pnpm exec biome check .claude/docs/NOTIFICATIONS.md app/api/transactions/notifications.test.ts 'app/api/transactions/[id]/route.ts' app/api/transactions/batch/route.ts app/api/transactions/route.ts lib/api/stock-transaction-notifications.ts lib/api/stock-transaction-notifications.test.ts lib/api/transaction.ts lib/api/transaction.test.ts

Closes #347