### PR TITLE
[codex] Implement invitation acceptance notifications

### DIFF
--- a/.claude/docs/NOTIFICATIONS.md
+++ b/.claude/docs/NOTIFICATIONS.md
@@ -759,6 +759,26 @@ stock_transaction_deleted:{transactionId}
 - 범위: 요청 승인/거절/취소 결과를 요청자에게 알림으로 전달하고, 초대 수락 시 기존 구성원에게 확인형 알림을 전달한다.
 - 완료 기준: 요청자는 처리 결과 알림을 받고 원본 기록으로 이동할 수 있으며, 초대 수락 시 기존 구성원이 가구 화면으로 이동할 수 있다.
 
+초대 수락 알림은 초대 상태 정합성과 함께 처리한다. **Household Member**가 실제 소속의 source of truth이고, `invitations.status`는 초대 요청의 lifecycle audit이다. 따라서 초대받은 사용자가 이미 해당 가구의 구성원이어도 초대 수락 API는 실패하지 않고 해당 invitation을 `accepted`로 정리해야 한다. UI에서 accepted invitation을 숨기는 것만으로는 충분하지 않으며, pending invitation과 member row가 공존하는 상태를 남기지 않는다.
+
+`invitation_accepted` User Notification의 수신자는 신규 합류자를 제외한 기존 가구 구성원 전체이다. 초대한 사람도 기존 구성원이므로 포함된다. 신규 합류자 본인은 이미 수락 플로우 안에 있으므로 자기 행동에 대한 확인 알림을 받지 않는다.
+
+초대 수락 알림은 `source_type = 'invitation'`, `source_id = invitation.id`로 추적한다. 중복 방지는 `dedupe_key = invitation_accepted:{invitationId}`를 사용한다. 초대 수락은 invitation lifecycle에서 한 번만 의미 있는 사건이므로 수락 API가 재호출되어도 같은 invitation에 대한 알림을 반복 생성하지 않는다. 알림 링크는 `household_settings`를 사용한다.
+
+멱등 수락은 초대받은 사용자가 이미 같은 household의 **Household Member**인 경우에만 적용한다. 사용자가 다른 household에 이미 속해있는 경우는 자동 이동이나 병합을 하지 않고 실패시킨다. 현재 앱은 사용자당 단일 household를 전제로 하므로, 다른 가구 소속자를 조용히 초대 가구로 합류시키면 데이터 소유권과 가구 경계가 깨질 수 있다.
+
+수락 처리 순서는 **Household Member** 추가 후 `invitations.status = 'accepted'` 업데이트이다. `household_members`가 실제 소속의 source of truth이므로, 멤버 추가가 실패했는데 invitation만 accepted가 되는 상태를 만들지 않는다. 단, 같은 household의 멤버 row가 이미 존재하는 경우는 멤버 추가를 성공으로 간주하고 invitation status를 accepted로 정리한다. `invitation_accepted` User Notification은 멤버십과 invitation lifecycle 정리가 끝난 뒤 best effort로 생성한다.
+
+같은 이메일에 여러 pending invitation이 있으면 현재 수락 API는 최신 유효 초대 1개를 수락한다. DB unique 제약은 `(household_id, email)`이므로 서로 다른 household에서 같은 이메일을 초대할 수 있고, 현재 초대 callback은 특정 invitation id/token을 전달하지 않는다. 사용자당 단일 household 전제에서는 최신 유효 초대 수락을 현재 범위의 규칙으로 둔다. 특정 초대를 명시적으로 수락하게 하려면 초대 링크에 invitation id 또는 token을 포함하는 별도 개선이 필요하다.
+
+초대 수락 알림 문구는 신규 합류자의 `profiles.name`을 우선 사용하고, 이름이 비어 있으면 이메일을 fallback으로 사용한다. 앱의 구성원 표시는 `profiles`를 기준으로 하므로, `auth.users`의 `display_name`은 알림 문구의 source로 사용하지 않는다.
+
+#348은 초대 수락 알림뿐 아니라 #191에서 관찰된 pending invitation/member 공존 상태를 예방하는 수락 정합성 수정을 포함한다. 알림은 정상적인 **Invitation Acceptance** 이벤트에 의존하므로, 수락 API가 invitation lifecycle을 정리하지 못하는 상태를 남긴 채 알림만 생성하지 않는다.
+
+초대 수락 알림 생성 실패는 초대 수락 자체를 실패시키지 않는다. **Household Member** 생성과 invitation lifecycle 정리가 성공했다면 `invitation_accepted` User Notification 생성은 best effort로 처리한다. 알림 생성 실패는 서버 로그에 남기고, dedupe 또는 preference 때문에 알림 row가 생성되지 않은 경우는 정상 처리한다.
+
+Record Change Request 승인/거절 결과 알림은 요청자에게 보낸다. 요청자가 pending 요청을 취소한 경우에는 대상 소유자에게 취소 확인 알림을 보낸다. 결과 알림은 `source_type = 'record_change_request'`, `source_id = record_change_requests.id`, `link_kind = 'record_change_request_detail'`을 사용하고, 중복 방지는 `record_change_request_result:{requestId}:{status}`를 사용한다. 결과 알림 생성 실패는 원본 요청 상태 변경을 실패시키지 않는다.
+
 ### Slice 8. Push 채널 구독과 테스트 알림 (#349)
 
 - Type: AFK
