### PR TITLE
[codex] Add non-expense withdrawal ledger flow

### DIFF
--- a/app/(main)/ledger/page.tsx
+++ b/app/(main)/ledger/page.tsx
@@ -37,7 +37,7 @@ export default async function LedgerPage() {
             <div>
               <p className="font-semibold text-gray-900">기록 추가</p>
               <p className="text-xs text-gray-500 mt-0.5">
-                수입, 지출, 이체 내역 등록
+                수입, 지출, 내부이체, 비지출 출금 내역 등록
               </p>
             </div>
           </div>

--- a/components/ledger/LedgerEntryChangeRequestDialog.tsx
+++ b/components/ledger/LedgerEntryChangeRequestDialog.tsx
@@ -47,11 +47,13 @@ interface LedgerEntryChangeRequestDialogProps {
 function getInitialMoneySourceId(entry: LedgerEntryWithDetails) {
   const value = getLedgerMoneySourceValue({
     paymentMethodId:
-      entry.type === "expense"
+      entry.type === "expense" || entry.type === "non_expense_withdrawal"
         ? entry.fromPaymentMethodId
         : entry.toPaymentMethodId,
     accountId:
-      entry.type === "expense" ? entry.fromAccountId : entry.toAccountId,
+      entry.type === "expense" || entry.type === "non_expense_withdrawal"
+        ? entry.fromAccountId
+        : entry.toAccountId,
   });
 
   return value || "none";
@@ -81,7 +83,11 @@ export function LedgerEntryChangeRequestDialog({
     useState<LedgerRecordUpdateRequestFormValues | null>(null);
   const [message, setMessage] = useState("");
 
-  const categoryType = entry?.type === "transfer" ? undefined : entry?.type;
+  const categoryType =
+    entry?.type === "transfer" || entry?.type === "non_expense_withdrawal"
+      ? undefined
+      : entry?.type;
+
   const { data: categories = [] } = useCategories(categoryType as CategoryType);
   const { data: paymentMethods = [] } = usePaymentMethods();
   const { data: accounts = [] } = useAccounts();
@@ -219,32 +225,44 @@ export function LedgerEntryChangeRequestDialog({
               />
             </div>
 
-            <div className="grid grid-cols-2 gap-3">
-              <div className="space-y-2">
-                <Label>카테고리</Label>
-                <Select
-                  value={values.categoryId ?? "none"}
-                  onValueChange={(value) =>
-                    updateValue("categoryId", value === "none" ? null : value)
-                  }
-                >
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">선택 안함</SelectItem>
-                    {categories.map((category) => (
-                      <SelectItem key={category.id} value={category.id}>
-                        {category.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
+            <div
+              className={
+                entry.type === "non_expense_withdrawal"
+                  ? "grid grid-cols-1"
+                  : "grid grid-cols-2 gap-3"
+              }
+            >
+              {entry.type !== "non_expense_withdrawal" && (
+                <div className="space-y-2">
+                  <Label>카테고리</Label>
+                  <Select
+                    value={values.categoryId ?? "none"}
+                    onValueChange={(value) =>
+                      updateValue("categoryId", value === "none" ? null : value)
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="none">선택 안함</SelectItem>
+                      {categories.map((category) => (
+                        <SelectItem key={category.id} value={category.id}>
+                          {category.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
 
               <div className="space-y-2">
                 <Label>
-                  {entry.type === "expense" ? "결제 방법" : "입금 계좌"}
+                  {entry.type === "expense"
+                    ? "결제 방법"
+                    : entry.type === "non_expense_withdrawal"
+                      ? "출금처"
+                      : "입금 계좌"}
                 </Label>
                 <Select
                   value={values.moneySourceId}

--- a/components/ledger/LedgerEntryDeleteDialog.test.tsx
+++ b/components/ledger/LedgerEntryDeleteDialog.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { LedgerEntryWithDetails } from "@/lib/api/ledger";
+import { LedgerEntryDeleteDialog } from "./LedgerEntryDeleteDialog";
+
+vi.mock("@/hooks/use-ledger-entries", () => ({
+  useDeleteLedgerEntry: vi.fn(() => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  })),
+}));
+
+const nonExpenseWithdrawalEntry: LedgerEntryWithDetails = {
+  id: "entry-2",
+  householdId: "household-1",
+  ownerId: "owner-1",
+  ownerName: "소유자",
+  type: "non_expense_withdrawal",
+  amount: 50000,
+  title: "카드대금",
+  categoryId: null,
+  categoryName: null,
+  categoryIcon: null,
+  fromAccountId: "account-1",
+  fromAccountName: "토스뱅크",
+  fromPaymentMethodId: null,
+  fromPaymentMethodName: null,
+  toAccountId: null,
+  toAccountName: null,
+  toPaymentMethodId: null,
+  toPaymentMethodName: null,
+  isShared: true,
+  memo: "카드대금 정산",
+  transactedAt: "2026-06-02T00:00:00.000Z",
+  createdAt: "2026-06-02T00:00:00.000Z",
+  updatedAt: "2026-06-02T00:00:00.000Z",
+};
+
+describe("LedgerEntryDeleteDialog", () => {
+  it("비지출 출금 기록 삭제 시 비지출 출금 및 출금처 라벨을 정상적으로 표시한다", () => {
+    render(
+      <LedgerEntryDeleteDialog
+        entry={nonExpenseWithdrawalEntry}
+        open={true}
+        onOpenChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("비지출 출금")).toBeInTheDocument();
+    expect(screen.getByText("출금처")).toBeInTheDocument();
+    expect(screen.getByText("토스뱅크")).toBeInTheDocument();
+  });
+});

--- a/components/ledger/LedgerEntryDeleteDialog.tsx
+++ b/components/ledger/LedgerEntryDeleteDialog.tsx
@@ -50,8 +50,49 @@ export function LedgerEntryDeleteDialog({
 
   if (!entry) return null;
 
-  const typeLabel = entry.type === "expense" ? "지출" : "수입";
-  const typeVariant = entry.type === "expense" ? "default" : "secondary";
+  const typeLabel =
+    entry.type === "expense"
+      ? "지출"
+      : entry.type === "income"
+        ? "수입"
+        : entry.type === "non_expense_withdrawal"
+          ? "비지출 출금"
+          : "내부이체";
+
+  const typeVariant =
+    entry.type === "expense" || entry.type === "non_expense_withdrawal"
+      ? "default"
+      : "secondary";
+
+  const moneyLocationLabel =
+    entry.type === "expense"
+      ? "결제 방법"
+      : entry.type === "non_expense_withdrawal"
+        ? "출금처"
+        : entry.type === "transfer"
+          ? "돈 이동"
+          : "입금 계좌";
+
+  const moneyLocationValue = (() => {
+    if (entry.type === "transfer") {
+      const from =
+        entry.fromAccountName ?? entry.fromPaymentMethodName ?? "출발지";
+      const to = entry.toAccountName ?? entry.toPaymentMethodName ?? "도착지";
+      return `${from} → ${to}`;
+    }
+    if (entry.type === "income") {
+      return (
+        entry.toAccountName ?? entry.toPaymentMethodName ?? "입금 위치 없음"
+      );
+    }
+    return (
+      entry.fromPaymentMethodName ??
+      entry.fromAccountName ??
+      (entry.type === "non_expense_withdrawal"
+        ? "출금 위치 없음"
+        : "결제 위치 없음")
+    );
+  })();
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -87,20 +128,13 @@ export function LedgerEntryDeleteDialog({
                 <span>{entry.categoryName}</span>
               </div>
             )}
-            {(entry.fromPaymentMethodName ||
-              entry.fromAccountName ||
-              entry.toAccountName) && (
+            {moneyLocationValue && (
               <div className="flex justify-between">
-                <span>
-                  {entry.type === "expense" ? "결제 방법" : "입금 계좌"}
-                </span>
-                <span>
-                  {entry.fromPaymentMethodName ||
-                    entry.fromAccountName ||
-                    entry.toAccountName}
-                </span>
+                <span>{moneyLocationLabel}</span>
+                <span>{moneyLocationValue}</span>
               </div>
             )}
+
             <div className="flex justify-between">
               <span>날짜</span>
               <span>

--- a/components/ledger/LedgerEntryEditDialog.tsx
+++ b/components/ledger/LedgerEntryEditDialog.tsx
@@ -59,7 +59,7 @@ const editFormSchema = z.object({
     .string()
     .min(1, "내용을 입력해주세요.")
     .max(100, "내용은 100자 이내여야 합니다."),
-  categoryId: z.string().min(1, "카테고리를 선택해주세요."),
+  categoryId: z.string().optional(),
   paymentMethodId: z.string().optional(),
   accountId: z.string().optional(),
   transactedAt: z.string().min(1, "날짜를 선택해주세요."),
@@ -86,6 +86,26 @@ export function LedgerEntryEditDialog({
   const { data: paymentMethods = [] } = usePaymentMethods();
   const { data: accounts = [] } = useAccounts();
 
+  const dynamicSchema = editFormSchema.superRefine((data, ctx) => {
+    if (entry?.type === "non_expense_withdrawal") {
+      if (!data.accountId && !data.paymentMethodId) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["accountId"],
+          message: "출금처를 선택해주세요.",
+        });
+      }
+    } else if (entry?.type !== "transfer") {
+      if (!data.categoryId) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["categoryId"],
+          message: "카테고리를 선택해주세요.",
+        });
+      }
+    }
+  });
+
   const {
     register,
     handleSubmit,
@@ -94,7 +114,7 @@ export function LedgerEntryEditDialog({
     setValue,
     formState: { errors, isSubmitting },
   } = useForm<EditFormValues>({
-    resolver: zodResolver(editFormSchema),
+    resolver: zodResolver(dynamicSchema),
   });
 
   const watchCategoryId = watch("categoryId");
@@ -103,7 +123,6 @@ export function LedgerEntryEditDialog({
   const watchAccountId = watch("accountId");
   const watchTitle = watch("title");
 
-  // entry 변경 시 폼 초기화
   useEffect(() => {
     if (entry) {
       const date = new Date(entry.transactedAt);
@@ -115,7 +134,7 @@ export function LedgerEntryEditDialog({
         categoryId: entry.categoryId ?? "",
         paymentMethodId: entry.fromPaymentMethodId ?? undefined,
         accountId:
-          entry.type === "expense"
+          entry.type === "expense" || entry.type === "non_expense_withdrawal"
             ? (entry.fromAccountId ?? undefined)
             : (entry.toAccountId ?? undefined),
         transactedAt: formattedDate,
@@ -141,7 +160,7 @@ export function LedgerEntryEditDialog({
       };
 
       // 유형에 따라 결제수단/계좌 필드 설정
-      if (entry.type === "expense") {
+      if (entry.type === "expense" || entry.type === "non_expense_withdrawal") {
         updateData.fromPaymentMethodId = data.paymentMethodId || null;
         updateData.fromAccountId = data.accountId || null;
       } else if (entry.type === "income") {
@@ -171,8 +190,14 @@ export function LedgerEntryEditDialog({
       ? "지출"
       : entry.type === "income"
         ? "수입"
-        : "이체";
-  const typeVariant = entry.type === "expense" ? "default" : "secondary";
+        : entry.type === "non_expense_withdrawal"
+          ? "비지출 출금"
+          : "내부이체";
+  const typeVariant =
+    entry.type === "expense" || entry.type === "non_expense_withdrawal"
+      ? "default"
+      : "secondary";
+
   const privacyLabel = entry.isShared ? "공용" : "개인";
 
   // 결제수단/계좌 통합 value
@@ -199,8 +224,12 @@ export function LedgerEntryEditDialog({
     setMobileView("form");
   };
 
-  const moneySourceMode = entry.type === "expense" ? "expense" : "income";
-  const moneySourcePlaceholder = "선택 안함";
+  const moneySourceMode =
+    entry.type === "expense" || entry.type === "non_expense_withdrawal"
+      ? "expense"
+      : "income";
+  const moneySourcePlaceholder =
+    entry.type === "non_expense_withdrawal" ? "선택" : "선택 안함";
   const moneySourceLabel = getLedgerMoneySourceLabel({
     mode: moneySourceMode,
     value: paymentValue,
@@ -226,7 +255,7 @@ export function LedgerEntryEditDialog({
   const transferEditNotice = (
     <div className="flex items-start gap-2 rounded-md bg-muted/50 p-3 text-sm text-muted-foreground">
       <InfoIcon className="mt-0.5 h-4 w-4 shrink-0" />
-      <p>이체 기록은 삭제 후 다시 등록해주세요.</p>
+      <p>내부이체 기록은 삭제 후 다시 등록해주세요.</p>
     </div>
   );
 
@@ -236,7 +265,8 @@ export function LedgerEntryEditDialog({
         <Dialog open={open} onOpenChange={onOpenChange}>
           <DialogContent className="sm:max-w-md">
             <DialogHeader>
-              <DialogTitle>이체 기록</DialogTitle>
+              <DialogTitle>내부이체 기록</DialogTitle>
+
               <DialogDescription asChild>
                 {descriptionContent}
               </DialogDescription>
@@ -272,7 +302,8 @@ export function LedgerEntryEditDialog({
 
           <div className="flex-1 overflow-y-auto px-4 pt-16 space-y-4">
             <div className="space-y-1">
-              <h3 className="text-lg font-bold text-gray-900">이체 기록</h3>
+              <h3 className="text-lg font-bold text-gray-900">내부이체 기록</h3>
+
               <div className="text-sm text-gray-500">{descriptionContent}</div>
             </div>
 
@@ -334,37 +365,51 @@ export function LedgerEntryEditDialog({
       </div>
 
       {/* 카테고리 + 결제수단/계좌 — 2컬럼 그리드 */}
-      <div className="grid grid-cols-2 gap-3">
-        <div className="space-y-2">
-          <Label>카테고리 *</Label>
-          {isDesktop ? (
-            <LedgerCategoryCombobox
-              value={watchCategoryId ?? ""}
-              categories={categories}
-              placeholder="선택"
-              onValueChange={(v) =>
-                setValue("categoryId", v, { shouldValidate: true })
-              }
-            />
-          ) : (
-            <LedgerCategoryTrigger
-              label={
-                categories.find((cat) => cat.id === watchCategoryId)?.name ??
-                "선택"
-              }
-              placeholder="선택"
-              onClick={() => setMobileView("categoryPicker")}
-            />
-          )}
-          {errors.categoryId && (
-            <p className="text-sm text-destructive">
-              {errors.categoryId.message}
-            </p>
-          )}
-        </div>
+      <div
+        className={
+          entry.type === "non_expense_withdrawal"
+            ? "grid grid-cols-1"
+            : "grid grid-cols-2 gap-3"
+        }
+      >
+        {entry.type !== "non_expense_withdrawal" && (
+          <div className="space-y-2">
+            <Label>카테고리 *</Label>
+            {isDesktop ? (
+              <LedgerCategoryCombobox
+                value={watchCategoryId ?? ""}
+                categories={categories}
+                placeholder="선택"
+                onValueChange={(v) =>
+                  setValue("categoryId", v, { shouldValidate: true })
+                }
+              />
+            ) : (
+              <LedgerCategoryTrigger
+                label={
+                  categories.find((cat) => cat.id === watchCategoryId)?.name ??
+                  "선택"
+                }
+                placeholder="선택"
+                onClick={() => setMobileView("categoryPicker")}
+              />
+            )}
+            {errors.categoryId && (
+              <p className="text-sm text-destructive">
+                {errors.categoryId.message}
+              </p>
+            )}
+          </div>
+        )}
 
         <div className="space-y-2">
-          <Label>{entry.type === "expense" ? "결제 방법" : "입금 계좌"}</Label>
+          <Label>
+            {entry.type === "expense"
+              ? "결제 방법"
+              : entry.type === "non_expense_withdrawal"
+                ? "출금처 *"
+                : "입금 계좌"}
+          </Label>
           {isDesktop ? (
             <LedgerMoneySourceCombobox
               mode={moneySourceMode}
@@ -381,6 +426,11 @@ export function LedgerEntryEditDialog({
               placeholder={moneySourcePlaceholder}
               onClick={() => setMobileView("moneySourcePicker")}
             />
+          )}
+          {(errors.accountId || errors.paymentMethodId) && (
+            <p className="text-sm text-destructive">
+              {errors.accountId?.message || errors.paymentMethodId?.message}
+            </p>
           )}
         </div>
       </div>
@@ -557,7 +607,11 @@ export function LedgerEntryEditDialog({
               accounts={accounts}
               ownerId={entry.ownerId}
               title={
-                entry.type === "expense" ? "결제 방법 선택" : "입금 계좌 선택"
+                entry.type === "expense"
+                  ? "결제 방법 선택"
+                  : entry.type === "non_expense_withdrawal"
+                    ? "출금처 선택"
+                    : "입금 계좌 선택"
               }
               searchPlaceholder="이름, 기관, 소유자 검색"
               onBack={() => setMobileView("form")}

--- a/components/ledger/entry-composer/ComposerFormStep.tsx
+++ b/components/ledger/entry-composer/ComposerFormStep.tsx
@@ -100,7 +100,9 @@ export function ComposerFormStep({
     form.setValue(`items.${index}.accountId`, undefined);
   };
 
-  const handleTypeChange = (value: "expense" | "income" | "transfer") => {
+  const handleTypeChange = (
+    value: "expense" | "income" | "transfer" | "non_expense_withdrawal",
+  ) => {
     form.setValue(`items.${index}.type`, value);
     form.setValue(`items.${index}.categoryId`, "");
     form.setValue(`items.${index}.paymentMethodId`, undefined);
@@ -138,7 +140,13 @@ export function ComposerFormStep({
             <Select
               value={itemType}
               onValueChange={(value) =>
-                handleTypeChange(value as "expense" | "income" | "transfer")
+                handleTypeChange(
+                  value as
+                    | "expense"
+                    | "income"
+                    | "transfer"
+                    | "non_expense_withdrawal",
+                )
               }
             >
               <SelectTrigger className="h-10 w-full">
@@ -147,7 +155,10 @@ export function ComposerFormStep({
               <SelectContent>
                 <SelectItem value="expense">지출</SelectItem>
                 <SelectItem value="income">수입</SelectItem>
-                <SelectItem value="transfer">이체</SelectItem>
+                <SelectItem value="transfer">내부이체</SelectItem>
+                <SelectItem value="non_expense_withdrawal">
+                  비지출 출금
+                </SelectItem>
               </SelectContent>
             </Select>
           </div>
@@ -171,6 +182,12 @@ export function ComposerFormStep({
           </div>
         </div>
 
+        {itemType === "non_expense_withdrawal" && (
+          <div className="rounded-lg bg-gray-50 p-3 text-xs text-gray-500">
+            카드대금, 대출상환 등 이미 기록된 지출의 정산
+          </div>
+        )}
+
         {mode === "full" && (
           <div className="space-y-1">
             <Label className="text-sm text-gray-700">날짜</Label>
@@ -185,7 +202,7 @@ export function ComposerFormStep({
           </div>
         )}
 
-        {itemType !== "transfer" && (
+        {itemType !== "transfer" && itemType !== "non_expense_withdrawal" && (
           <div className="space-y-1">
             <Label className="text-sm text-gray-700">카테고리 *</Label>
             {isDesktop ? (
@@ -231,7 +248,9 @@ export function ComposerFormStep({
             placeholder={
               itemType === "transfer"
                 ? "예: 카카오페이 충전, 증권 계좌 입금"
-                : "예: 점심, 커피"
+                : itemType === "non_expense_withdrawal"
+                  ? "예: 신한카드 6월 대금, 신용대출 상환"
+                  : "예: 점심, 커피"
             }
           />
           {errors?.title && (
@@ -256,30 +275,51 @@ export function ComposerFormStep({
           {itemType !== "transfer" && (
             <div className="space-y-1">
               <Label className="text-sm text-gray-700">
-                {itemType === "expense" ? "결제 방법" : "입금 계좌"}
+                {itemType === "expense"
+                  ? "결제 방법"
+                  : itemType === "non_expense_withdrawal"
+                    ? "출금처 *"
+                    : "입금 계좌"}
               </Label>
               {isDesktop ? (
                 <LedgerMoneySourceCombobox
-                  mode={itemType}
+                  mode={
+                    itemType === "non_expense_withdrawal" ? "expense" : itemType
+                  }
                   value={moneySourceValue}
                   paymentMethods={paymentMethods}
                   accounts={accounts}
                   ownerId={userId}
-                  placeholder="선택 안함"
+                  placeholder={
+                    itemType === "non_expense_withdrawal" ? "선택" : "선택 안함"
+                  }
                   onValueChange={handleMoneySourceChange}
                 />
               ) : (
                 <LedgerMoneySourceTrigger
                   label={getLedgerMoneySourceLabel({
-                    mode: itemType,
+                    mode:
+                      itemType === "non_expense_withdrawal"
+                        ? "expense"
+                        : itemType,
                     value: moneySourceValue,
                     paymentMethods,
                     accounts,
-                    placeholder: "선택 안함",
+                    placeholder:
+                      itemType === "non_expense_withdrawal"
+                        ? "선택"
+                        : "선택 안함",
                   })}
-                  placeholder="선택 안함"
+                  placeholder={
+                    itemType === "non_expense_withdrawal" ? "선택" : "선택 안함"
+                  }
                   onClick={() => setMobileView("moneySourcePicker")}
                 />
+              )}
+              {(errors?.accountId || errors?.paymentMethodId) && (
+                <p className="text-xs text-red-500">
+                  {errors.accountId?.message || errors.paymentMethodId?.message}
+                </p>
               )}
             </div>
           )}
@@ -375,7 +415,7 @@ export function ComposerFormStep({
 
       {!isDesktop && (
         <>
-          {itemType !== "transfer" && (
+          {itemType !== "transfer" && itemType !== "non_expense_withdrawal" && (
             <Drawer
               open={mobileView === "categoryPicker"}
               onOpenChange={(open) => {
@@ -415,13 +455,19 @@ export function ComposerFormStep({
               onOpenAutoFocus={(event) => event.preventDefault()}
             >
               <LedgerMoneySourcePickerPanel
-                mode={itemType}
+                mode={
+                  itemType === "non_expense_withdrawal" ? "expense" : itemType
+                }
                 value={moneySourceValue}
                 paymentMethods={paymentMethods}
                 accounts={accounts}
                 ownerId={userId}
                 title={
-                  itemType === "expense" ? "결제 방법 선택" : "입금 계좌 선택"
+                  itemType === "expense"
+                    ? "결제 방법 선택"
+                    : itemType === "non_expense_withdrawal"
+                      ? "출금처 선택"
+                      : "입금 계좌 선택"
                 }
                 searchPlaceholder="이름, 기관, 소유자 검색"
                 onBack={() => setMobileView("form")}

--- a/components/ledger/entry-composer/ComposerListStep.tsx
+++ b/components/ledger/entry-composer/ComposerListStep.tsx
@@ -92,10 +92,11 @@ export function ComposerListStep({
   };
 
   const getCategoryName = (
-    type: "expense" | "income" | "transfer",
+    type: "expense" | "income" | "transfer" | "non_expense_withdrawal",
     categoryId?: string,
   ) => {
-    if (type === "transfer") return "이체";
+    if (type === "transfer") return "내부이체";
+    if (type === "non_expense_withdrawal") return "비지출 출금";
     const cats = type === "expense" ? expenseCategories : incomeCategories;
     return cats.find((c) => c.id === categoryId)?.name || "카테고리 없음";
   };
@@ -167,7 +168,11 @@ export function ComposerListStep({
                 onValueChange={(value) => {
                   form.setValue(
                     "defaultType",
-                    value as "expense" | "income" | "transfer",
+                    value as
+                      | "expense"
+                      | "income"
+                      | "transfer"
+                      | "non_expense_withdrawal",
                   );
                 }}
               >
@@ -177,7 +182,10 @@ export function ComposerListStep({
                 <SelectContent>
                   <SelectItem value="expense">지출</SelectItem>
                   <SelectItem value="income">수입</SelectItem>
-                  <SelectItem value="transfer">이체</SelectItem>
+                  <SelectItem value="transfer">내부이체</SelectItem>
+                  <SelectItem value="non_expense_withdrawal">
+                    비지출 출금
+                  </SelectItem>
                 </SelectContent>
               </Select>
             </div>
@@ -234,14 +242,18 @@ export function ComposerListStep({
               item.type === "income"
                 ? "수입"
                 : item.type === "transfer"
-                  ? "이체"
-                  : "지출";
+                  ? "내부이체"
+                  : item.type === "non_expense_withdrawal"
+                    ? "비지출 출금"
+                    : "지출";
             const typeColor =
               item.type === "income"
                 ? "text-blue-600"
                 : item.type === "transfer"
                   ? "text-gray-600"
-                  : "text-red-600";
+                  : item.type === "non_expense_withdrawal"
+                    ? "text-purple-600"
+                    : "text-red-600";
             const hasError = !!form.formState.errors.items?.[index];
 
             return (

--- a/components/ledger/entry-composer/LedgerEntryComposer.tsx
+++ b/components/ledger/entry-composer/LedgerEntryComposer.tsx
@@ -19,11 +19,15 @@ import {
 import { ComposerFormStep } from "./ComposerFormStep";
 import { ComposerListStep } from "./ComposerListStep";
 
-export type ComposerType = "expense" | "income" | "transfer";
+export type ComposerType =
+  | "expense"
+  | "income"
+  | "transfer"
+  | "non_expense_withdrawal";
 
 export const ledgerComposerItemSchema = z
   .object({
-    type: z.enum(["expense", "income", "transfer"]),
+    type: z.enum(["expense", "income", "transfer", "non_expense_withdrawal"]),
     isShared: z.boolean(),
     amount: z.string().min(1, "금액을 입력해주세요."),
     title: z.string().min(1, "내용을 입력해주세요."),
@@ -65,6 +69,17 @@ export const ledgerComposerItemSchema = z
       return;
     }
 
+    if (value.type === "non_expense_withdrawal") {
+      if (!value.accountId && !value.paymentMethodId) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["accountId"],
+          message: "출금처를 선택해주세요.",
+        });
+      }
+      return;
+    }
+
     if (!value.categoryId) {
       ctx.addIssue({
         code: "custom",
@@ -75,7 +90,12 @@ export const ledgerComposerItemSchema = z
   });
 
 export const ledgerComposerSchema = z.object({
-  defaultType: z.enum(["expense", "income", "transfer"]),
+  defaultType: z.enum([
+    "expense",
+    "income",
+    "transfer",
+    "non_expense_withdrawal",
+  ]),
   defaultIsShared: z.boolean(),
   defaultDate: z.string().min(1),
   items: z.array(ledgerComposerItemSchema).min(1),

--- a/components/ledger/funnel/AddTransferStep.tsx
+++ b/components/ledger/funnel/AddTransferStep.tsx
@@ -264,7 +264,7 @@ export function AddTransferStep({
             않습니다.
           </p>
           <p className="text-xs text-gray-500">
-            타인에게 보낸 돈은 이체가 아니라 지출로 기록해주세요.
+            타인에게 보낸 돈은 내부이체가 아니라 지출로 기록해주세요.
           </p>
         </div>
 

--- a/components/ledger/funnel/ConfirmStep.tsx
+++ b/components/ledger/funnel/ConfirmStep.tsx
@@ -52,7 +52,8 @@ export function ConfirmStep({
       ? Number(transferItem.amount)
       : items.reduce((sum, item) => sum + Number(item.amount), 0);
   const typeLabel =
-    type === "expense" ? "지출" : type === "income" ? "수입" : "이체";
+    type === "expense" ? "지출" : type === "income" ? "수입" : "내부이체";
+
   const itemCount = type === "transfer" ? 1 : items.length;
 
   const getTransferLocationName = (

--- a/components/ledger/funnel/SelectTypeStep.tsx
+++ b/components/ledger/funnel/SelectTypeStep.tsx
@@ -53,7 +53,7 @@ export function SelectTypeStep({ onSelect }: SelectTypeStepProps) {
             <ArrowRightLeftIcon className="w-6 h-6 text-gray-600" />
           </div>
           <div>
-            <p className="text-lg font-semibold text-gray-900">이체</p>
+            <p className="text-lg font-semibold text-gray-900">내부이체</p>
             <p className="text-sm text-gray-500">
               계좌, 선불페이, 상품권 간 이동
             </p>

--- a/components/ledger/records/LedgerEntryDetailClient.tsx
+++ b/components/ledger/records/LedgerEntryDetailClient.tsx
@@ -35,7 +35,8 @@ type RequestMode = "update" | "delete";
 
 function getTypeLabel(type: LedgerEntryWithDetails["type"]) {
   if (type === "income") return "수입";
-  if (type === "transfer") return "이체";
+  if (type === "transfer") return "내부이체";
+  if (type === "non_expense_withdrawal") return "비지출 출금";
   return "지출";
 }
 
@@ -52,7 +53,11 @@ function getMoneyLocation(entry: LedgerEntryWithDetails) {
   }
 
   return (
-    entry.fromPaymentMethodName ?? entry.fromAccountName ?? "결제 위치 없음"
+    entry.fromPaymentMethodName ??
+    entry.fromAccountName ??
+    (entry.type === "non_expense_withdrawal"
+      ? "출금 위치 없음"
+      : "결제 위치 없음")
   );
 }
 
@@ -112,10 +117,21 @@ export function LedgerEntryDetailClient({
   const showUpdateAction = hasActions && canUpdate;
   const showDeleteAction = hasActions;
   const typeLabel = getTypeLabel(entry.type);
-  const typeVariant = entry.type === "expense" ? "default" : "secondary";
-  const title = entry.title ?? entry.categoryName ?? typeLabel;
+  const typeVariant =
+    entry.type === "expense" || entry.type === "non_expense_withdrawal"
+      ? "default"
+      : "secondary";
+  const title =
+    entry.title ??
+    (entry.type === "non_expense_withdrawal"
+      ? "비지출 출금"
+      : (entry.categoryName ?? typeLabel));
   const iconName =
-    entry.type === "transfer" ? "ArrowLeftRight" : entry.categoryIcon;
+    entry.type === "transfer"
+      ? "ArrowLeftRight"
+      : entry.type === "non_expense_withdrawal"
+        ? "ArrowUpRight"
+        : entry.categoryIcon;
 
   const handleRequest = (mode: RequestMode) => {
     setRequestMode(mode);
@@ -199,12 +215,20 @@ export function LedgerEntryDetailClient({
         </section>
 
         <section className="rounded-2xl bg-white px-5 py-2 shadow-sm ring-1 ring-gray-100">
+          {entry.type !== "non_expense_withdrawal" && (
+            <DetailInfoRow
+              label="카테고리"
+              value={entry.categoryName ?? "없음"}
+            />
+          )}
           <DetailInfoRow
-            label="카테고리"
-            value={entry.categoryName ?? "없음"}
-          />
-          <DetailInfoRow
-            label={entry.type === "transfer" ? "돈 이동" : "돈 위치"}
+            label={
+              entry.type === "transfer"
+                ? "돈 이동"
+                : entry.type === "non_expense_withdrawal"
+                  ? "출금처"
+                  : "돈 위치"
+            }
             value={getMoneyLocation(entry)}
           />
           <DetailInfoRow label="작성자" value={entry.ownerName} />

--- a/components/ledger/records/LedgerEntryRow.tsx
+++ b/components/ledger/records/LedgerEntryRow.tsx
@@ -14,6 +14,7 @@ interface LedgerEntryRowProps {
 export function LedgerEntryRow({ entry, href }: LedgerEntryRowProps) {
   const isIncome = entry.type === "income";
   const isTransfer = entry.type === "transfer";
+  const isNonExpenseWithdrawal = entry.type === "non_expense_withdrawal";
   const amountSign = isTransfer ? "" : isIncome ? "+" : "-";
   const amountColor = isTransfer
     ? "text-gray-900"
@@ -28,10 +29,14 @@ export function LedgerEntryRow({ entry, href }: LedgerEntryRowProps) {
         entry.toAccountName ?? entry.toPaymentMethodName ?? "도착지"
       }`
     : null;
-  const iconName = isTransfer ? "ArrowLeftRight" : entry.categoryIcon;
+  const iconName = isTransfer
+    ? "ArrowLeftRight"
+    : isNonExpenseWithdrawal
+      ? "ArrowUpRight"
+      : entry.categoryIcon;
 
   const metaParts = [
-    entry.categoryName,
+    isNonExpenseWithdrawal ? "비지출 출금" : entry.categoryName,
     transferLabel,
     entry.ownerName,
     paymentLabel,
@@ -52,9 +57,11 @@ export function LedgerEntryRow({ entry, href }: LedgerEntryRowProps) {
         <div className="flex min-w-0 items-center gap-1">
           <span className="line-clamp-2 min-w-0 font-semibold text-gray-900 text-sm leading-5 break-words">
             {entry.title ??
-              entry.categoryName ??
-              (isTransfer ? "이체" : "미분류")}
+              (isNonExpenseWithdrawal
+                ? "비지출 출금"
+                : (entry.categoryName ?? (isTransfer ? "내부이체" : "미분류")))}
           </span>
+
           {!entry.isShared && (
             <UserIcon className="w-3 h-3 text-gray-400 flex-shrink-0" />
           )}

--- a/lib/api/ledger.test.ts
+++ b/lib/api/ledger.test.ts
@@ -40,6 +40,16 @@ describe("calculateLedgerSummary", () => {
     expect(result.totalExpense).toBe(0);
   });
 
+  it("비지출 출금(non_expense_withdrawal)은 합산에서 제외한다", () => {
+    const entries = [
+      { type: "income" as const, amount: 1000000 },
+      { type: "non_expense_withdrawal" as const, amount: 500000 },
+    ];
+    const result = calculateLedgerSummary(entries);
+    expect(result.totalIncome).toBe(1000000);
+    expect(result.totalExpense).toBe(0);
+  });
+
   it("잔액 = 수입 - 지출", () => {
     const entries = [
       { type: "income" as const, amount: 5000000 },
@@ -342,6 +352,30 @@ describe("getLedgerBalanceEffects", () => {
 
     expect(effects).toEqual([
       { table: "payment_methods", id: "pm-1", delta: -12000 },
+    ]);
+  });
+
+  it("비지출 출금은 출금처 감소 효과를 만든다 (계좌)", () => {
+    const effects = getLedgerBalanceEffects({
+      type: "non_expense_withdrawal",
+      amount: 150000,
+      fromAccountId: "acc-1",
+    });
+
+    expect(effects).toEqual([
+      { table: "accounts", id: "acc-1", delta: -150000 },
+    ]);
+  });
+
+  it("비지출 출금은 출금처 감소 효과를 만든다 (결제수단)", () => {
+    const effects = getLedgerBalanceEffects({
+      type: "non_expense_withdrawal",
+      amount: 80000,
+      fromPaymentMethodId: "pm-1",
+    });
+
+    expect(effects).toEqual([
+      { table: "payment_methods", id: "pm-1", delta: -80000 },
     ]);
   });
 });

--- a/lib/api/ledger.ts
+++ b/lib/api/ledger.ts
@@ -44,7 +44,7 @@ export function isTransferCapablePaymentMethod(
 }
 
 export function buildLedgerEntryPayload(
-  type: "expense" | "income",
+  type: "expense" | "income" | "non_expense_withdrawal",
   isShared: boolean,
   item: LedgerItemFormData,
 ): CreateLedgerEntryInput {
@@ -55,12 +55,15 @@ export function buildLedgerEntryPayload(
       ? item.transactedAt
       : `${item.transactedAt}T00:00:00.000Z`,
     title: item.title,
-    categoryId: item.categoryId,
     isShared,
     memo: item.memo || undefined,
   };
 
-  if (type === "expense") {
+  if (item.categoryId && type !== "non_expense_withdrawal") {
+    base.categoryId = item.categoryId;
+  }
+
+  if (type === "expense" || type === "non_expense_withdrawal") {
     if (item.paymentMethodId) base.fromPaymentMethodId = item.paymentMethodId;
     if (item.accountId) base.fromAccountId = item.accountId;
   }
@@ -296,7 +299,7 @@ export function getLedgerBalanceEffects(
     ].filter(Boolean) as LedgerBalanceEffect[];
   }
 
-  if (input.type === "expense") {
+  if (input.type === "expense" || input.type === "non_expense_withdrawal") {
     return [
       input.fromAccountId && {
         table: "accounts" as const,

--- a/lib/ledger/record-change-request.test.ts
+++ b/lib/ledger/record-change-request.test.ts
@@ -61,3 +61,50 @@ describe("buildLedgerRecordUpdateProposedChanges", () => {
     });
   });
 });
+
+const nonExpenseWithdrawalEntry: LedgerEntryWithDetails = {
+  id: "entry-2",
+  householdId: "household-1",
+  ownerId: "owner-1",
+  ownerName: "소유자",
+  type: "non_expense_withdrawal",
+  amount: 50000,
+  title: "카드대금",
+  categoryId: null,
+  categoryName: null,
+  categoryIcon: null,
+  fromAccountId: "account-1",
+  fromAccountName: "토스뱅크",
+  fromPaymentMethodId: null,
+  fromPaymentMethodName: null,
+  toAccountId: null,
+  toAccountName: null,
+  toPaymentMethodId: null,
+  toPaymentMethodName: null,
+  isShared: true,
+  memo: "카드대금 정산",
+  transactedAt: "2026-06-02T00:00:00.000Z",
+  createdAt: "2026-06-02T00:00:00.000Z",
+  updatedAt: "2026-06-02T00:00:00.000Z",
+};
+
+describe("buildLedgerRecordUpdateProposedChanges with non_expense_withdrawal", () => {
+  it("비지출 출금 결제수단 변경을 fromPaymentMethodId 및 fromAccountId로 반환하고 categoryId를 제외한다", () => {
+    const result = buildLedgerRecordUpdateProposedChanges(
+      nonExpenseWithdrawalEntry,
+      {
+        amount: 50000,
+        title: "카드대금",
+        categoryId: "some-category-id", // 무시되어야 함
+        moneySourceId: "pm:payment-2",
+        transactedAt: "2026-06-02",
+        memo: "카드대금 정산",
+      },
+    );
+
+    expect(result).toEqual({
+      fromAccountId: null,
+      fromPaymentMethodId: "payment-2",
+    });
+  });
+});

--- a/lib/ledger/record-change-request.ts
+++ b/lib/ledger/record-change-request.ts
@@ -15,7 +15,7 @@ function toIsoDateStart(value: string) {
 }
 
 function getOriginalMoneySourceId(entry: LedgerEntryWithDetails) {
-  if (entry.type === "expense") {
+  if (entry.type === "expense" || entry.type === "non_expense_withdrawal") {
     if (entry.fromPaymentMethodId) return `pm:${entry.fromPaymentMethodId}`;
     if (entry.fromAccountId) return `acc:${entry.fromAccountId}`;
   }
@@ -41,7 +41,7 @@ function applyMoneySourceChange(
       ? value.slice(4)
       : null;
 
-  if (entry.type === "expense") {
+  if (entry.type === "expense" || entry.type === "non_expense_withdrawal") {
     changes.fromPaymentMethodId = isPaymentMethod ? id : null;
     changes.fromAccountId = isAccount ? id : null;
     return;
@@ -61,9 +61,13 @@ export function buildLedgerRecordUpdateProposedChanges(
 
   if (values.amount !== entry.amount) changes.amount = values.amount;
   if (values.title !== (entry.title ?? "")) changes.title = values.title;
-  if (values.categoryId !== entry.categoryId) {
+  if (
+    entry.type !== "non_expense_withdrawal" &&
+    values.categoryId !== entry.categoryId
+  ) {
     changes.categoryId = values.categoryId;
   }
+
   if (transactedAt !== entry.transactedAt) changes.transactedAt = transactedAt;
   if (memo !== entry.memo) changes.memo = memo;
 

--- a/schemas/ledger-entry.test.ts
+++ b/schemas/ledger-entry.test.ts
@@ -121,6 +121,58 @@ describe("createLedgerEntrySchema", () => {
       expect(result.success).toBe(false);
     });
   });
+
+  describe("non_expense_withdrawal validation", () => {
+    const base = {
+      type: "non_expense_withdrawal" as const,
+      amount: 50000,
+      transactedAt: "2026-06-12T00:00:00.000Z",
+      title: "카드대금 결제",
+      isShared: true,
+    };
+
+    it("비지출 출금은 출금처(계좌 또는 결제수단) 중 하나만 필요하다", () => {
+      const okAccount = createLedgerEntrySchema.safeParse({
+        ...base,
+        fromAccountId: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+      });
+      expect(okAccount.success).toBe(true);
+
+      const okPm = createLedgerEntrySchema.safeParse({
+        ...base,
+        fromPaymentMethodId: "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a22",
+      });
+      expect(okPm.success).toBe(true);
+
+      const missingSource = createLedgerEntrySchema.safeParse(base);
+      expect(missingSource.success).toBe(false);
+
+      const doubleSource = createLedgerEntrySchema.safeParse({
+        ...base,
+        fromAccountId: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+        fromPaymentMethodId: "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a22",
+      });
+      expect(doubleSource.success).toBe(false);
+    });
+
+    it("비지출 출금은 입금처(to_*)를 가질 수 없다", () => {
+      const result = createLedgerEntrySchema.safeParse({
+        ...base,
+        fromAccountId: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+        toAccountId: "c0eebc99-9c0b-4ef8-bb6d-6bb9bd380a33",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("비지출 출금은 카테고리(categoryId)를 가질 수 없다", () => {
+      const result = createLedgerEntrySchema.safeParse({
+        ...base,
+        fromAccountId: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+        categoryId: "d0eebc99-9c0b-4ef8-bb6d-6bb9bd380a44",
+      });
+      expect(result.success).toBe(false);
+    });
+  });
 });
 
 describe("updateLedgerEntrySchema", () => {

--- a/schemas/ledger-entry.ts
+++ b/schemas/ledger-entry.ts
@@ -1,6 +1,11 @@
 import { z } from "zod";
 
-const ledgerEntryTypeValues = ["expense", "income", "transfer"] as const;
+const ledgerEntryTypeValues = [
+  "expense",
+  "income",
+  "transfer",
+  "non_expense_withdrawal",
+] as const;
 
 const createLedgerEntryBaseSchema = z.object({
   type: z.enum(ledgerEntryTypeValues, {
@@ -23,37 +28,65 @@ const createLedgerEntryBaseSchema = z.object({
 
 export const createLedgerEntrySchema = createLedgerEntryBaseSchema.superRefine(
   (value, ctx) => {
-    if (value.type !== "transfer") return;
+    if (value.type === "transfer") {
+      const sourceCount =
+        Number(Boolean(value.fromAccountId)) +
+        Number(Boolean(value.fromPaymentMethodId));
+      const destinationCount =
+        Number(Boolean(value.toAccountId)) +
+        Number(Boolean(value.toPaymentMethodId));
 
-    const sourceCount =
-      Number(Boolean(value.fromAccountId)) +
-      Number(Boolean(value.fromPaymentMethodId));
-    const destinationCount =
-      Number(Boolean(value.toAccountId)) +
-      Number(Boolean(value.toPaymentMethodId));
+      if (sourceCount !== 1) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["fromAccountId"],
+          message: "이체 출발지를 하나 선택해주세요.",
+        });
+      }
 
-    if (sourceCount !== 1) {
-      ctx.addIssue({
-        code: "custom",
-        path: ["fromAccountId"],
-        message: "이체 출발지를 하나 선택해주세요.",
-      });
-    }
+      if (destinationCount !== 1) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["toAccountId"],
+          message: "이체 도착지를 하나 선택해주세요.",
+        });
+      }
 
-    if (destinationCount !== 1) {
-      ctx.addIssue({
-        code: "custom",
-        path: ["toAccountId"],
-        message: "이체 도착지를 하나 선택해주세요.",
-      });
-    }
+      if (value.categoryId) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["categoryId"],
+          message: "이체에는 카테고리를 선택할 수 없습니다.",
+        });
+      }
+    } else if (value.type === "non_expense_withdrawal") {
+      const sourceCount =
+        Number(Boolean(value.fromAccountId)) +
+        Number(Boolean(value.fromPaymentMethodId));
 
-    if (value.categoryId) {
-      ctx.addIssue({
-        code: "custom",
-        path: ["categoryId"],
-        message: "이체에는 카테고리를 선택할 수 없습니다.",
-      });
+      if (sourceCount !== 1) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["fromAccountId"],
+          message: "출금처를 하나 선택해주세요.",
+        });
+      }
+
+      if (value.toAccountId || value.toPaymentMethodId) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["toAccountId"],
+          message: "비지출 출금에는 입금처를 설정할 수 없습니다.",
+        });
+      }
+
+      if (value.categoryId) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["categoryId"],
+          message: "비지출 출금에는 카테고리를 설정할 수 없습니다.",
+        });
+      }
     }
   },
 );

--- a/supabase/migrations/20260612111500_add_non_expense_withdrawal.sql
+++ b/supabase/migrations/20260612111500_add_non_expense_withdrawal.sql
@@ -1,0 +1,2 @@
+-- Alter ledger_entry_type enum to include non_expense_withdrawal
+ALTER TYPE public.ledger_entry_type ADD VALUE 'non_expense_withdrawal';

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -1336,7 +1336,11 @@ export type Database = {
       exchange_type: "KOSPI" | "KOSDAQ" | "NYSE" | "NASDAQ" | "AMEX";
       household_role: "owner" | "member";
       invitation_status: "pending" | "accepted" | "expired" | "cancelled";
-      ledger_entry_type: "expense" | "income" | "transfer";
+      ledger_entry_type:
+        | "expense"
+        | "income"
+        | "transfer"
+        | "non_expense_withdrawal";
       market_type: "KR" | "US" | "OTHER";
       notification_link_kind:
         | "ledger_record_detail"
@@ -1548,7 +1552,12 @@ export const Constants = {
       exchange_type: ["KOSPI", "KOSDAQ", "NYSE", "NASDAQ", "AMEX"],
       household_role: ["owner", "member"],
       invitation_status: ["pending", "accepted", "expired", "cancelled"],
-      ledger_entry_type: ["expense", "income", "transfer"],
+      ledger_entry_type: [
+        "expense",
+        "income",
+        "transfer",
+        "non_expense_withdrawal",
+      ],
       market_type: ["KR", "US", "OTHER"],
       notification_link_kind: [
         "ledger_record_detail",


### PR DESCRIPTION
## Summary

Implements #375.

- Add `non_expense_withdrawal` to ledger entry schema/types and Supabase enum migration.
- Add the ledger composer UX for 비지출 출금 with from-only money source selection and no category.
- Exclude non-expense withdrawals from income/expense summaries while applying balance effects to the source account or payment method.
- Rename transfer UI labels to 내부이체 and update record/detail/edit/delete/change-request flows for the new type.

## Validation

- pnpm vitest run lib/ledger/record-change-request components/ledger/LedgerEntryDeleteDialog.test.tsx lib/api/ledger schemas/ledger-entry.test.ts
- pnpm type-check
- pnpm biome check .

## Review

Agent-collab reviewer approved the implementation in tmp/agent-collab/review.md.
