### PR TITLE
fix(ui): 폼 내역 삭제 배지 및 결제수단 정보 표시 개선 (#377)

### DIFF
--- a/components/accounts/BalanceDetailClient.tsx
+++ b/components/accounts/BalanceDetailClient.tsx
@@ -145,7 +145,10 @@ function PaymentMethodBalanceDetailView({ id }: { id: string }) {
       subtitle={[
         data.paymentMethod.ownerName,
         PAYMENT_METHOD_TYPE_LABELS[data.paymentMethod.type],
-        data.paymentMethod.issuer,
+        data.paymentMethod.type === "credit_card" ||
+        data.paymentMethod.type === "debit_card"
+          ? data.paymentMethod.issuer
+          : null,
       ]
         .filter(Boolean)
         .join(" · ")}
@@ -226,12 +229,14 @@ function BalanceDetailLayout({
           </div>
         </div>
 
-        <div className="mt-6">
-          <p className="text-gray-500 text-sm">{balanceLabel}</p>
-          <p className="mt-1 font-bold text-3xl text-gray-900">
-            {balance === null ? "-" : formatCurrency(balance)}
-          </p>
-        </div>
+        {balance !== null && (
+          <div className="mt-6">
+            <p className="text-gray-500 text-sm">{balanceLabel}</p>
+            <p className="mt-1 font-bold text-3xl text-gray-900">
+              {formatCurrency(balance)}
+            </p>
+          </div>
+        )}
 
         {totalLabel && (
           <div className="mt-4 grid grid-cols-2 gap-3">

--- a/components/ledger/entry-composer/ComposerListStep.tsx
+++ b/components/ledger/entry-composer/ComposerListStep.tsx
@@ -248,7 +248,7 @@ export function ComposerListStep({
               <div
                 key={field.id}
                 className={cn(
-                  "flex items-center gap-2 rounded-2xl border p-4 shadow-sm transition-colors",
+                  "relative mt-2 flex items-center gap-2 rounded-2xl border p-4 shadow-sm transition-colors",
                   hasError
                     ? "border-red-200 bg-red-50/10 hover:border-red-300"
                     : "border-gray-100 bg-white hover:border-gray-200",
@@ -289,24 +289,20 @@ export function ComposerListStep({
                         ? `${Number(item.amount).toLocaleString()}원`
                         : "0원"}
                     </span>
-                    <ChevronRightIcon className="size-4 text-gray-400" />
                   </div>
                 </div>
 
-                {fields.length > 1 && (
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      remove(index);
-                    }}
-                    className="size-8 text-gray-400 hover:text-red-500 shrink-0"
-                  >
-                    <Trash2Icon className="size-4" />
-                  </Button>
-                )}
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    remove(index);
+                  }}
+                  className="absolute -top-2.5 -right-2.5 flex h-6 w-6 items-center justify-center rounded-full bg-gray-400 text-white shadow-md hover:bg-red-500 transition-colors z-10"
+                >
+                  <X className="h-3 w-3" strokeWidth={3} />
+                </button>
               </div>
             );
           })}

--- a/components/transactions/StockComposerListStep.tsx
+++ b/components/transactions/StockComposerListStep.tsx
@@ -147,7 +147,7 @@ export function StockComposerListStep({
                 <div
                   key={field.id}
                   className={cn(
-                    "flex items-center gap-2 rounded-2xl border p-4 shadow-sm transition-colors",
+                    "relative mt-2 flex items-center gap-2 rounded-2xl border p-4 shadow-sm transition-colors",
                     hasError
                       ? "border-red-200 bg-red-50/10 hover:border-red-300"
                       : "border-gray-100 bg-white hover:border-gray-200",
@@ -184,22 +184,20 @@ export function StockComposerListStep({
                           ? formatCurrency(subtotal, currency)
                           : "0원"}
                       </span>
-                      <ChevronRightIcon className="h-4 w-4 text-gray-400" />
                     </div>
                   </div>
 
-                  <Button
+                  <button
                     type="button"
-                    variant="ghost"
-                    size="icon"
                     onClick={(e) => {
+                      e.preventDefault();
                       e.stopPropagation();
                       remove(index);
                     }}
-                    className="h-8 w-8 text-gray-400 hover:text-red-500 shrink-0"
+                    className="absolute -top-2.5 -right-2.5 flex h-6 w-6 items-center justify-center rounded-full bg-gray-400 text-white shadow-md hover:bg-red-500 transition-colors z-10"
                   >
-                    <Trash2Icon className="h-4 w-4" />
-                  </Button>
+                    <X className="h-3 w-3" strokeWidth={3} />
+                  </button>
                 </div>
               );
             })}


### PR DESCRIPTION
해결 이슈: #377

- 가계부 폼 및 주식 폼의 내역 삭제 아이콘을 모서리에 걸치는 네이티브 배지 스타일(X 아이콘)로 변경 및 통일
- 결제수단 상세 조회 시 신용/체크카드의 경우 불필요한 자체 잔액 없음 및 '-' 표시 렌더링 제거
- 발급사가 불필요한 결제수단(선불페이, 현금 등)의 경우 subtitle에서 발급사 항목 제외