@@ -780,3 +800,13 @@ stock_transaction_deleted:{transactionId}
 8. 기존 owner mismatch 데이터는 자동 마이그레이션하지 않는다.
 9. 주식 거래 변경 알림(#347)은 직접 거래 API에서 발생한 생성/수정/삭제만 다루며, Record Change Request 승인 결과 알림은 #348에서 다룬다.
 10. 주식 거래 변경 알림 링크는 `stock_record_date`로 통일한다.
+11. 초대 수락은 멱등 처리하며, 실제 소속은 `household_members`, 초대 lifecycle은 `invitations.status`에 기록한다.
+12. 초대 수락 알림은 신규 합류자를 제외한 기존 가구 구성원 전체에게 보낸다.
+13. 초대 수락 알림은 `invitation_accepted:{invitationId}` dedupe key와 `household_settings` 링크를 사용한다.
+14. 초대 수락 멱등 처리는 이미 같은 household에 속한 사용자에게만 적용하고, 다른 household 소속자는 자동 이동하지 않는다.
+15. 초대 수락은 멤버 추가를 먼저 완료하고, 그 다음 invitation status를 `accepted`로 기록하며, 알림은 이후 best effort로 생성한다.
+16. 같은 이메일에 여러 pending invitation이 있으면 최신 유효 초대 1개를 수락한다.
+17. 초대 수락 알림 문구는 `profiles.name`을 우선 사용하고, 비어 있으면 이메일을 fallback으로 사용한다.
+18. #348은 초대 수락 알림과 함께 #191의 pending invitation/member 공존 상태를 예방하는 수락 정합성 수정을 포함한다.
+19. 초대 수락 알림 생성 실패는 원본 초대 수락을 실패시키지 않는다.
+20. Record Change Request 승인/거절 결과는 요청자에게, 취소 결과는 대상 소유자에게 알린다.

--- a/app/api/auth/setup-household/route.ts
+++ b/app/api/auth/setup-household/route.ts
@@ -5,6 +5,7 @@ import {
   getPendingInvitationForUser,
   getUserHouseholdId,
 } from "@/lib/api/invitation";
+import { notifyInvitationAccepted } from "@/lib/api/invitation-notifications";
 import { createClient } from "@/lib/supabase/server";
 
 export async function POST() {
@@ -18,16 +19,6 @@ export async function POST() {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    // 이미 가구가 있는지 확인
-    const existingHouseholdId = await getUserHouseholdId(supabase, user.id);
-    if (existingHouseholdId) {
-      return NextResponse.json({
-        success: true,
-        householdId: existingHouseholdId,
-        message: "Already has household",
-      });
-    }
-
     // 초대가 있는지 확인
     if (user.email) {
       const invitation = await getPendingInvitationForUser(
@@ -37,12 +28,28 @@ export async function POST() {
 
       if (invitation) {
         await acceptInvitation(supabase, invitation, user.id);
+        await notifyInvitationAccepted(supabase, {
+          invitationId: invitation.id,
+          householdId: invitation.household_id,
+          acceptedUserId: user.id,
+          invitedEmail: invitation.email,
+        });
         return NextResponse.json({
           success: true,
           householdId: invitation.household_id,
           message: "Invitation accepted",
         });
       }
+    }
+
+    // 이미 가구가 있는지 확인
+    const existingHouseholdId = await getUserHouseholdId(supabase, user.id);
+    if (existingHouseholdId) {
+      return NextResponse.json({
+        success: true,
+        householdId: existingHouseholdId,
+        message: "Already has household",
+      });
     }
 
     // 초대가 없으면 새 가구 생성

--- a/app/api/invitations/accept/route.ts
+++ b/app/api/invitations/accept/route.ts
@@ -6,6 +6,7 @@ import {
   getPendingInvitationForUser,
   getUserHouseholdId,
 } from "@/lib/api/invitation";
+import { notifyInvitationAccepted } from "@/lib/api/invitation-notifications";
 import { createClient } from "@/lib/supabase/server";
 
 /**
@@ -29,6 +30,26 @@ export async function POST() {
       throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
     }
 
+    // pending 초대 확인
+    const invitation = await getPendingInvitationForUser(supabase, user.email);
+
+    if (invitation) {
+      // 초대 수락
+      await acceptInvitation(supabase, invitation, user.id);
+      await notifyInvitationAccepted(supabase, {
+        invitationId: invitation.id,
+        householdId: invitation.household_id,
+        acceptedUserId: user.id,
+        invitedEmail: invitation.email,
+      });
+      return NextResponse.json({
+        data: {
+          type: "invited",
+          householdId: invitation.household_id,
+        },
+      });
+    }
+
     // 이미 가구에 속해있는지 확인
     const existingHouseholdId = await getUserHouseholdId(supabase, user.id);
     if (existingHouseholdId) {
@@ -36,20 +57,6 @@ export async function POST() {
         data: {
           type: "existing",
           householdId: existingHouseholdId,
-        },
-      });
-    }
-
-    // pending 초대 확인
-    const invitation = await getPendingInvitationForUser(supabase, user.email);
-
-    if (invitation) {
-      // 초대 수락
-      await acceptInvitation(supabase, invitation, user.id);
-      return NextResponse.json({
-        data: {
-          type: "invited",
-          householdId: invitation.household_id,
         },
       });
     }

--- a/lib/api/invitation-notifications.test.ts
+++ b/lib/api/invitation-notifications.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createUserNotification } from "@/lib/api/notifications";
+import { notifyInvitationAccepted } from "./invitation-notifications";
+
+vi.mock("@/lib/api/notifications", () => ({
+  createUserNotification: vi.fn().mockResolvedValue({ id: "notification-1" }),
+}));
+
+const createUserNotificationMock = vi.mocked(createUserNotification);
+
+function createInvitationNotificationSupabaseMock() {
+  const householdMembersBuilder = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    neq: vi.fn().mockResolvedValue({
+      data: [{ user_id: "owner-1" }, { user_id: "member-1" }],
+      error: null,
+    }),
+  };
+  const profilesBuilder = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue({
+      data: { name: "우니", email: "woonie@example.com" },
+      error: null,
+    }),
+  };
+
+  return {
+    from: vi.fn((table: string) => {
+      if (table === "household_members") return householdMembersBuilder;
+      if (table === "profiles") return profilesBuilder;
+      throw new Error(`Unexpected table: ${table}`);
+    }),
+    householdMembersBuilder,
+    profilesBuilder,
+  };
+}
+
+describe("invitation notification helpers", () => {
+  beforeEach(() => {
+    createUserNotificationMock.mockClear();
+  });
+
+  it("초대 수락 시 신규 합류자를 제외한 기존 구성원에게 알림을 만든다", async () => {
+    const supabase = createInvitationNotificationSupabaseMock();
+
+    await notifyInvitationAccepted(supabase as never, {
+      invitationId: "00000000-0000-4000-8000-000000000301",
+      householdId: "household-1",
+      acceptedUserId: "accepted-user-1",
+      invitedEmail: "fallback@example.com",
+    });
+
+    expect(supabase.from).toHaveBeenCalledWith("household_members");
+    expect(supabase.householdMembersBuilder.neq).toHaveBeenCalledWith(
+      "user_id",
+      "accepted-user-1",
+    );
+    expect(createUserNotificationMock).toHaveBeenCalledTimes(2);
+    expect(createUserNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recipientId: "owner-1",
+        householdId: "household-1",
+        type: "invitation_accepted",
+        title: "새 구성원이 합류했습니다",
+        body: "우니님이 가구에 합류했습니다.",
+        link: { kind: "household_settings" },
+        source: {
+          type: "invitation",
+          id: "00000000-0000-4000-8000-000000000301",
+        },
+        dedupeKey: "invitation_accepted:00000000-0000-4000-8000-000000000301",
+      }),
+    );
+  });
+
+  it("프로필 이름이 없으면 초대 이메일을 알림 문구 fallback으로 사용한다", async () => {
+    const supabase = createInvitationNotificationSupabaseMock();
+    supabase.profilesBuilder.maybeSingle.mockResolvedValueOnce({
+      data: { name: "", email: "profile@example.com" },
+      error: null,
+    });
+
+    await notifyInvitationAccepted(supabase as never, {
+      invitationId: "00000000-0000-4000-8000-000000000301",
+      householdId: "household-1",
+      acceptedUserId: "accepted-user-1",
+      invitedEmail: "fallback@example.com",
+    });
+
+    expect(createUserNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: "fallback@example.com님이 가구에 합류했습니다.",
+      }),
+    );
+  });
+
+  it("알림 생성 실패는 원본 초대 수락으로 전파하지 않는다", async () => {
+    const supabase = createInvitationNotificationSupabaseMock();
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    createUserNotificationMock.mockRejectedValueOnce(
+      new Error("notification insert failed"),
+    );
+
+    await expect(
+      notifyInvitationAccepted(supabase as never, {
+        invitationId: "00000000-0000-4000-8000-000000000301",
+        householdId: "household-1",
+        acceptedUserId: "accepted-user-1",
+        invitedEmail: "fallback@example.com",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Invitation accepted notification creation error:",
+      expect.any(Error),
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/lib/api/invitation-notifications.ts
+++ b/lib/api/invitation-notifications.ts
@@ -1,0 +1,83 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/types";
+import { createUserNotification } from "./notifications";
+
+interface InvitationAcceptedNotificationInput {
+  invitationId: string;
+  householdId: string;
+  acceptedUserId: string;
+  invitedEmail: string;
+}
+
+async function getHouseholdNotificationRecipients(
+  supabase: SupabaseClient<Database>,
+  householdId: string,
+  acceptedUserId: string,
+): Promise<string[]> {
+  const { data, error } = await supabase
+    .from("household_members")
+    .select("user_id")
+    .eq("household_id", householdId)
+    .neq("user_id", acceptedUserId);
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []).map((member) => member.user_id);
+}
+
+async function getAcceptedUserDisplayName(
+  supabase: SupabaseClient<Database>,
+  acceptedUserId: string,
+  invitedEmail: string,
+): Promise<string> {
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("name, email")
+    .eq("id", acceptedUserId)
+    .maybeSingle();
+
+  if (error) {
+    throw error;
+  }
+
+  return data?.name?.trim() || invitedEmail;
+}
+
+export async function notifyInvitationAccepted(
+  supabase: SupabaseClient<Database>,
+  input: InvitationAcceptedNotificationInput,
+): Promise<void> {
+  try {
+    const [recipients, acceptedUserName] = await Promise.all([
+      getHouseholdNotificationRecipients(
+        supabase,
+        input.householdId,
+        input.acceptedUserId,
+      ),
+      getAcceptedUserDisplayName(
+        supabase,
+        input.acceptedUserId,
+        input.invitedEmail,
+      ),
+    ]);
+
+    await Promise.all(
+      recipients.map((recipientId) =>
+        createUserNotification({
+          recipientId,
+          householdId: input.householdId,
+          type: "invitation_accepted",
+          title: "새 구성원이 합류했습니다",
+          body: `${acceptedUserName}님이 가구에 합류했습니다.`,
+          link: { kind: "household_settings" },
+          source: { type: "invitation", id: input.invitationId },
+          dedupeKey: `invitation_accepted:${input.invitationId}`,
+        }),
+      ),
+    );
+  } catch (error) {
+    console.error("Invitation accepted notification creation error:", error);
+  }
+}

--- a/lib/api/invitation.test.ts
+++ b/lib/api/invitation.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createAdminClient } from "@/lib/supabase/admin";
+import type { Invitation } from "@/types";
+import { APIError } from "./error";
+import { acceptInvitation } from "./invitation";
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(),
+}));
+
+const createAdminClientMock = vi.mocked(createAdminClient);
+
+const invitation = {
+  id: "00000000-0000-4000-8000-000000000301",
+  household_id: "household-1",
+  created_by: "owner-1",
+  email: "member@example.com",
+  status: "pending",
+  expires_at: "2026-06-10T00:00:00.000Z",
+  created_at: "2026-06-01T00:00:00.000Z",
+} as Invitation;
+
+function createAcceptInvitationAdminMock(options: {
+  existingMembership: { household_id: string } | null;
+}) {
+  const membershipSelectBuilder = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue({
+      data: options.existingMembership,
+      error: null,
+    }),
+  };
+  const membershipInsertBuilder = {
+    insert: vi.fn().mockResolvedValue({ error: null }),
+  };
+  const invitationUpdateBuilder = {
+    update: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockResolvedValue({ error: null }),
+  };
+
+  const householdMembersFrom = vi
+    .fn()
+    .mockReturnValueOnce(membershipSelectBuilder)
+    .mockReturnValue(membershipInsertBuilder);
+
+  const admin = {
+    from: vi.fn((table: string) => {
+      if (table === "household_members") return householdMembersFrom();
+      if (table === "invitations") return invitationUpdateBuilder;
+      throw new Error(`Unexpected table: ${table}`);
+    }),
+    membershipSelectBuilder,
+    membershipInsertBuilder,
+    invitationUpdateBuilder,
+  };
+
+  return admin;
+}
+
+describe("acceptInvitation", () => {
+  beforeEach(() => {
+    createAdminClientMock.mockReset();
+  });
+
+  it("이미 같은 가구 구성원이면 멤버 추가 없이 invitation을 accepted로 정리한다", async () => {
+    const admin = createAcceptInvitationAdminMock({
+      existingMembership: { household_id: "household-1" },
+    });
+    createAdminClientMock.mockReturnValue(admin as never);
+
+    await expect(
+      acceptInvitation({} as never, invitation, "member-1"),
+    ).resolves.toBeUndefined();
+
+    expect(admin.membershipInsertBuilder.insert).not.toHaveBeenCalled();
+    expect(admin.invitationUpdateBuilder.update).toHaveBeenCalledWith({
+      status: "accepted",
+    });
+    expect(admin.invitationUpdateBuilder.eq).toHaveBeenCalledWith(
+      "id",
+      invitation.id,
+    );
+  });
+
+  it("다른 가구 구성원은 초대 가구로 자동 이동하지 않는다", async () => {
+    const admin = createAcceptInvitationAdminMock({
+      existingMembership: { household_id: "other-household" },
+    });
+    createAdminClientMock.mockReturnValue(admin as never);
+
+    await expect(
+      acceptInvitation({} as never, invitation, "member-1"),
+    ).rejects.toMatchObject(
+      new APIError(
+        "INVITATION_ALREADY_IN_OTHER_HOUSEHOLD",
+        "이미 다른 가구에 속해있습니다.",
+        409,
+      ),
+    );
+
+    expect(admin.membershipInsertBuilder.insert).not.toHaveBeenCalled();
+    expect(admin.invitationUpdateBuilder.update).not.toHaveBeenCalled();
+  });
+});

--- a/lib/api/invitation.ts
+++ b/lib/api/invitation.ts
@@ -1,4 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { APIError } from "@/lib/api/error";
 import { createAdminClient } from "@/lib/supabase/admin";
 import type { Database, Invitation } from "@/types";
 
@@ -215,21 +216,58 @@ export async function acceptInvitation(
 ): Promise<void> {
   const adminClient = createAdminClient();
 
-  // 가구에 member로 추가
-  const { error: memberError } = await adminClient
+  const { data: existingMembership, error: membershipError } = await adminClient
     .from("household_members")
-    .insert({
-      household_id: invitation.household_id,
-      user_id: userId,
-      role: "member",
-    });
+    .select("household_id")
+    .eq("user_id", userId)
+    .maybeSingle();
 
-  if (memberError) {
-    // 이미 가구에 속해있는 경우
-    if (memberError.code === "23505") {
-      throw new Error("이미 가구에 속해있습니다.");
+  if (membershipError) {
+    throw membershipError;
+  }
+
+  if (existingMembership) {
+    if (existingMembership.household_id !== invitation.household_id) {
+      throw new APIError(
+        "INVITATION_ALREADY_IN_OTHER_HOUSEHOLD",
+        "이미 다른 가구에 속해있습니다.",
+        409,
+      );
     }
-    throw memberError;
+  } else {
+    // 가구에 member로 추가
+    const { error: memberError } = await adminClient
+      .from("household_members")
+      .insert({
+        household_id: invitation.household_id,
+        user_id: userId,
+        role: "member",
+      });
+
+    if (memberError) {
+      if (memberError.code !== "23505") {
+        throw memberError;
+      }
+
+      const { data: duplicateMembership, error: duplicateMembershipError } =
+        await adminClient
+          .from("household_members")
+          .select("household_id")
+          .eq("user_id", userId)
+          .maybeSingle();
+
+      if (duplicateMembershipError) {
+        throw duplicateMembershipError;
+      }
+
+      if (duplicateMembership?.household_id !== invitation.household_id) {
+        throw new APIError(
+          "INVITATION_ALREADY_IN_OTHER_HOUSEHOLD",
+          "이미 다른 가구에 속해있습니다.",
+          409,
+        );
+      }
+    }
   }
 
   // 초대 상태 업데이트

--- a/lib/api/record-change-request-notifications.test.ts
+++ b/lib/api/record-change-request-notifications.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createUserNotification } from "@/lib/api/notifications";
+import { notifyRecordChangeRequestResult } from "./record-change-request-notifications";
+
+vi.mock("@/lib/api/notifications", () => ({
+  createUserNotification: vi.fn().mockResolvedValue({ id: "notification-1" }),
+}));
+
+const createUserNotificationMock = vi.mocked(createUserNotification);
+
+describe("record change request result notification helpers", () => {
+  beforeEach(() => {
+    createUserNotificationMock.mockClear();
+  });
+
+  it("승인 결과는 요청자에게 요청 상세 링크로 알린다", async () => {
+    await notifyRecordChangeRequestResult({
+      id: "00000000-0000-4000-8000-000000000401",
+      household_id: "household-1",
+      requester_id: "requester-1",
+      target_owner_id: "owner-1",
+      target_type: "ledger_entry",
+      status: "approved",
+      response_message: "반영했습니다.",
+    });
+
+    expect(createUserNotificationMock).toHaveBeenCalledWith({
+      recipientId: "requester-1",
+      householdId: "household-1",
+      type: "ledger_request_result",
+      title: "가계부 변경 요청이 승인되었습니다",
+      body: "반영했습니다.",
+      link: {
+        kind: "record_change_request_detail",
+        params: { requestId: "00000000-0000-4000-8000-000000000401" },
+      },
+      source: {
+        type: "record_change_request",
+        id: "00000000-0000-4000-8000-000000000401",
+      },
+      dedupeKey:
+        "record_change_request_result:00000000-0000-4000-8000-000000000401:approved",
+    });
+  });
+
+  it("거절 결과는 주식 요청자에게 주식 결과 타입으로 알린다", async () => {
+    await notifyRecordChangeRequestResult({
+      id: "00000000-0000-4000-8000-000000000402",
+      household_id: "household-1",
+      requester_id: "requester-1",
+      target_owner_id: "owner-1",
+      target_type: "stock_transaction",
+      status: "rejected",
+      response_message: null,
+    });
+
+    expect(createUserNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recipientId: "requester-1",
+        type: "stock_transaction_request_result",
+        title: "주식 거래 변경 요청이 거절되었습니다",
+        body: null,
+        dedupeKey:
+          "record_change_request_result:00000000-0000-4000-8000-000000000402:rejected",
+      }),
+    );
+  });
+
+  it("취소 결과는 대상 소유자에게 알린다", async () => {
+    await notifyRecordChangeRequestResult({
+      id: "00000000-0000-4000-8000-000000000403",
+      household_id: "household-1",
+      requester_id: "requester-1",
+      target_owner_id: "owner-1",
+      target_type: "ledger_entry",
+      status: "cancelled",
+      response_message: null,
+    });
+
+    expect(createUserNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recipientId: "owner-1",
+        type: "ledger_request_result",
+        title: "가계부 변경 요청이 취소되었습니다",
+        dedupeKey:
+          "record_change_request_result:00000000-0000-4000-8000-000000000403:cancelled",
+      }),
+    );
+  });
+
+  it("알림 생성 실패는 요청 처리 결과로 전파하지 않는다", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    createUserNotificationMock.mockRejectedValueOnce(
+      new Error("notification insert failed"),
+    );
+
+    await expect(
+      notifyRecordChangeRequestResult({
+        id: "00000000-0000-4000-8000-000000000404",
+        household_id: "household-1",
+        requester_id: "requester-1",
+        target_owner_id: "owner-1",
+        target_type: "ledger_entry",
+        status: "approved",
+        response_message: null,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Record change request result notification creation error:",
+      expect.any(Error),
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/lib/api/record-change-request-notifications.ts
+++ b/lib/api/record-change-request-notifications.ts
@@ -1,0 +1,72 @@
+import type { RecordChangeRequest } from "@/types";
+import { createUserNotification } from "./notifications";
+
+type RecordChangeRequestResultNotification = Pick<
+  RecordChangeRequest,
+  | "id"
+  | "household_id"
+  | "requester_id"
+  | "target_owner_id"
+  | "target_type"
+  | "status"
+  | "response_message"
+>;
+
+function getRequestResultType(targetType: RecordChangeRequest["target_type"]) {
+  return targetType === "ledger_entry"
+    ? "ledger_request_result"
+    : "stock_transaction_request_result";
+}
+
+function getRequestResultDomainLabel(
+  targetType: RecordChangeRequest["target_type"],
+) {
+  return targetType === "ledger_entry" ? "가계부" : "주식 거래";
+}
+
+function getStatusLabel(status: RecordChangeRequest["status"]) {
+  switch (status) {
+    case "approved":
+      return "승인";
+    case "rejected":
+      return "거절";
+    case "cancelled":
+      return "취소";
+    default:
+      return null;
+  }
+}
+
+export async function notifyRecordChangeRequestResult(
+  request: RecordChangeRequestResultNotification,
+): Promise<void> {
+  const statusLabel = getStatusLabel(request.status);
+  if (!statusLabel) return;
+
+  try {
+    const recipientId =
+      request.status === "cancelled"
+        ? request.target_owner_id
+        : request.requester_id;
+    const domainLabel = getRequestResultDomainLabel(request.target_type);
+
+    await createUserNotification({
+      recipientId,
+      householdId: request.household_id,
+      type: getRequestResultType(request.target_type),
+      title: `${domainLabel} 변경 요청이 ${statusLabel}되었습니다`,
+      body: request.response_message ?? null,
+      link: {
+        kind: "record_change_request_detail",
+        params: { requestId: request.id },
+      },
+      source: { type: "record_change_request", id: request.id },
+      dedupeKey: `record_change_request_result:${request.id}:${request.status}`,
+    });
+  } catch (error) {
+    console.error(
+      "Record change request result notification creation error:",
+      error,
+    );
+  }
+}

--- a/lib/api/record-change-requests.ts
+++ b/lib/api/record-change-requests.ts
@@ -16,6 +16,7 @@ import {
   stockTransactionUpdateProposedChangesSchema,
 } from "@/schemas/record-change-request";
 import type { Database, Json, RecordChangeRequest } from "@/types";
+import { notifyRecordChangeRequestResult } from "./record-change-request-notifications";
 
 export interface ValidatedRecordChangeRequestTarget {
   householdId: string;
@@ -613,6 +614,8 @@ export async function cancelRecordChangeRequest(
     throw error;
   }
 
+  await notifyRecordChangeRequestResult(data);
+
   return data;
 }
 
@@ -645,6 +648,8 @@ export async function resolveRecordChangeRequest(
   if (error) {
     throw error;
   }
+
+  await notifyRecordChangeRequestResult(data);
 
   return data;
 }


### PR DESCRIPTION
## Summary

Implements #348 and prevents the pending invitation/member coexistence case from #191.

- Make invitation acceptance idempotent for users who already belong to the invited household, while rejecting users who already belong to another household.
- Create `invitation_accepted` User Notifications for existing household members, excluding the newly joined user, with `invitation_accepted:{invitationId}` dedupe.
- Add Record Change Request result notifications for approved/rejected/cancelled states.
- Document the accepted invitation lifecycle, notification recipients, dedupe keys, and best-effort notification behavior.

## Root Cause / Notes

#191 can happen when membership exists but the invitation lifecycle is not moved out of `pending`. This PR treats `household_members` as the source of truth for membership and `invitations.status` as the request lifecycle audit, so repeated acceptance settles the invitation instead of leaving stale pending rows.

The separate orphan household cleanup/risk is tracked in #363 and is not included in this PR.

## Validation

- `pnpm check`
- `pnpm type-check`
- `pnpm test`
- `pnpm build`
