### PR TITLE
[codex] Implement issue 367 balance detail and notification batch

### DIFF
--- a/.claude/docs/NOTIFICATIONS.md
+++ b/.claude/docs/NOTIFICATIONS.md
@@ -310,6 +310,7 @@ PATCH /api/notifications/[id]/read
 POST /api/notifications/read-all
 GET /api/notification-preferences
 PATCH /api/notification-preferences/[type]
+POST /api/notification-preferences/batch
 ```
 
 알림 목록은 최신순 cursor pagination을 사용한다.
@@ -320,7 +321,7 @@ order by created_at desc, id desc
 
 cursor는 `createdAt + id` 조합을 인코딩한다. 알림 삭제, 아카이브, 자동 만료, 보존 기간 정책은 Issue #342 범위에서 제외한다.
 
-`GET /api/notification-preferences`는 Default Notification Preference와 저장된 override를 서버에서 merge한 완성 목록을 반환한다. `PATCH /api/notification-preferences/[type]`는 단건 타입의 `inAppEnabled`, `pushEnabled`를 저장한다. 설정 토글은 낙관적 업데이트를 적용하고 실패 시 rollback한다.
+`GET /api/notification-preferences`는 Default Notification Preference와 저장된 override를 서버에서 merge한 완성 목록을 반환한다. `PATCH /api/notification-preferences/[type]`는 단건 타입의 `inAppEnabled`, `pushEnabled`를 저장한다. `POST /api/notification-preferences/batch`는 여러 타입을 한 번에 저장하며, batch 전체가 성공하거나 실패한다. 성공 응답은 저장 후 merge된 완성 목록을 반환한다. 설정 토글은 낙관적 업데이트를 적용하고 실패 시 rollback한다.
 
 #### UI Behavior
 

--- a/app/(main)/assets/accounts/[accountId]/page.tsx
+++ b/app/(main)/assets/accounts/[accountId]/page.tsx
@@ -1,0 +1,20 @@
+import { BalanceDetailClient } from "@/components/accounts/BalanceDetailClient";
+import { PageContainer } from "@/components/layout";
+
+interface AccountDetailPageProps {
+  params: Promise<{
+    accountId: string;
+  }>;
+}
+
+export default async function AccountDetailPage({
+  params,
+}: AccountDetailPageProps) {
+  const { accountId } = await params;
+
+  return (
+    <PageContainer maxWidth="medium">
+      <BalanceDetailClient kind="account" id={accountId} />
+    </PageContainer>
+  );
+}

--- a/app/(main)/ledger/payment-methods/[paymentMethodId]/page.tsx
+++ b/app/(main)/ledger/payment-methods/[paymentMethodId]/page.tsx
@@ -1,0 +1,20 @@
+import { BalanceDetailClient } from "@/components/accounts/BalanceDetailClient";
+import { PageContainer } from "@/components/layout";
+
+interface PaymentMethodDetailPageProps {
+  params: Promise<{
+    paymentMethodId: string;
+  }>;
+}
+
+export default async function PaymentMethodDetailPage({
+  params,
+}: PaymentMethodDetailPageProps) {
+  const { paymentMethodId } = await params;
+
+  return (
+    <PageContainer maxWidth="medium">
+      <BalanceDetailClient kind="payment_method" id={paymentMethodId} />
+    </PageContainer>
+  );
+}

--- a/app/api/accounts/[id]/route.ts
+++ b/app/api/accounts/[id]/route.ts
@@ -1,11 +1,64 @@
 import { NextResponse } from "next/server";
 import { deleteAccount, updateAccount } from "@/lib/api/account";
+import { getAccountBalanceDetail } from "@/lib/api/balance-adjustment";
 import { APIError, toErrorResponse } from "@/lib/api/error";
+import { getUserHouseholdId } from "@/lib/api/invitation";
 import { createClient } from "@/lib/supabase/server";
 import { updateAccountSchema } from "@/schemas/account";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
+}
+
+export async function GET(_request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    const householdId = await getUserHouseholdId(supabase, user.id);
+    if (!householdId) {
+      throw new APIError(
+        "HOUSEHOLD_NOT_FOUND",
+        "가구 정보를 찾을 수 없습니다.",
+        404,
+      );
+    }
+
+    const detail = await getAccountBalanceDetail(
+      supabase,
+      householdId,
+      user.id,
+      id,
+    );
+
+    return NextResponse.json({ data: detail });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    console.error("Account detail error:", error);
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "서버 오류가 발생했습니다.",
+        },
+      },
+      { status: 500 },
+    );
+  }
 }
 
 /**

--- a/app/api/balance-adjustments/route.ts
+++ b/app/api/balance-adjustments/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { createBalanceAdjustment } from "@/lib/api/balance-adjustment";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import { getUserHouseholdId } from "@/lib/api/invitation";
+import { createClient } from "@/lib/supabase/server";
+import { createBalanceAdjustmentSchema } from "@/schemas/balance-adjustment";
+
+export async function POST(request: Request) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    const body = await request.json();
+    const result = createBalanceAdjustmentSchema.safeParse(body);
+
+    if (!result.success) {
+      const firstError = result.error.issues[0];
+      throw new APIError(
+        "VALIDATION_ERROR",
+        firstError?.message ?? "유효하지 않은 요청입니다.",
+        400,
+      );
+    }
+
+    const householdId = await getUserHouseholdId(supabase, user.id);
+    if (!householdId) {
+      throw new APIError(
+        "HOUSEHOLD_NOT_FOUND",
+        "가구 정보를 찾을 수 없습니다.",
+        404,
+      );
+    }
+
+    const adjustment = await createBalanceAdjustment(supabase, {
+      householdId,
+      ownerId: user.id,
+      targetType: result.data.targetType,
+      accountId: result.data.accountId,
+      paymentMethodId: result.data.paymentMethodId,
+      actualBalance: result.data.actualBalance,
+      adjustedAt: result.data.adjustedAt,
+      memo: result.data.memo,
+    });
+
+    return NextResponse.json({ data: adjustment }, { status: 201 });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    console.error("Balance adjustment creation error:", error);
+    return NextResponse.json(
+      {
+        error: { code: "INTERNAL_ERROR", message: "서버 오류가 발생했습니다." },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/notification-preferences/batch/route.ts
+++ b/app/api/notification-preferences/batch/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+import { APIError, toErrorResponse } from "@/lib/api/error";
+import { upsertNotificationPreferences } from "@/lib/api/notifications";
+import { notificationPreferenceBatchUpdateSchema } from "@/lib/notifications/schema";
+import { createClient } from "@/lib/supabase/server";
+
+export async function PATCH(request: Request) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    const body = await request.json();
+    const result = notificationPreferenceBatchUpdateSchema.safeParse(body);
+
+    if (!result.success) {
+      const firstError = result.error.issues[0];
+      throw new APIError(
+        "VALIDATION_ERROR",
+        firstError?.message ?? "유효하지 않은 요청입니다.",
+        400,
+      );
+    }
+
+    const preferences = await upsertNotificationPreferences(
+      supabase,
+      user.id,
+      result.data.updates,
+    );
+
+    return NextResponse.json({ data: preferences });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    console.error("Notification preference batch update error:", error);
+    return NextResponse.json(
+      {
+        error: { code: "INTERNAL_ERROR", message: "서버 오류가 발생했습니다." },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/payment-methods/[id]/route.ts
+++ b/app/api/payment-methods/[id]/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
+import { getPaymentMethodBalanceDetail } from "@/lib/api/balance-adjustment";
 import { APIError, toErrorResponse } from "@/lib/api/error";
+import { getUserHouseholdId } from "@/lib/api/invitation";
 import {
   deletePaymentMethod,
   updatePaymentMethod,
@@ -9,6 +11,54 @@ import { updatePaymentMethodSchema } from "@/schemas/payment-method";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
+}
+
+export async function GET(_request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new APIError("AUTH_UNAUTHORIZED", "로그인이 필요합니다.", 401);
+    }
+
+    const householdId = await getUserHouseholdId(supabase, user.id);
+    if (!householdId) {
+      throw new APIError(
+        "HOUSEHOLD_NOT_FOUND",
+        "가구 정보를 찾을 수 없습니다.",
+        404,
+      );
+    }
+
+    const detail = await getPaymentMethodBalanceDetail(
+      supabase,
+      householdId,
+      user.id,
+      id,
+    );
+
+    return NextResponse.json({ data: detail });
+  } catch (error) {
+    if (error instanceof APIError) {
+      return NextResponse.json(toErrorResponse(error), {
+        status: error.statusCode,
+      });
+    }
+
+    console.error("Payment method detail error:", error);
+    return NextResponse.json(
+      {
+        error: { code: "INTERNAL_ERROR", message: "서버 오류가 발생했습니다." },
+      },
+      { status: 500 },
+    );
+  }
 }
 
 /**

--- a/components/accounts/AccountList.tsx
+++ b/components/accounts/AccountList.tsx
@@ -8,6 +8,7 @@ import {
   Trash2,
   UserRound,
 } from "lucide-react";
+import Link from "next/link";
 import { useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -20,6 +21,7 @@ import {
 import { useAccounts } from "@/hooks/use-accounts";
 import { useCurrentUserId } from "@/hooks/use-current-user";
 import type { AccountWithOwner } from "@/lib/api/account";
+import { formatCurrency } from "@/lib/utils/format";
 import { AccountDeleteDialog } from "./AccountDeleteDialog";
 import { AccountFormDialog } from "./AccountFormDialog";
 
@@ -75,37 +77,60 @@ function AccountCollection({
         const accountTypeLabel = account.accountType
           ? (ACCOUNT_TYPE_LABELS[account.accountType] ?? account.accountType)
           : "-";
+        const balanceLabel = isInvestmentAccountType(account.accountType)
+          ? "예수금"
+          : "잔액";
 
         return (
           <article
             key={account.id}
             className="flex min-h-[96px] items-center gap-3 border-gray-100 border-t px-4 py-4 first:border-t-0 sm:px-5"
           >
-            <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-gray-100 text-gray-500">
-              <CreditCard className="size-5" />
-            </div>
+            <Link
+              href={`/assets/accounts/${account.id}`}
+              className="flex min-w-0 flex-1 items-center gap-3"
+            >
+              <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-gray-100 text-gray-500">
+                <CreditCard className="size-5" />
+              </div>
 
-            <div className="min-w-0 flex-1">
-              <div className="flex min-w-0 flex-wrap items-center gap-2">
-                <h4 className="truncate font-semibold text-gray-900">
-                  {account.name}
-                </h4>
-                <Badge variant="outline">{accountTypeLabel}</Badge>
+              <div className="min-w-0 flex-1">
+                <div className="flex min-w-0 flex-wrap items-center gap-2">
+                  <h4 className="truncate font-semibold text-gray-900">
+                    {account.name}
+                  </h4>
+                  <Badge variant="outline">{accountTypeLabel}</Badge>
+                </div>
+                <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-gray-500 text-sm">
+                  <span className="inline-flex items-center gap-1">
+                    <UserRound className="size-4" />
+                    {account.ownerName}
+                  </span>
+                  <span className="inline-flex items-center gap-1">
+                    <Building2 className="size-4" />
+                    {account.broker || "기관 미입력"}
+                  </span>
+                  {account.lastFour && (
+                    <span className="text-gray-400">끝 {account.lastFour}</span>
+                  )}
+                </div>
+                <p className="mt-2 font-semibold text-gray-900 text-sm sm:hidden">
+                  {balanceLabel}{" "}
+                  {account.balance === null
+                    ? "-"
+                    : formatCurrency(account.balance)}
+                </p>
               </div>
-              <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-gray-500 text-sm">
-                <span className="inline-flex items-center gap-1">
-                  <UserRound className="size-4" />
-                  {account.ownerName}
-                </span>
-                <span className="inline-flex items-center gap-1">
-                  <Building2 className="size-4" />
-                  {account.broker || "기관 미입력"}
-                </span>
-                {account.lastFour && (
-                  <span className="text-gray-400">끝 {account.lastFour}</span>
-                )}
+
+              <div className="hidden shrink-0 text-right sm:block">
+                <p className="text-gray-400 text-xs">{balanceLabel}</p>
+                <p className="font-semibold text-gray-900">
+                  {account.balance === null
+                    ? "-"
+                    : formatCurrency(account.balance)}
+                </p>
               </div>
-            </div>
+            </Link>
 
             {isOwner && (
               <DropdownMenu>

--- a/components/accounts/BalanceDetailClient.tsx
+++ b/components/accounts/BalanceDetailClient.tsx
@@ -1,0 +1,484 @@
+"use client";
+
+import {
+  ArrowDownLeft,
+  ArrowUpRight,
+  Banknote,
+  Loader2,
+  PencilLine,
+  WalletCards,
+} from "lucide-react";
+import { useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  useAccountBalanceDetail,
+  useCreateBalanceAdjustment,
+  usePaymentMethodBalanceDetail,
+} from "@/hooks/use-balance-detail";
+import { useCurrentUserId } from "@/hooks/use-current-user";
+import type {
+  AccountBalanceDetail,
+  BalanceTimelineItem,
+  PaymentMethodBalanceDetail,
+} from "@/lib/api/balance-adjustment";
+import { cn } from "@/lib/utils/cn";
+import { formatCurrency } from "@/lib/utils/format";
+
+const AUXILIARY_PAYMENT_METHOD_TYPES = new Set([
+  "prepaid",
+  "gift_card",
+  "cash",
+]);
+
+const PAYMENT_METHOD_TYPE_LABELS: Record<string, string> = {
+  credit_card: "신용카드",
+  debit_card: "체크카드",
+  prepaid: "선불페이",
+  gift_card: "상품권",
+  cash: "현금",
+};
+
+const ACCOUNT_TYPE_LABELS: Record<string, string> = {
+  checking: "입출금",
+  savings: "적금",
+  deposit: "예금",
+  stock: "일반",
+  isa: "ISA",
+  pension: "연금저축",
+  cma: "CMA",
+};
+
+interface BalanceDetailClientProps {
+  kind: "account" | "payment_method";
+  id: string;
+}
+
+function formatDateTime(value: string) {
+  return new Intl.DateTimeFormat("ko-KR", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  }).format(new Date(value));
+}
+
+function getAccountIsInvestment(detail: AccountBalanceDetail) {
+  return detail.account.category === "investment";
+}
+
+function getPaymentMethodHasBalance(detail: PaymentMethodBalanceDetail) {
+  return AUXILIARY_PAYMENT_METHOD_TYPES.has(detail.paymentMethod.type);
+}
+
+export function BalanceDetailClient({ kind, id }: BalanceDetailClientProps) {
+  if (kind === "account") {
+    return <AccountBalanceDetailView id={id} />;
+  }
+  return <PaymentMethodBalanceDetailView id={id} />;
+}
+
+function AccountBalanceDetailView({ id }: { id: string }) {
+  const { data, isLoading, error } = useAccountBalanceDetail(id);
+
+  if (isLoading) return <BalanceDetailSkeleton />;
+  if (error || !data) return <BalanceDetailError />;
+
+  const isInvestment = getAccountIsInvestment(data);
+
+  return (
+    <BalanceDetailLayout
+      title={data.account.name}
+      subtitle={[
+        data.account.ownerName,
+        data.account.broker,
+        data.account.accountType
+          ? ACCOUNT_TYPE_LABELS[data.account.accountType]
+          : null,
+      ]
+        .filter(Boolean)
+        .join(" · ")}
+      balanceLabel={isInvestment ? "예수금" : "현재 잔액"}
+      balance={data.account.balance}
+      totalLabel={isInvestment ? "계좌 총액" : null}
+      totalValue={isInvestment ? data.totalValue : null}
+      stockValue={isInvestment ? data.stockValue : null}
+      helperText={
+        isInvestment
+          ? "예수금은 주식 매수/매도와 가계부 입출금에 따라 변합니다."
+          : null
+      }
+      canAdjust
+      actionLabel={isInvestment ? "예수금 맞추기" : "실제 잔액 맞추기"}
+      target={{
+        targetType: "account",
+        accountId: data.account.id,
+        currentBalance: data.account.balance ?? 0,
+        ownerId: data.account.ownerId,
+      }}
+      timeline={data.timeline}
+    />
+  );
+}
+
+function PaymentMethodBalanceDetailView({ id }: { id: string }) {
+  const { data, isLoading, error } = usePaymentMethodBalanceDetail(id);
+
+  if (isLoading) return <BalanceDetailSkeleton />;
+  if (error || !data) return <BalanceDetailError />;
+
+  const hasBalance = getPaymentMethodHasBalance(data);
+
+  return (
+    <BalanceDetailLayout
+      title={data.paymentMethod.name}
+      subtitle={[
+        data.paymentMethod.ownerName,
+        PAYMENT_METHOD_TYPE_LABELS[data.paymentMethod.type],
+        data.paymentMethod.issuer,
+      ]
+        .filter(Boolean)
+        .join(" · ")}
+      balanceLabel={hasBalance ? "보조잔액" : "자체 잔액 없음"}
+      balance={hasBalance ? data.paymentMethod.balance : null}
+      totalLabel={null}
+      totalValue={null}
+      stockValue={null}
+      helperText={
+        hasBalance
+          ? "선불/상품권/현금 잔액은 가계부용 보조잔액이며 총자산에는 포함되지 않습니다."
+          : "신용카드와 체크카드는 지출 내역 중심으로 관리하며 자체 잔액을 갖지 않습니다."
+      }
+      canAdjust={hasBalance}
+      actionLabel="실제 잔액 맞추기"
+      target={{
+        targetType: "payment_method",
+        paymentMethodId: data.paymentMethod.id,
+        currentBalance: data.paymentMethod.balance ?? 0,
+        ownerId: data.paymentMethod.ownerId,
+      }}
+      timeline={data.timeline}
+    />
+  );
+}
+
+function BalanceDetailLayout({
+  title,
+  subtitle,
+  balanceLabel,
+  balance,
+  totalLabel,
+  totalValue,
+  stockValue,
+  helperText,
+  canAdjust,
+  actionLabel,
+  target,
+  timeline,
+}: {
+  title: string;
+  subtitle: string;
+  balanceLabel: string;
+  balance: number | null;
+  totalLabel: string | null;
+  totalValue: number | null;
+  stockValue: number | null;
+  helperText: string | null;
+  canAdjust: boolean;
+  actionLabel: string;
+  target: {
+    targetType: "account" | "payment_method";
+    accountId?: string;
+    paymentMethodId?: string;
+    currentBalance: number;
+    ownerId: string;
+  };
+  timeline: BalanceTimelineItem[];
+}) {
+  const { userId } = useCurrentUserId();
+  const [adjustOpen, setAdjustOpen] = useState(false);
+  const canCurrentUserAdjust = canAdjust && userId === target.ownerId;
+
+  return (
+    <div className="space-y-5">
+      <section className="rounded-2xl bg-white p-5 shadow-sm">
+        <div className="flex items-start gap-3">
+          <div className="flex size-11 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
+            <Banknote className="size-5" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <h1 className="truncate font-semibold text-gray-900 text-xl">
+              {title}
+            </h1>
+            {subtitle && (
+              <p className="mt-1 text-gray-500 text-sm">{subtitle}</p>
+            )}
+          </div>
+        </div>
+
+        <div className="mt-6">
+          <p className="text-gray-500 text-sm">{balanceLabel}</p>
+          <p className="mt-1 font-bold text-3xl text-gray-900">
+            {balance === null ? "-" : formatCurrency(balance)}
+          </p>
+        </div>
+
+        {totalLabel && (
+          <div className="mt-4 grid grid-cols-2 gap-3">
+            <div className="rounded-xl bg-gray-50 p-3">
+              <p className="text-gray-500 text-xs">보유 주식 평가액</p>
+              <p className="mt-1 font-semibold text-gray-900">
+                {formatCurrency(stockValue ?? 0)}
+              </p>
+            </div>
+            <div className="rounded-xl bg-gray-50 p-3">
+              <p className="text-gray-500 text-xs">{totalLabel}</p>
+              <p className="mt-1 font-semibold text-gray-900">
+                {formatCurrency(totalValue ?? 0)}
+              </p>
+            </div>
+          </div>
+        )}
+
+        {helperText && (
+          <p className="mt-4 text-gray-500 text-sm">{helperText}</p>
+        )}
+
+        {canCurrentUserAdjust && (
+          <Button
+            type="button"
+            className="mt-5 w-full"
+            onClick={() => setAdjustOpen(true)}
+          >
+            <PencilLine className="size-4" />
+            {actionLabel}
+          </Button>
+        )}
+      </section>
+
+      <TimelineSection items={timeline} />
+
+      <BalanceAdjustmentDialog
+        open={adjustOpen}
+        onOpenChange={setAdjustOpen}
+        title={actionLabel}
+        target={target}
+      />
+    </div>
+  );
+}
+
+function TimelineSection({ items }: { items: BalanceTimelineItem[] }) {
+  return (
+    <section className="space-y-2">
+      <h2 className="px-1 font-semibold text-gray-700 text-sm">
+        잔액 변화 내역
+      </h2>
+      <div className="overflow-hidden rounded-2xl bg-white shadow-sm">
+        {items.length === 0 ? (
+          <div className="p-6 text-center text-gray-500 text-sm">
+            아직 표시할 내역이 없습니다.
+          </div>
+        ) : (
+          items.map((item, index) => (
+            <TimelineRow
+              key={`${item.kind}:${item.id}`}
+              item={item}
+              showBorder={index > 0}
+            />
+          ))
+        )}
+      </div>
+    </section>
+  );
+}
+
+function TimelineRow({
+  item,
+  showBorder,
+}: {
+  item: BalanceTimelineItem;
+  showBorder: boolean;
+}) {
+  const isPositive = item.delta >= 0;
+  const Icon = isPositive ? ArrowDownLeft : ArrowUpRight;
+
+  return (
+    <article
+      className={cn(
+        "flex items-center gap-3 p-4",
+        showBorder && "border-gray-100 border-t",
+      )}
+    >
+      <div
+        className={cn(
+          "flex size-10 shrink-0 items-center justify-center rounded-full",
+          isPositive
+            ? "bg-green-50 text-green-700"
+            : "bg-gray-100 text-gray-600",
+        )}
+      >
+        <Icon className="size-5" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex min-w-0 items-center gap-2">
+          <p className="truncate font-medium text-gray-900">{item.title}</p>
+          <span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 font-medium text-[11px] text-gray-500">
+            {item.label}
+          </span>
+        </div>
+        <p className="mt-1 text-gray-500 text-sm">
+          {formatDateTime(item.occurredAt)}
+        </p>
+      </div>
+      <p
+        className={cn(
+          "shrink-0 font-semibold",
+          isPositive ? "text-green-700" : "text-gray-900",
+        )}
+      >
+        {isPositive ? "+" : "-"}
+        {formatCurrency(Math.abs(item.delta))}
+      </p>
+    </article>
+  );
+}
+
+function BalanceAdjustmentDialog({
+  open,
+  onOpenChange,
+  title,
+  target,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  target: {
+    targetType: "account" | "payment_method";
+    accountId?: string;
+    paymentMethodId?: string;
+    currentBalance: number;
+  };
+}) {
+  const mutation = useCreateBalanceAdjustment();
+  const [actualBalance, setActualBalance] = useState(
+    String(target.currentBalance),
+  );
+  const [memo, setMemo] = useState("");
+
+  const delta = useMemo(() => {
+    const next = Number(actualBalance);
+    return Number.isFinite(next) ? next - target.currentBalance : 0;
+  }, [actualBalance, target.currentBalance]);
+
+  const handleSubmit = async () => {
+    const nextBalance = Number(actualBalance);
+    if (!Number.isFinite(nextBalance)) return;
+
+    await mutation.mutateAsync({
+      targetType: target.targetType,
+      accountId: target.accountId,
+      paymentMethodId: target.paymentMethodId,
+      actualBalance: nextBalance,
+      memo: memo.trim() || undefined,
+    });
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent onOpenAutoFocus={(event) => event.preventDefault()}>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>
+            앱 잔액과 실제 잔액의 차이를 맞춘 기록이에요. 수입/지출 통계에는
+            포함되지 않아요.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="actual-balance">실제 잔액</Label>
+            <Input
+              id="actual-balance"
+              type="number"
+              inputMode="decimal"
+              value={actualBalance}
+              onChange={(event) => setActualBalance(event.target.value)}
+            />
+          </div>
+          <div className="rounded-xl bg-gray-50 p-3 text-sm">
+            <div className="flex items-center justify-between">
+              <span className="text-gray-500">현재 앱 잔액</span>
+              <span className="font-medium">
+                {formatCurrency(target.currentBalance)}
+              </span>
+            </div>
+            <div className="mt-2 flex items-center justify-between">
+              <span className="text-gray-500">조정 차액</span>
+              <span className="font-semibold">{formatCurrency(delta)}</span>
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="adjustment-memo">메모</Label>
+            <Textarea
+              id="adjustment-memo"
+              rows={3}
+              value={memo}
+              onChange={(event) => setMemo(event.target.value)}
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => onOpenChange(false)}
+            disabled={mutation.isPending}
+          >
+            취소
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSubmit}
+            disabled={
+              mutation.isPending || !Number.isFinite(Number(actualBalance))
+            }
+          >
+            {mutation.isPending && <Loader2 className="size-4 animate-spin" />}
+            저장
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function BalanceDetailSkeleton() {
+  return (
+    <div className="space-y-5">
+      <Skeleton className="h-52 rounded-2xl" />
+      <Skeleton className="h-72 rounded-2xl" />
+    </div>
+  );
+}
+
+function BalanceDetailError() {
+  return (
+    <div className="rounded-2xl bg-white p-8 text-center shadow-sm">
+      <WalletCards className="mx-auto size-10 text-gray-300" />
+      <p className="mt-3 text-gray-500 text-sm">
+        상세 정보를 불러오지 못했습니다.
+      </p>
+    </div>
+  );
+}

--- a/components/accounts/PaymentMethodList.tsx
+++ b/components/accounts/PaymentMethodList.tsx
@@ -8,6 +8,7 @@ import {
   Trash2,
   UserRound,
 } from "lucide-react";
+import Link from "next/link";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
@@ -19,6 +20,7 @@ import {
 import { useCurrentUserId } from "@/hooks/use-current-user";
 import { usePaymentMethods } from "@/hooks/use-payment-methods";
 import type { PaymentMethodWithDetails } from "@/lib/api/payment-method";
+import { formatCurrency } from "@/lib/utils/format";
 import { PaymentMethodDeleteDialog } from "./PaymentMethodDeleteDialog";
 import { PaymentMethodFormDialog } from "./PaymentMethodFormDialog";
 
@@ -29,6 +31,12 @@ const PAYMENT_METHOD_TYPE_LABELS: Record<string, string> = {
   gift_card: "상품권",
   cash: "현금",
 };
+
+const AUXILIARY_PAYMENT_METHOD_TYPES = new Set([
+  "prepaid",
+  "gift_card",
+  "cash",
+]);
 
 export function PaymentMethodList() {
   const { data: paymentMethods, isLoading, error } = usePaymentMethods();
@@ -92,41 +100,69 @@ export function PaymentMethodList() {
       <div className="overflow-hidden rounded-2xl bg-white shadow-sm ring-1 ring-gray-100">
         {paymentMethods.map((method) => {
           const isOwner = currentUserId === method.ownerId;
+          const hasBalance = AUXILIARY_PAYMENT_METHOD_TYPES.has(method.type);
           return (
             <article
               key={method.id}
               className="flex min-h-[96px] items-center gap-3 border-gray-100 border-t px-4 py-4 first:border-t-0 sm:px-5"
             >
-              <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-gray-100 text-gray-500">
-                <CreditCard className="size-5" />
-              </div>
+              <Link
+                href={`/ledger/payment-methods/${method.id}`}
+                className="flex min-w-0 flex-1 items-center gap-3"
+              >
+                <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-gray-100 text-gray-500">
+                  <CreditCard className="size-5" />
+                </div>
 
-              <div className="min-w-0 flex-1">
-                <div className="flex min-w-0 flex-wrap items-center gap-2">
-                  <h4 className="truncate font-semibold text-gray-900">
-                    {method.name}
-                  </h4>
-                  {method.lastFour && (
-                    <span className="text-gray-400 text-xs">
-                      {method.lastFour}
+                <div className="min-w-0 flex-1">
+                  <div className="flex min-w-0 flex-wrap items-center gap-2">
+                    <h4 className="truncate font-semibold text-gray-900">
+                      {method.name}
+                    </h4>
+                    {method.lastFour && (
+                      <span className="text-gray-400 text-xs">
+                        {method.lastFour}
+                      </span>
+                    )}
+                  </div>
+                  <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-gray-500 text-sm">
+                    <span>
+                      {PAYMENT_METHOD_TYPE_LABELS[method.type] || method.type}
                     </span>
-                  )}
+                    <span className="inline-flex items-center gap-1">
+                      <UserRound className="size-4" />
+                      {method.ownerName}
+                    </span>
+                    <span>{method.issuer || "발급사 미입력"}</span>
+                    <span className="inline-flex items-center gap-1">
+                      <Link2 className="size-4" />
+                      {method.linkedAccountName || "연결 계좌 없음"}
+                    </span>
+                  </div>
+                  <p className="mt-2 font-semibold text-gray-900 text-sm sm:hidden">
+                    {hasBalance
+                      ? `보조잔액 ${
+                          method.balance === null
+                            ? "-"
+                            : formatCurrency(method.balance)
+                        }`
+                      : "자체 잔액 없음"}
+                  </p>
                 </div>
-                <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-gray-500 text-sm">
-                  <span>
-                    {PAYMENT_METHOD_TYPE_LABELS[method.type] || method.type}
-                  </span>
-                  <span className="inline-flex items-center gap-1">
-                    <UserRound className="size-4" />
-                    {method.ownerName}
-                  </span>
-                  <span>{method.issuer || "발급사 미입력"}</span>
-                  <span className="inline-flex items-center gap-1">
-                    <Link2 className="size-4" />
-                    {method.linkedAccountName || "연결 계좌 없음"}
-                  </span>
+
+                <div className="hidden shrink-0 text-right sm:block">
+                  <p className="text-gray-400 text-xs">
+                    {hasBalance ? "보조잔액" : "잔액"}
+                  </p>
+                  <p className="font-semibold text-gray-900">
+                    {hasBalance
+                      ? method.balance === null
+                        ? "-"
+                        : formatCurrency(method.balance)
+                      : "-"}
+                  </p>
                 </div>
-              </div>
+              </Link>
 
               {isOwner && (
                 <DropdownMenu>

--- a/components/ledger/LedgerEntryChangeRequestDialog.tsx
+++ b/components/ledger/LedgerEntryChangeRequestDialog.tsx
@@ -171,7 +171,10 @@ export function LedgerEntryChangeRequestDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent
+        className="left-0 top-0 flex h-[100dvh] max-h-[100dvh] w-full max-w-full translate-x-0 translate-y-0 flex-col overflow-y-auto rounded-none border-0 p-5 sm:left-[50%] sm:top-[50%] sm:h-auto sm:max-h-[85dvh] sm:max-w-md sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-lg sm:border sm:p-6"
+        onOpenAutoFocus={(event) => event.preventDefault()}
+      >
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription>{description}</DialogDescription>
@@ -301,7 +304,7 @@ export function LedgerEntryChangeRequestDialog({
           />
         </div>
 
-        <DialogFooter>
+        <DialogFooter className="mt-auto">
           <Button
             type="button"
             variant="outline"

--- a/components/notifications/NotificationSettingsClient.tsx
+++ b/components/notifications/NotificationSettingsClient.tsx
@@ -6,6 +6,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import {
   useNotificationPreferences,
   useUpdateNotificationPreference,
+  useUpdateNotificationPreferencesBatch,
 } from "@/hooks/use-notification-preferences";
 import { usePushSubscription } from "@/hooks/use-push-subscription";
 import {
@@ -27,7 +28,7 @@ const IMPORTANT_PUSH_TYPES = new Set<NotificationType>([
 export function NotificationSettingsClient() {
   const { data: preferences = [], isLoading } = useNotificationPreferences();
   const pushSubscription = usePushSubscription();
-  const updatePreference = useUpdateNotificationPreference();
+  const updatePreferencesBatch = useUpdateNotificationPreferencesBatch();
 
   if (isLoading) {
     return (
@@ -60,7 +61,7 @@ export function NotificationSettingsClient() {
       <PushDeviceCard
         preferences={preferences}
         pushSubscription={pushSubscription}
-        updatePreference={updatePreference}
+        updatePreferencesBatch={updatePreferencesBatch}
       />
 
       {Object.entries(NOTIFICATION_PREFERENCE_GROUP_LABELS).map(
@@ -98,11 +99,13 @@ export function NotificationSettingsClient() {
 function PushDeviceCard({
   preferences,
   pushSubscription,
-  updatePreference,
+  updatePreferencesBatch,
 }: {
   preferences: NotificationPreferenceView[];
   pushSubscription: ReturnType<typeof usePushSubscription>;
-  updatePreference: ReturnType<typeof useUpdateNotificationPreference>;
+  updatePreferencesBatch: ReturnType<
+    typeof useUpdateNotificationPreferencesBatch
+  >;
 }) {
   const importantPushTargets = preferences.filter(
     (preference) =>
@@ -114,15 +117,13 @@ function PushDeviceCard({
     pushSubscription.isSubscribed && importantPushTargets.length > 0;
 
   const handleEnableImportantPush = async () => {
-    for (const preference of importantPushTargets) {
-      await updatePreference.mutateAsync({
+    await updatePreferencesBatch.mutateAsync({
+      updates: importantPushTargets.map((preference) => ({
         type: preference.type,
-        input: {
-          inAppEnabled: preference.inAppEnabled,
-          pushEnabled: true,
-        },
-      });
-    }
+        inAppEnabled: preference.inAppEnabled,
+        pushEnabled: true,
+      })),
+    });
   };
 
   const content = getPushDeviceCardContent(pushSubscription.deviceState);
@@ -199,11 +200,11 @@ function PushDeviceCard({
                 type="button"
                 size="sm"
                 variant="secondary"
-                disabled={updatePreference.isPending}
+                disabled={updatePreferencesBatch.isPending}
                 onClick={handleEnableImportantPush}
                 className="mt-3"
               >
-                {updatePreference.isPending && (
+                {updatePreferencesBatch.isPending && (
                   <Loader2 className="size-4 animate-spin" />
                 )}
                 주요 알림 Push 켜기
@@ -344,12 +345,14 @@ function PreferenceRow({
           label="앱"
           enabled={preference.inAppEnabled}
           disabled={updatePreference.isPending}
+          pending={updatePreference.isPending}
           onClick={() => handleToggle("inAppEnabled")}
         />
         <ToggleButton
           label="Push"
           enabled={preference.pushEnabled}
           disabled={pushDisabled}
+          pending={updatePreference.isPending}
           onClick={() => handleToggle("pushEnabled")}
         />
       </div>
@@ -361,11 +364,13 @@ function ToggleButton({
   label,
   enabled,
   disabled,
+  pending,
   onClick,
 }: {
   label: string;
   enabled: boolean;
   disabled: boolean;
+  pending: boolean;
   onClick: () => void;
 }) {
   return (
@@ -380,7 +385,7 @@ function ToggleButton({
         enabled ? "bg-primary text-white" : "bg-gray-100 text-gray-500",
       )}
     >
-      {disabled && <Loader2 className="size-3 animate-spin" />}
+      {pending && <Loader2 className="size-3 animate-spin" />}
       {label}
     </button>
   );

--- a/components/transactions/TransactionChangeRequestDialog.tsx
+++ b/components/transactions/TransactionChangeRequestDialog.tsx
@@ -167,7 +167,10 @@ export function TransactionChangeRequestDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent
+        className="left-0 top-0 flex h-[100dvh] max-h-[100dvh] w-full max-w-full translate-x-0 translate-y-0 flex-col overflow-y-auto rounded-none border-0 p-5 sm:left-[50%] sm:top-[50%] sm:h-auto sm:max-h-[85dvh] sm:max-w-md sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-lg sm:border sm:p-6"
+        onOpenAutoFocus={(event) => event.preventDefault()}
+      >
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             {!isUpdate && (
@@ -288,7 +291,7 @@ export function TransactionChangeRequestDialog({
               />
             </div>
 
-            <DialogFooter>
+            <DialogFooter className="mt-auto">
               <Button
                 type="button"
                 variant="outline"
@@ -315,7 +318,7 @@ export function TransactionChangeRequestDialog({
               />
             </div>
 
-            <DialogFooter>
+            <DialogFooter className="mt-auto">
               <Button
                 type="button"
                 variant="outline"

--- a/constants/service-routes.ts
+++ b/constants/service-routes.ts
@@ -67,6 +67,11 @@ export const SERVICE_ROUTE_TREE = [
             mobile: "task",
             closeHref: "/ledger/payment-methods",
           },
+          {
+            href: "/ledger/payment-methods/[paymentMethodId]",
+            pattern: "/ledger/payment-methods/[paymentMethodId]",
+            label: "결제수단 상세",
+          },
         ],
       },
       { href: "/ledger/categories", label: "카테고리 관리" },

--- a/hooks/use-balance-detail.ts
+++ b/hooks/use-balance-detail.ts
@@ -1,0 +1,112 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import type {
+  AccountBalanceDetail,
+  PaymentMethodBalanceDetail,
+} from "@/lib/api/balance-adjustment";
+import { queries } from "@/lib/queries/keys";
+import type { BalanceAdjustmentTargetType } from "@/types";
+
+interface ApiDataResponse<T> {
+  data: T;
+}
+
+interface ApiErrorResponse {
+  error?: {
+    message?: string;
+  };
+}
+
+export interface CreateBalanceAdjustmentClientInput {
+  targetType: BalanceAdjustmentTargetType;
+  accountId?: string;
+  paymentMethodId?: string;
+  actualBalance: number;
+  adjustedAt?: string;
+  memo?: string;
+}
+
+async function readApiJson<T>(response: Response): Promise<T> {
+  const json = (await response.json()) as ApiDataResponse<T> | ApiErrorResponse;
+
+  if (!response.ok) {
+    throw new Error(
+      (json as ApiErrorResponse).error?.message ?? "요청에 실패했습니다.",
+    );
+  }
+
+  return (json as ApiDataResponse<T>).data;
+}
+
+async function fetchAccountDetail(id: string) {
+  const response = await fetch(`/api/accounts/${id}`);
+  return readApiJson<AccountBalanceDetail>(response);
+}
+
+async function fetchPaymentMethodDetail(id: string) {
+  const response = await fetch(`/api/payment-methods/${id}`);
+  return readApiJson<PaymentMethodBalanceDetail>(response);
+}
+
+async function createBalanceAdjustment(
+  input: CreateBalanceAdjustmentClientInput,
+) {
+  const response = await fetch("/api/balance-adjustments", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  return readApiJson(response);
+}
+
+export function useAccountBalanceDetail(id: string) {
+  return useQuery({
+    queryKey: queries.accounts.detail(id).queryKey,
+    queryFn: () => fetchAccountDetail(id),
+  });
+}
+
+export function usePaymentMethodBalanceDetail(id: string) {
+  return useQuery({
+    queryKey: queries.paymentMethods.detail(id).queryKey,
+    queryFn: () => fetchPaymentMethodDetail(id),
+  });
+}
+
+export function useCreateBalanceAdjustment() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: createBalanceAdjustment,
+    onSuccess: (_data, variables) => {
+      toast.success("잔액을 맞췄습니다.");
+      queryClient.invalidateQueries({
+        queryKey: queries.accounts.all.queryKey,
+      });
+      queryClient.invalidateQueries({
+        queryKey: queries.paymentMethods.all.queryKey,
+      });
+      queryClient.invalidateQueries({
+        queryKey: queries.assets.summary.queryKey,
+      });
+      if (variables.accountId) {
+        queryClient.invalidateQueries({
+          queryKey: queries.accounts.detail(variables.accountId).queryKey,
+        });
+      }
+      if (variables.paymentMethodId) {
+        queryClient.invalidateQueries({
+          queryKey: queries.paymentMethods.detail(variables.paymentMethodId)
+            .queryKey,
+        });
+      }
+    },
+    onError: (error) => {
+      toast.error(
+        error instanceof Error ? error.message : "잔액 조정에 실패했습니다.",
+      );
+    },
+  });
+}

--- a/hooks/use-notification-preferences.ts
+++ b/hooks/use-notification-preferences.ts
@@ -4,6 +4,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import type { NotificationPreferenceView } from "@/lib/notifications/defaults";
 import type {
+  NotificationPreferenceBatchUpdate,
   NotificationPreferenceUpdate,
   NotificationType,
 } from "@/lib/notifications/schema";
@@ -51,6 +52,17 @@ async function updateNotificationPreference({
   return readApiJson<NotificationPreferenceView>(response);
 }
 
+async function updateNotificationPreferencesBatch(
+  input: NotificationPreferenceBatchUpdate,
+) {
+  const response = await fetch("/api/notification-preferences/batch", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  return readApiJson<NotificationPreferenceView[]>(response);
+}
+
 export function useNotificationPreferences() {
   return useQuery({
     queryKey: queries.notifications.preferences.queryKey,
@@ -86,6 +98,64 @@ export function useUpdateNotificationPreference() {
       );
 
       return { previous };
+    },
+    onError: (error, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(
+          queries.notifications.preferences.queryKey,
+          context.previous,
+        );
+      }
+
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "알림 설정 저장에 실패했습니다.",
+      );
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({
+        queryKey: queries.notifications.preferences.queryKey,
+      });
+    },
+  });
+}
+
+export function useUpdateNotificationPreferencesBatch() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updateNotificationPreferencesBatch,
+    onMutate: async ({ updates }) => {
+      await queryClient.cancelQueries({
+        queryKey: queries.notifications.preferences.queryKey,
+      });
+      const previous = queryClient.getQueryData<NotificationPreferenceView[]>(
+        queries.notifications.preferences.queryKey,
+      );
+
+      const updateMap = new Map(updates.map((update) => [update.type, update]));
+      queryClient.setQueryData<NotificationPreferenceView[]>(
+        queries.notifications.preferences.queryKey,
+        (current) =>
+          current?.map((preference) => {
+            const update = updateMap.get(preference.type);
+            if (!update) return preference;
+            return {
+              ...preference,
+              inAppEnabled: update.inAppEnabled,
+              pushEnabled: update.inAppEnabled ? update.pushEnabled : false,
+            };
+          }) ?? current,
+      );
+
+      return { previous };
+    },
+    onSuccess: (preferences) => {
+      queryClient.setQueryData(
+        queries.notifications.preferences.queryKey,
+        preferences,
+      );
     },
     onError: (error, _variables, context) => {
       if (context?.previous) {

--- a/lib/api/balance-adjustment.test.ts
+++ b/lib/api/balance-adjustment.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import {
+  getBalanceAdjustmentDelta,
+  isBalanceAdjustablePaymentMethodType,
+} from "./balance-adjustment";
+
+describe("balance adjustment domain helpers", () => {
+  it("현재 잔액과 실제 잔액의 차이를 delta로 계산한다", () => {
+    expect(getBalanceAdjustmentDelta(10_000, 12_500)).toBe(2_500);
+    expect(getBalanceAdjustmentDelta(10_000, 7_000)).toBe(-3_000);
+  });
+
+  it("선불/상품권/현금만 결제수단 잔액 조정 대상이다", () => {
+    expect(isBalanceAdjustablePaymentMethodType("prepaid")).toBe(true);
+    expect(isBalanceAdjustablePaymentMethodType("gift_card")).toBe(true);
+    expect(isBalanceAdjustablePaymentMethodType("cash")).toBe(true);
+    expect(isBalanceAdjustablePaymentMethodType("credit_card")).toBe(false);
+    expect(isBalanceAdjustablePaymentMethodType("debit_card")).toBe(false);
+  });
+});

--- a/lib/api/balance-adjustment.ts
+++ b/lib/api/balance-adjustment.ts
@@ -1,0 +1,629 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { getExchangeRateSafe } from "@/lib/api/exchange";
+import { getHoldings } from "@/lib/api/holdings";
+import { getStockPrices } from "@/lib/api/stock-price";
+import { calculateHoldingValuation } from "@/lib/api/valuation";
+import type {
+  AccountCategory,
+  AccountType,
+  BalanceAdjustment,
+  BalanceAdjustmentTargetType,
+  Database,
+  Json,
+  PaymentMethodType,
+} from "@/types";
+import { APIError } from "./error";
+
+const AUXILIARY_PAYMENT_METHOD_TYPES = new Set<PaymentMethodType>([
+  "prepaid",
+  "gift_card",
+  "cash",
+]);
+
+export function isBalanceAdjustablePaymentMethodType(type: PaymentMethodType) {
+  return AUXILIARY_PAYMENT_METHOD_TYPES.has(type);
+}
+
+export function getBalanceAdjustmentDelta(
+  previousBalance: number,
+  actualBalance: number,
+) {
+  return actualBalance - previousBalance;
+}
+
+export type BalanceTimelineItemKind =
+  | "ledger"
+  | "stock_transaction"
+  | "balance_adjustment";
+
+export interface BalanceTimelineItem {
+  id: string;
+  kind: BalanceTimelineItemKind;
+  label: string;
+  title: string;
+  amount: number;
+  delta: number;
+  occurredAt: string;
+  memo: string | null;
+  meta: Record<string, Json>;
+}
+
+export interface AccountBalanceDetail {
+  type: "account";
+  account: {
+    id: string;
+    householdId: string;
+    ownerId: string;
+    ownerName: string;
+    name: string;
+    broker: string | null;
+    lastFour: string | null;
+    accountType: AccountType | null;
+    category: AccountCategory | null;
+    balance: number | null;
+    balanceUpdatedAt: string | null;
+    memo: string | null;
+  };
+  stockValue: number | null;
+  totalValue: number | null;
+  timeline: BalanceTimelineItem[];
+}
+
+export interface PaymentMethodBalanceDetail {
+  type: "payment_method";
+  paymentMethod: {
+    id: string;
+    householdId: string;
+    ownerId: string;
+    ownerName: string;
+    name: string;
+    type: PaymentMethodType;
+    linkedAccountId: string | null;
+    linkedAccountName: string | null;
+    issuer: string | null;
+    lastFour: string | null;
+    paymentDay: number | null;
+    balance: number | null;
+    balanceUpdatedAt: string | null;
+    memo: string | null;
+  };
+  timeline: BalanceTimelineItem[];
+}
+
+interface CreateBalanceAdjustmentParams {
+  householdId: string;
+  ownerId: string;
+  targetType: BalanceAdjustmentTargetType;
+  accountId?: string | null;
+  paymentMethodId?: string | null;
+  actualBalance: number;
+  adjustedAt?: string;
+  memo?: string | null;
+}
+
+function toNumber(value: number | string | null | undefined): number {
+  return Number(value ?? 0);
+}
+
+function getAccountCategory(account: {
+  category: AccountCategory | null;
+  account_type: AccountType | null;
+}): AccountCategory | null {
+  if (account.category) return account.category;
+  if (
+    account.account_type === "checking" ||
+    account.account_type === "savings" ||
+    account.account_type === "deposit"
+  ) {
+    return "bank";
+  }
+  if (
+    account.account_type === "stock" ||
+    account.account_type === "isa" ||
+    account.account_type === "pension" ||
+    account.account_type === "cma"
+  ) {
+    return "investment";
+  }
+  return null;
+}
+
+function sortTimeline(items: BalanceTimelineItem[]) {
+  return items.sort(
+    (a, b) =>
+      new Date(b.occurredAt).getTime() - new Date(a.occurredAt).getTime(),
+  );
+}
+
+function mapLedgerLabel(type: string, delta: number) {
+  if (type === "transfer") return delta >= 0 ? "입금" : "출금";
+  if (type === "income") return "예수금 입금";
+  return "지출";
+}
+
+async function fetchOwnerName(
+  supabase: SupabaseClient<Database>,
+  ownerId: string,
+) {
+  const { data } = await supabase
+    .from("profiles")
+    .select("name")
+    .eq("id", ownerId)
+    .maybeSingle();
+  return data?.name ?? "알 수 없음";
+}
+
+async function fetchAccountStockValue(
+  supabase: SupabaseClient<Database>,
+  householdId: string,
+  accountId: string,
+) {
+  const holdingsResult = await getHoldings(supabase, householdId, {
+    filters: { accountId },
+    pagination: { page: 1, pageSize: 200 },
+  });
+  const holdings = holdingsResult.data;
+  if (holdings.length === 0) return 0;
+
+  const exchangeRateResult = await getExchangeRateSafe(supabase);
+  const exchangeRate = exchangeRateResult?.rate ?? 1300;
+  const stockPrices = await getStockPrices(
+    supabase,
+    holdings
+      .filter((holding) => holding.market === "KR" || holding.market === "US")
+      .map((holding) => ({
+        market: holding.market as "KR" | "US",
+        code: holding.ticker,
+      })),
+  );
+
+  return holdings.reduce((sum, holding) => {
+    const valuation = calculateHoldingValuation(
+      {
+        quantity: holding.quantity,
+        avgPrice: holding.avgPrice,
+        totalInvested: holding.totalInvested,
+        currency: holding.currency,
+      },
+      stockPrices[`${holding.market}:${holding.ticker}`],
+      exchangeRate,
+    );
+    return sum + valuation.currentValue;
+  }, 0);
+}
+
+async function getAccountTimeline(
+  supabase: SupabaseClient<Database>,
+  householdId: string,
+  userId: string,
+  accountId: string,
+): Promise<BalanceTimelineItem[]> {
+  const [{ data: ledgerRows }, { data: stockRows }, { data: adjustments }] =
+    await Promise.all([
+      supabase
+        .from("ledger_entries")
+        .select(
+          "id,type,amount,title,memo,from_account_id,to_account_id,is_shared,owner_id,transacted_at,categories(name)",
+        )
+        .eq("household_id", householdId)
+        .or(`from_account_id.eq.${accountId},to_account_id.eq.${accountId}`)
+        .order("transacted_at", { ascending: false })
+        .limit(80),
+      supabase
+        .from("transactions")
+        .select("id,ticker,type,quantity,price,memo,transacted_at")
+        .eq("household_id", householdId)
+        .eq("account_id", accountId)
+        .order("transacted_at", { ascending: false })
+        .limit(80),
+      supabase
+        .from("balance_adjustments")
+        .select("*")
+        .eq("household_id", householdId)
+        .eq("account_id", accountId)
+        .order("adjusted_at", { ascending: false })
+        .limit(80),
+    ]);
+
+  const ledgerItems =
+    ledgerRows
+      ?.filter((row) => row.is_shared || row.owner_id === userId)
+      .map((row) => {
+        const amount = toNumber(row.amount);
+        const delta =
+          row.to_account_id === accountId
+            ? amount
+            : row.from_account_id === accountId
+              ? -amount
+              : 0;
+        const category = row.categories as { name: string } | null;
+        return {
+          id: row.id,
+          kind: "ledger" as const,
+          label: mapLedgerLabel(row.type, delta),
+          title: row.title ?? category?.name ?? "가계부 기록",
+          amount,
+          delta,
+          occurredAt: row.transacted_at,
+          memo: row.memo,
+          meta: {
+            ledgerType: row.type,
+            categoryName: category?.name ?? null,
+          },
+        };
+      }) ?? [];
+
+  const stockItems =
+    stockRows?.map((row) => {
+      const amount = toNumber(row.quantity) * toNumber(row.price);
+      const delta = row.type === "buy" ? -amount : amount;
+      return {
+        id: row.id,
+        kind: "stock_transaction" as const,
+        label: row.type === "buy" ? "주식 매수" : "주식 매도",
+        title: row.ticker,
+        amount,
+        delta,
+        occurredAt: row.transacted_at,
+        memo: row.memo,
+        meta: {
+          ticker: row.ticker,
+          transactionType: row.type,
+          quantity: toNumber(row.quantity),
+          price: toNumber(row.price),
+        },
+      };
+    }) ?? [];
+
+  const adjustmentItems =
+    adjustments?.map((row) => ({
+      id: row.id,
+      kind: "balance_adjustment" as const,
+      label: "잔액 조정",
+      title: row.title,
+      amount: Math.abs(toNumber(row.delta)),
+      delta: toNumber(row.delta),
+      occurredAt: row.adjusted_at,
+      memo: row.memo,
+      meta: {
+        previousBalance: toNumber(row.previous_balance),
+        actualBalance: toNumber(row.actual_balance),
+      },
+    })) ?? [];
+
+  return sortTimeline([...ledgerItems, ...stockItems, ...adjustmentItems]);
+}
+
+async function getPaymentMethodTimeline(
+  supabase: SupabaseClient<Database>,
+  householdId: string,
+  userId: string,
+  paymentMethodId: string,
+): Promise<BalanceTimelineItem[]> {
+  const [{ data: ledgerRows }, { data: adjustments }] = await Promise.all([
+    supabase
+      .from("ledger_entries")
+      .select(
+        "id,type,amount,title,memo,from_payment_method_id,to_payment_method_id,is_shared,owner_id,transacted_at,categories(name)",
+      )
+      .eq("household_id", householdId)
+      .or(
+        `from_payment_method_id.eq.${paymentMethodId},to_payment_method_id.eq.${paymentMethodId}`,
+      )
+      .order("transacted_at", { ascending: false })
+      .limit(80),
+    supabase
+      .from("balance_adjustments")
+      .select("*")
+      .eq("household_id", householdId)
+      .eq("payment_method_id", paymentMethodId)
+      .order("adjusted_at", { ascending: false })
+      .limit(80),
+  ]);
+
+  const ledgerItems =
+    ledgerRows
+      ?.filter((row) => row.is_shared || row.owner_id === userId)
+      .map((row) => {
+        const amount = toNumber(row.amount);
+        const delta =
+          row.to_payment_method_id === paymentMethodId
+            ? amount
+            : row.from_payment_method_id === paymentMethodId
+              ? -amount
+              : 0;
+        const category = row.categories as { name: string } | null;
+        return {
+          id: row.id,
+          kind: "ledger" as const,
+          label: mapLedgerLabel(row.type, delta),
+          title: row.title ?? category?.name ?? "가계부 기록",
+          amount,
+          delta,
+          occurredAt: row.transacted_at,
+          memo: row.memo,
+          meta: {
+            ledgerType: row.type,
+            categoryName: category?.name ?? null,
+          },
+        };
+      }) ?? [];
+
+  const adjustmentItems =
+    adjustments?.map((row) => ({
+      id: row.id,
+      kind: "balance_adjustment" as const,
+      label: "잔액 조정",
+      title: row.title,
+      amount: Math.abs(toNumber(row.delta)),
+      delta: toNumber(row.delta),
+      occurredAt: row.adjusted_at,
+      memo: row.memo,
+      meta: {
+        previousBalance: toNumber(row.previous_balance),
+        actualBalance: toNumber(row.actual_balance),
+      },
+    })) ?? [];
+
+  return sortTimeline([...ledgerItems, ...adjustmentItems]);
+}
+
+export async function getAccountBalanceDetail(
+  supabase: SupabaseClient<Database>,
+  householdId: string,
+  userId: string,
+  accountId: string,
+): Promise<AccountBalanceDetail> {
+  const { data: account, error } = await supabase
+    .from("accounts")
+    .select("*")
+    .eq("id", accountId)
+    .eq("household_id", householdId)
+    .single();
+
+  if (error || !account) {
+    throw new APIError("ACCOUNT_NOT_FOUND", "계좌를 찾을 수 없습니다.", 404);
+  }
+
+  const ownerName = await fetchOwnerName(supabase, account.owner_id);
+  const category = getAccountCategory(account);
+  const stockValue =
+    category === "investment"
+      ? await fetchAccountStockValue(supabase, householdId, accountId)
+      : null;
+  const balance = account.balance === null ? null : toNumber(account.balance);
+
+  return {
+    type: "account",
+    account: {
+      id: account.id,
+      householdId: account.household_id,
+      ownerId: account.owner_id,
+      ownerName,
+      name: account.name,
+      broker: account.broker,
+      lastFour: account.last_four,
+      accountType: account.account_type,
+      category,
+      balance,
+      balanceUpdatedAt: account.balance_updated_at,
+      memo: account.memo,
+    },
+    stockValue,
+    totalValue:
+      category === "investment" ? (balance ?? 0) + (stockValue ?? 0) : balance,
+    timeline: await getAccountTimeline(
+      supabase,
+      householdId,
+      userId,
+      accountId,
+    ),
+  };
+}
+
+export async function getPaymentMethodBalanceDetail(
+  supabase: SupabaseClient<Database>,
+  householdId: string,
+  userId: string,
+  paymentMethodId: string,
+): Promise<PaymentMethodBalanceDetail> {
+  const { data: paymentMethod, error } = await supabase
+    .from("payment_methods")
+    .select("*")
+    .eq("id", paymentMethodId)
+    .eq("household_id", householdId)
+    .single();
+
+  if (error || !paymentMethod) {
+    throw new APIError(
+      "PAYMENT_METHOD_NOT_FOUND",
+      "결제수단을 찾을 수 없습니다.",
+      404,
+    );
+  }
+
+  const [{ data: linkedAccount }, ownerName] = await Promise.all([
+    paymentMethod.linked_account_id
+      ? supabase
+          .from("accounts")
+          .select("name")
+          .eq("id", paymentMethod.linked_account_id)
+          .maybeSingle()
+      : Promise.resolve({ data: null }),
+    fetchOwnerName(supabase, paymentMethod.owner_id),
+  ]);
+
+  return {
+    type: "payment_method",
+    paymentMethod: {
+      id: paymentMethod.id,
+      householdId: paymentMethod.household_id,
+      ownerId: paymentMethod.owner_id,
+      ownerName,
+      name: paymentMethod.name,
+      type: paymentMethod.type,
+      linkedAccountId: paymentMethod.linked_account_id,
+      linkedAccountName: linkedAccount?.name ?? null,
+      issuer: paymentMethod.issuer,
+      lastFour: paymentMethod.last_four,
+      paymentDay: paymentMethod.payment_day,
+      balance:
+        paymentMethod.balance === null ? null : toNumber(paymentMethod.balance),
+      balanceUpdatedAt: paymentMethod.balance_updated_at,
+      memo: paymentMethod.memo,
+    },
+    timeline: await getPaymentMethodTimeline(
+      supabase,
+      householdId,
+      userId,
+      paymentMethodId,
+    ),
+  };
+}
+
+export async function createBalanceAdjustment(
+  supabase: SupabaseClient<Database>,
+  params: CreateBalanceAdjustmentParams,
+): Promise<BalanceAdjustment> {
+  if (params.targetType === "account") {
+    if (!params.accountId) {
+      throw new APIError("VALIDATION_ERROR", "계좌를 선택해주세요.", 400);
+    }
+
+    const { data: account } = await supabase
+      .from("accounts")
+      .select("id, household_id, owner_id, balance")
+      .eq("id", params.accountId)
+      .single();
+
+    if (!account || account.household_id !== params.householdId) {
+      throw new APIError("ACCOUNT_NOT_FOUND", "계좌를 찾을 수 없습니다.", 404);
+    }
+    if (account.owner_id !== params.ownerId) {
+      throw new APIError(
+        "BALANCE_ADJUSTMENT_FORBIDDEN",
+        "본인의 계좌만 잔액을 맞출 수 있습니다.",
+        403,
+      );
+    }
+
+    return createAdjustmentAndUpdateTarget(supabase, {
+      ...params,
+      previousBalance: toNumber(account.balance),
+      accountId: account.id,
+      paymentMethodId: null,
+    });
+  }
+
+  if (!params.paymentMethodId) {
+    throw new APIError("VALIDATION_ERROR", "결제수단을 선택해주세요.", 400);
+  }
+
+  const { data: paymentMethod } = await supabase
+    .from("payment_methods")
+    .select("id, household_id, owner_id, type, balance")
+    .eq("id", params.paymentMethodId)
+    .single();
+
+  if (!paymentMethod || paymentMethod.household_id !== params.householdId) {
+    throw new APIError(
+      "PAYMENT_METHOD_NOT_FOUND",
+      "결제수단을 찾을 수 없습니다.",
+      404,
+    );
+  }
+  if (paymentMethod.owner_id !== params.ownerId) {
+    throw new APIError(
+      "BALANCE_ADJUSTMENT_FORBIDDEN",
+      "본인의 결제수단만 잔액을 맞출 수 있습니다.",
+      403,
+    );
+  }
+  if (!isBalanceAdjustablePaymentMethodType(paymentMethod.type)) {
+    throw new APIError(
+      "BALANCE_ADJUSTMENT_UNSUPPORTED",
+      "이 결제수단은 자체 잔액을 맞출 수 없습니다.",
+      400,
+    );
+  }
+
+  return createAdjustmentAndUpdateTarget(supabase, {
+    ...params,
+    previousBalance: toNumber(paymentMethod.balance),
+    accountId: null,
+    paymentMethodId: paymentMethod.id,
+  });
+}
+
+async function createAdjustmentAndUpdateTarget(
+  supabase: SupabaseClient<Database>,
+  params: CreateBalanceAdjustmentParams & {
+    previousBalance: number;
+    accountId: string | null;
+    paymentMethodId: string | null;
+  },
+): Promise<BalanceAdjustment> {
+  const now = new Date().toISOString();
+  const adjustedAt = params.adjustedAt ?? now;
+  const delta = getBalanceAdjustmentDelta(
+    params.previousBalance,
+    params.actualBalance,
+  );
+  const targetTable =
+    params.targetType === "account" ? "accounts" : "payment_methods";
+  const targetId =
+    params.targetType === "account" ? params.accountId : params.paymentMethodId;
+
+  const { error: updateError } = await supabase
+    .from(targetTable)
+    .update({
+      balance: params.actualBalance,
+      balance_updated_at: adjustedAt,
+      updated_at: now,
+    })
+    .eq("id", targetId ?? "");
+
+  if (updateError) {
+    throw new APIError(
+      "BALANCE_ADJUSTMENT_UPDATE_ERROR",
+      "잔액 업데이트에 실패했습니다.",
+      500,
+    );
+  }
+
+  const { data, error } = await supabase
+    .from("balance_adjustments")
+    .insert({
+      household_id: params.householdId,
+      owner_id: params.ownerId,
+      target_type: params.targetType,
+      account_id: params.accountId,
+      payment_method_id: params.paymentMethodId,
+      previous_balance: params.previousBalance,
+      actual_balance: params.actualBalance,
+      delta,
+      title: "잔액 맞춤",
+      memo: params.memo ?? null,
+      adjusted_at: adjustedAt,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    await supabase
+      .from(targetTable)
+      .update({
+        balance: params.previousBalance,
+        balance_updated_at: now,
+        updated_at: now,
+      })
+      .eq("id", targetId ?? "");
+    throw new APIError(
+      "BALANCE_ADJUSTMENT_ERROR",
+      "잔액 조정 기록 생성에 실패했습니다.",
+      500,
+    );
+  }
+
+  return data;
+}

--- a/lib/api/notifications.ts
+++ b/lib/api/notifications.ts
@@ -280,6 +280,35 @@ export async function upsertNotificationPreference(
   };
 }
 
+export async function upsertNotificationPreferences(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+  updates: Array<{
+    type: NotificationType;
+    inAppEnabled: boolean;
+    pushEnabled: boolean;
+  }>,
+): Promise<NotificationPreferenceView[]> {
+  const now = new Date().toISOString();
+  const rows = updates.map((update) => ({
+    user_id: userId,
+    type: update.type,
+    in_app_enabled: update.inAppEnabled,
+    push_enabled: update.inAppEnabled ? update.pushEnabled : false,
+    updated_at: now,
+  }));
+
+  const { error } = await supabase
+    .from("notification_preferences")
+    .upsert(rows, { onConflict: "user_id,type" });
+
+  if (error) {
+    throw error;
+  }
+
+  return getNotificationPreferences(supabase, userId);
+}
+
 export async function createUserNotification(
   input: CreateUserNotificationInput,
 ): Promise<NotificationItem | null> {

--- a/lib/notifications/schema.test.ts
+++ b/lib/notifications/schema.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { notificationPreferenceBatchUpdateSchema } from "./schema";
+
+describe("notificationPreferenceBatchUpdateSchema", () => {
+  it("여러 알림 설정 업데이트를 받는다", () => {
+    const result = notificationPreferenceBatchUpdateSchema.safeParse({
+      updates: [
+        {
+          type: "ledger_record_change_request",
+          inAppEnabled: true,
+          pushEnabled: true,
+        },
+        {
+          type: "stock_transaction_changed",
+          inAppEnabled: true,
+          pushEnabled: true,
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("같은 알림 종류가 중복되면 거부한다", () => {
+    const result = notificationPreferenceBatchUpdateSchema.safeParse({
+      updates: [
+        {
+          type: "ledger_record_change_request",
+          inAppEnabled: true,
+          pushEnabled: true,
+        },
+        {
+          type: "ledger_record_change_request",
+          inAppEnabled: true,
+          pushEnabled: false,
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/lib/notifications/schema.ts
+++ b/lib/notifications/schema.ts
@@ -70,6 +70,34 @@ export type NotificationPreferenceUpdate = z.infer<
   typeof notificationPreferenceUpdateSchema
 >;
 
+export const notificationPreferenceBatchUpdateSchema = z
+  .object({
+    updates: z
+      .array(
+        notificationPreferenceUpdateSchema.extend({
+          type: notificationTypeSchema,
+        }),
+      )
+      .min(1, "변경할 알림 설정을 하나 이상 입력해주세요."),
+  })
+  .superRefine((value, context) => {
+    const seen = new Set<NotificationType>();
+    for (const [index, update] of value.updates.entries()) {
+      if (seen.has(update.type)) {
+        context.addIssue({
+          code: "custom",
+          message: "같은 알림 종류를 중복해서 설정할 수 없습니다.",
+          path: ["updates", index, "type"],
+        });
+      }
+      seen.add(update.type);
+    }
+  });
+
+export type NotificationPreferenceBatchUpdate = z.infer<
+  typeof notificationPreferenceBatchUpdateSchema
+>;
+
 export function normalizeNotificationLink(link?: NotificationLink | null): {
   linkKind: NotificationLinkKind | null;
   linkParams: Record<string, unknown>;

--- a/lib/queries/keys.ts
+++ b/lib/queries/keys.ts
@@ -9,6 +9,7 @@ export const queries = createQueryKeyStore({
   accounts: {
     all: null,
     list: null,
+    detail: (id: string) => ({ queryKey: [id] }),
   },
 
   home: {
@@ -24,6 +25,7 @@ export const queries = createQueryKeyStore({
   paymentMethods: {
     all: null,
     list: null,
+    detail: (id: string) => ({ queryKey: [id] }),
   },
 
   holdings: {

--- a/schemas/balance-adjustment.ts
+++ b/schemas/balance-adjustment.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+export const balanceAdjustmentTargetTypeSchema = z.enum([
+  "account",
+  "payment_method",
+]);
+
+export const createBalanceAdjustmentSchema = z.object({
+  targetType: balanceAdjustmentTargetTypeSchema,
+  accountId: z.uuid().optional(),
+  paymentMethodId: z.uuid().optional(),
+  actualBalance: z.number(),
+  adjustedAt: z.iso.datetime().optional(),
+  memo: z.string().max(500, "메모는 500자 이내여야 합니다.").optional(),
+});
+
+export type CreateBalanceAdjustmentInput = z.infer<
+  typeof createBalanceAdjustmentSchema
+>;

--- a/supabase/migrations/20260607000000_create_balance_adjustments.sql
+++ b/supabase/migrations/20260607000000_create_balance_adjustments.sql
@@ -1,0 +1,61 @@
+create type balance_adjustment_target_type as enum (
+  'account',
+  'payment_method'
+);
+
+create table public.balance_adjustments (
+  id uuid primary key default gen_random_uuid(),
+  household_id uuid not null references public.households(id) on delete cascade,
+  owner_id uuid not null references public.profiles(id) on delete cascade,
+  target_type balance_adjustment_target_type not null,
+  account_id uuid references public.accounts(id) on delete cascade,
+  payment_method_id uuid references public.payment_methods(id) on delete cascade,
+  previous_balance numeric(18, 2) not null,
+  actual_balance numeric(18, 2) not null,
+  delta numeric(18, 2) not null,
+  title text not null default '잔액 맞춤',
+  memo text,
+  adjusted_at timestamptz not null,
+  created_at timestamptz default now() not null,
+
+  constraint balance_adjustments_target_check check (
+    (
+      target_type = 'account'
+      and account_id is not null
+      and payment_method_id is null
+    )
+    or
+    (
+      target_type = 'payment_method'
+      and payment_method_id is not null
+      and account_id is null
+    )
+  )
+);
+
+create index balance_adjustments_household_adjusted_at_idx
+  on public.balance_adjustments(household_id, adjusted_at desc, id desc);
+
+create index balance_adjustments_account_adjusted_at_idx
+  on public.balance_adjustments(account_id, adjusted_at desc)
+  where account_id is not null;
+
+create index balance_adjustments_payment_method_adjusted_at_idx
+  on public.balance_adjustments(payment_method_id, adjusted_at desc)
+  where payment_method_id is not null;
+
+alter table public.balance_adjustments enable row level security;
+
+create policy "Household members can view balance adjustments"
+  on public.balance_adjustments for select
+  using (public.is_household_member(household_id));
+
+create policy "Users can create own balance adjustments"
+  on public.balance_adjustments for insert
+  with check (
+    public.is_household_member(household_id)
+    and owner_id = (select auth.uid())
+  );
+
+comment on table public.balance_adjustments is
+  'Correction events that set a managed account or auxiliary payment method balance to an actual balance.';

--- a/types/index.ts
+++ b/types/index.ts
@@ -25,6 +25,8 @@ export type HouseholdRole = Enums<"household_role">;
 export type UserRole = Enums<"user_role">;
 export type AllocationCategory = Enums<"allocation_category">;
 export type LedgerEntryType = Enums<"ledger_entry_type">;
+export type BalanceAdjustmentTargetType =
+  Enums<"balance_adjustment_target_type">;
 export type CategoryType = Enums<"category_type">;
 export type NotificationType = Enums<"notification_type">;
 export type NotificationLinkKind = Enums<"notification_link_kind">;
@@ -49,11 +51,13 @@ export type Notification = Tables<"notifications">;
 export type NotificationPreference = Tables<"notification_preferences">;
 export type PushSubscription = Tables<"push_subscriptions">;
 export type RecordChangeRequest = Tables<"record_change_requests">;
+export type BalanceAdjustment = Tables<"balance_adjustments">;
 
 // 가계부 테이블 타입
 export type LedgerEntry = Tables<"ledger_entries">;
 export type LedgerEntryInsert = TablesInsert<"ledger_entries">;
 export type LedgerEntryUpdate = TablesUpdate<"ledger_entries">;
+export type BalanceAdjustmentInsert = TablesInsert<"balance_adjustments">;
 export type Category = Tables<"categories">;
 
 // View 타입

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -97,6 +97,83 @@ export type Database = {
           },
         ];
       };
+      balance_adjustments: {
+        Row: {
+          account_id: string | null;
+          actual_balance: number;
+          adjusted_at: string;
+          created_at: string;
+          delta: number;
+          household_id: string;
+          id: string;
+          memo: string | null;
+          owner_id: string;
+          payment_method_id: string | null;
+          previous_balance: number;
+          target_type: Database["public"]["Enums"]["balance_adjustment_target_type"];
+          title: string;
+        };
+        Insert: {
+          account_id?: string | null;
+          actual_balance: number;
+          adjusted_at: string;
+          created_at?: string;
+          delta: number;
+          household_id: string;
+          id?: string;
+          memo?: string | null;
+          owner_id: string;
+          payment_method_id?: string | null;
+          previous_balance: number;
+          target_type: Database["public"]["Enums"]["balance_adjustment_target_type"];
+          title?: string;
+        };
+        Update: {
+          account_id?: string | null;
+          actual_balance?: number;
+          adjusted_at?: string;
+          created_at?: string;
+          delta?: number;
+          household_id?: string;
+          id?: string;
+          memo?: string | null;
+          owner_id?: string;
+          payment_method_id?: string | null;
+          previous_balance?: number;
+          target_type?: Database["public"]["Enums"]["balance_adjustment_target_type"];
+          title?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "balance_adjustments_account_id_fkey";
+            columns: ["account_id"];
+            isOneToOne: false;
+            referencedRelation: "accounts";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "balance_adjustments_household_id_fkey";
+            columns: ["household_id"];
+            isOneToOne: false;
+            referencedRelation: "households";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "balance_adjustments_owner_id_fkey";
+            columns: ["owner_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "balance_adjustments_payment_method_id_fkey";
+            columns: ["payment_method_id"];
+            isOneToOne: false;
+            referencedRelation: "payment_methods";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
       categories: {
         Row: {
           created_at: string;
@@ -1253,6 +1330,7 @@ export type Database = {
         | "commodity"
         | "crypto"
         | "alternative";
+      balance_adjustment_target_type: "account" | "payment_method";
       category_type: "expense" | "income";
       currency_type: "KRW" | "USD";
       exchange_type: "KOSPI" | "KOSDAQ" | "NYSE" | "NASDAQ" | "AMEX";
@@ -1462,6 +1540,7 @@ export const Constants = {
         "crypto",
         "alternative",
       ],
+      balance_adjustment_target_type: ["account", "payment_method"],
       category_type: ["expense", "income"],
       currency_type: ["KRW", "USD"],
       exchange_type: ["KOSPI", "KOSDAQ", "NYSE", "NASDAQ", "AMEX"],


### PR DESCRIPTION
## Summary

Implements #367.

- Add a general-purpose notification preference batch endpoint and wire the bulk Push action to it.
- Add account and payment-method balance detail screens with transaction timelines.
- Add balance adjustment support for account cash balances and auxiliary payment methods, including Supabase migration and API route.
- Show account/payment-method balances from list rows and link into the new detail screens.
- Make ledger and stock change-request dialogs fullscreen on mobile and prevent delete textareas from auto-focusing.

## Notes

- Balance adjustments use the new balance_adjustments table and balance_adjustment_target_type enum.
- Investment account balance detail treats the account balance as cash / 예수금 and shows estimated stock value separately.

## Validation

- pnpm test lib/notifications/schema.test.ts lib/api/balance-adjustment.test.ts constants/service-routes.test.ts components/accounts/AccountList.test.tsx components/accounts/PaymentMethodList.test.tsx
- pnpm biome check .
- pnpm type-check
- pnpm build
