### PR TITLE
[codex] Add screen primitives

### DIFF
--- a/.claude/docs/CONVENTIONS_FE.md
+++ b/.claude/docs/CONVENTIONS_FE.md
@@ -107,6 +107,8 @@ lib/queries/index.ts  # 모든 쿼리 정의
 
 금융 기록이나 자산을 많이 보여주는 사용자-facing 화면은 테이블이나 카드 그리드를 기본값으로 두지 않습니다. 먼저 데이터 성격에 맞는 컬렉션 UI를 설계하고, 필요한 경우에만 내부 구현 도구로 table primitive나 TanStack Table을 사용합니다.
 
+#384 이후 섹션, grouped list, row, metric, 상태, 금액 표시가 필요한 화면은 먼저 `components/layout/screen/`의 screen primitive를 검토합니다. 세부 기준은 `.claude/docs/SCREEN_PRIMITIVES.md`를 따릅니다.
+
 | 화면 유형 | 기본 구조 |
 |----------|----------|
 | 날짜 기반 기록 | 캘린더/날짜별 목록/타임라인 + 상세 또는 작업 화면 |

--- a/.claude/docs/SCREEN_PRIMITIVES.md
+++ b/.claude/docs/SCREEN_PRIMITIVES.md
@@ -1,0 +1,97 @@
+# SCREEN_PRIMITIVES.md
+
+> #384 공통 화면 primitive 기준. 후속 UI 개선 이슈(#385~#394)는 화면별 재설계 전에 이 문법을 먼저 검토합니다.
+
+## 목적
+
+Screen primitive는 oat 앱 화면의 섹션, 목록, 행, metric, 상태, 금액 표시 문법을 맞추기 위한 얇은 공통 컴포넌트입니다. 도메인 로직이나 데이터 계산을 소유하지 않고, 각 화면이 같은 스캔 패턴과 affordance를 공유하도록 돕습니다.
+
+위치:
+
+```txt
+components/layout/screen/
+```
+
+## Primitive
+
+| Primitive | 역할 | 사용 기준 |
+|-----------|------|-----------|
+| `ScreenSection` | 화면 안의 의미 있는 섹션 간격 | 섹션 자체를 카드로 감싸지 않을 때 |
+| `SectionHeader` | 섹션 제목, 설명, 우측 액션 | 목록/metric 묶음 위의 짧은 heading |
+| `GroupedList` | row 묶음 surface | 설정, 허브 진입점, 관리 목록 |
+| `EntryRow` | 대표 텍스트, 보조 정보, trailing 값/상태, disclosure/action | 반복 목록 row와 top-level 진입점 |
+| `MetricBlock` | 단일 강조 지표 | 총액, 월 지출, 수익률처럼 강조해야 하는 값 |
+| `MetricStrip` | 관련 metric의 얇은 반응형 배치 | 수입/지출/남은 금액처럼 비교가 필요한 묶음 |
+| `ScreenState` | empty/error/full-area loading 상태 | 데이터가 없거나 화면 전체를 불러오지 못한 경우 |
+| `AmountText` | 금액/수익률 텍스트 안정 표시 | row, metric, summary 안의 기본 금액 typography |
+
+## 사용 원칙
+
+- `components/ui`의 일반 atom이 아니라 oat 앱 화면 문법입니다. 도메인 컴포넌트는 이 primitive를 조합하되, 금융/가구 규칙은 자기 영역에 둡니다.
+- `GroupedList`는 조용한 row surface입니다. `bg-white`, divider, 얕은 ring, 작은 radius는 허용하지만 기본 shadow나 큰 card 스타일은 쓰지 않습니다.
+- `EntryRow`는 typed props를 기본으로 사용합니다. title, description, icon, trailing, disclosure/action을 표준화하고, 도메인별 우측 값은 `trailing` slot으로 넣습니다.
+- `MetricStrip`은 layout만 담당합니다. 어떤 metric을 보여줄지, 어떤 값을 계산할지는 후속 화면 이슈에서 결정합니다.
+- `ScreenState`는 전체 영역의 empty/error/loading에 사용합니다. 실제 목록의 loading skeleton row는 각 리스트에서 별도로 구성합니다.
+- `AmountText`가 기본 금액 표시 primitive입니다. `AmountWithPopover`는 deprecated이며, 전체 금액 disclosure가 꼭 필요한 legacy 화면에서만 유지합니다.
+
+## Amount Tone
+
+금액 색상 prop은 색 이름이나 `positive`/`negative`보다 의미를 드러내는 이름을 사용합니다.
+
+| Tone | 의미 | 기본 색상 |
+|------|------|-----------|
+| `income` | 가계부 수입 | 빨강 |
+| `expense` | 가계부 지출 | 파랑 |
+| `increase` | 수익률/시장 상승 | 빨강 |
+| `decrease` | 수익률/시장 하락 | 파랑 |
+| `neutral` | 방향성이 없는 금액 | 진한 회색 |
+| `muted` | 보조/비활성 금액 | 연한 회색 |
+
+한국식 금융 색상 기준으로 상승/수입은 빨강, 하락/지출은 파랑을 사용합니다.
+
+## 후속 이슈 적용 기준
+
+- #385 허브 화면은 기존 카드형 링크를 `ScreenSection` + `GroupedList` + `EntryRow` 중심으로 전환합니다.
+- #386, #389 분석 화면은 metric이 실제 비교 단위일 때만 `MetricBlock`/`MetricStrip`을 사용합니다. 차트나 분석 패널 전체를 metric primitive로 대체하지 않습니다.
+- #388 금액/긴 텍스트 정책은 `AmountText`를 기본값으로 삼고, popover나 축약 표시 임계값은 별도 정책으로 결정합니다.
+- #391, #390 관리/설정 목록은 `GroupedList`와 `EntryRow`를 우선 검토합니다.
+- #392 캘린더와 상세 화면은 기존 구조를 유지하되 row overflow와 금액 표시를 `EntryRow`/`AmountText` 기준에 맞춥니다.
+
+## 예시
+
+```tsx
+<ScreenSection>
+  <SectionHeader title="기능" />
+  <GroupedList>
+    <EntryRow
+      href="/ledger/records"
+      icon={CalendarDays}
+      title="기록 조회"
+      description="달력에서 수입/지출 내역 확인"
+    />
+    <EntryRow
+      title="이번 달 지출"
+      description="공용 기준"
+      trailing={<AmountText amount={1850000} tone="expense" />}
+    />
+  </GroupedList>
+</ScreenSection>
+```
+
+```tsx
+<MetricStrip columns={{ base: 2, md: 3 }}>
+  <MetricBlock
+    label="수입"
+    value={<AmountText amount={3200000} tone="income" />}
+  />
+  <MetricBlock
+    label="지출"
+    value={<AmountText amount={1850000} tone="expense" />}
+  />
+  <MetricBlock
+    label="남은 금액"
+    value={<AmountText amount={1350000} />}
+    emphasis
+  />
+</MetricStrip>
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@
 | **EXAMPLES.md** | `.claude/docs/` | 코드 예시 모음 |
 | **ENV.md** | `.claude/docs/` | 환경변수 설정 가이드 |
 | **NOTIFICATIONS.md** | `.claude/docs/` | 알림 기능 설계, 후보 이벤트, 구현 이슈 분해 |
+| **SCREEN_PRIMITIVES.md** | `.claude/docs/` | 공통 화면 primitive 기준, row/metric/state/amount 화면 문법 |
 
 ### Skills (작업별 자동 활성화)
 

--- a/components/layout/index.ts
+++ b/components/layout/index.ts
@@ -6,3 +6,4 @@ export { PageTransition } from "./PageTransition";
 export { PageTransitionProvider } from "./PageTransitionProvider";
 export { ServiceHeader } from "./ServiceHeader";
 export { Sidebar } from "./Sidebar";
+export * from "./screen";

--- a/components/layout/screen/AmountText.tsx
+++ b/components/layout/screen/AmountText.tsx
@@ -1,0 +1,75 @@
+import { cn } from "@/lib/utils/cn";
+import { formatCompactCurrency, formatCurrency } from "@/lib/utils/format";
+
+export type AmountTone =
+  | "neutral"
+  | "income"
+  | "expense"
+  | "increase"
+  | "decrease"
+  | "muted";
+
+interface AmountTextProps extends React.ComponentProps<"span"> {
+  amount?: number;
+  value?: React.ReactNode;
+  currency?: "KRW" | "USD";
+  sign?: string;
+  prefix?: string;
+  suffix?: string;
+  compact?: boolean;
+  tone?: AmountTone;
+  align?: "left" | "right";
+}
+
+const toneClasses: Record<AmountTone, string> = {
+  neutral: "text-gray-900",
+  income: "text-red-500",
+  expense: "text-blue-500",
+  increase: "text-red-500",
+  decrease: "text-blue-500",
+  muted: "text-gray-500",
+};
+
+const alignClasses = {
+  left: "text-left",
+  right: "text-right",
+};
+
+export function AmountText({
+  amount,
+  value,
+  currency = "KRW",
+  sign = "",
+  prefix = "",
+  suffix = "",
+  compact = false,
+  tone = "neutral",
+  align = "right",
+  className,
+  ...props
+}: AmountTextProps) {
+  const formattedValue =
+    value ??
+    (typeof amount === "number"
+      ? compact
+        ? formatCompactCurrency(amount, currency)
+        : formatCurrency(amount, currency)
+      : "");
+
+  return (
+    <span
+      className={cn(
+        "inline-block min-w-0 max-w-full font-semibold tabular-nums leading-tight [overflow-wrap:anywhere]",
+        toneClasses[tone],
+        alignClasses[align],
+        className,
+      )}
+      {...props}
+    >
+      {prefix}
+      {sign}
+      {formattedValue}
+      {suffix}
+    </span>
+  );
+}

--- a/components/layout/screen/EntryRow.tsx
+++ b/components/layout/screen/EntryRow.tsx
@@ -1,0 +1,105 @@
+import { ChevronRight, Loader2, type LucideIcon } from "lucide-react";
+import Link from "next/link";
+import { cn } from "@/lib/utils/cn";
+
+export type EntryRowAction = "none" | "disclosure";
+
+interface EntryRowProps {
+  icon?: LucideIcon;
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  href?: string;
+  onClick?: () => void;
+  trailing?: React.ReactNode;
+  action?: EntryRowAction;
+  disabled?: boolean;
+  isLoading?: boolean;
+  className?: string;
+  iconClassName?: string;
+  iconContainerClassName?: string;
+}
+
+export function EntryRow({
+  icon: Icon,
+  title,
+  description,
+  href,
+  onClick,
+  trailing,
+  action,
+  disabled = false,
+  isLoading = false,
+  className,
+  iconClassName,
+  iconContainerClassName,
+}: EntryRowProps) {
+  const showDisclosure =
+    !isLoading && !disabled && (action === "disclosure" || (!action && href));
+
+  const content = (
+    <>
+      <div className="flex min-w-0 flex-1 items-center gap-3">
+        {Icon && (
+          <div
+            className={cn(
+              "flex size-10 shrink-0 items-center justify-center rounded-xl bg-gray-100",
+              iconContainerClassName,
+            )}
+          >
+            <Icon className={cn("size-5 text-gray-600", iconClassName)} />
+          </div>
+        )}
+        <div className="min-w-0 flex-1">
+          <p className="truncate font-medium text-gray-900">{title}</p>
+          {description && (
+            <p className="mt-0.5 truncate text-sm text-gray-500">
+              {description}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {(trailing || isLoading || showDisclosure) && (
+        <div className="flex shrink-0 items-center gap-2">
+          {trailing && <div className="min-w-0 text-right">{trailing}</div>}
+          {isLoading ? (
+            <Loader2 className="size-5 animate-spin text-gray-400" />
+          ) : showDisclosure ? (
+            <ChevronRight className="size-5 text-gray-400" />
+          ) : null}
+        </div>
+      )}
+    </>
+  );
+
+  const baseClassName = cn(
+    "flex w-full items-center gap-3 px-4 py-3.5 text-left transition-colors",
+    disabled
+      ? "cursor-not-allowed opacity-60"
+      : "hover:bg-gray-50 active:bg-gray-100",
+    className,
+  );
+
+  if (href && !disabled) {
+    return (
+      <Link href={href} className={baseClassName}>
+        {content}
+      </Link>
+    );
+  }
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={disabled || isLoading}
+        className={baseClassName}
+      >
+        {content}
+      </button>
+    );
+  }
+
+  return <div className={baseClassName}>{content}</div>;
+}

--- a/components/layout/screen/GroupedList.tsx
+++ b/components/layout/screen/GroupedList.tsx
@@ -1,0 +1,16 @@
+import { cn } from "@/lib/utils/cn";
+
+export function GroupedList({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "divide-y divide-gray-100 overflow-hidden rounded-xl bg-white ring-1 ring-gray-100",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/components/layout/screen/MetricBlock.tsx
+++ b/components/layout/screen/MetricBlock.tsx
@@ -1,0 +1,50 @@
+import { cn } from "@/lib/utils/cn";
+
+interface MetricBlockProps extends React.ComponentProps<"div"> {
+  label: React.ReactNode;
+  value: React.ReactNode;
+  supporting?: React.ReactNode;
+  delta?: React.ReactNode;
+  tone?: "neutral" | "increase" | "decrease" | "muted";
+  emphasis?: boolean;
+}
+
+const toneClasses = {
+  neutral: "text-gray-900",
+  increase: "text-red-500",
+  decrease: "text-blue-500",
+  muted: "text-gray-500",
+};
+
+export function MetricBlock({
+  label,
+  value,
+  supporting,
+  delta,
+  tone = "neutral",
+  emphasis = false,
+  className,
+  ...props
+}: MetricBlockProps) {
+  return (
+    <div className={cn("min-w-0 space-y-1", className)} {...props}>
+      <p className="truncate text-xs font-medium text-gray-500">{label}</p>
+      <p
+        className={cn(
+          "min-w-0 font-bold leading-tight tabular-nums [overflow-wrap:anywhere]",
+          emphasis ? "text-xl" : "text-lg",
+          toneClasses[tone],
+        )}
+      >
+        {value}
+      </p>
+      {(supporting || delta) && (
+        <p className="truncate text-xs text-gray-500">
+          {supporting}
+          {supporting && delta ? " · " : null}
+          {delta}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/components/layout/screen/MetricStrip.tsx
+++ b/components/layout/screen/MetricStrip.tsx
@@ -1,0 +1,60 @@
+import { cn } from "@/lib/utils/cn";
+
+type ColumnCount = 1 | 2 | 3 | 4;
+
+interface MetricStripProps extends React.ComponentProps<"div"> {
+  columns?: {
+    base?: ColumnCount;
+    sm?: ColumnCount;
+    md?: ColumnCount;
+    lg?: ColumnCount;
+  };
+}
+
+const baseColumnClasses: Record<ColumnCount, string> = {
+  1: "grid-cols-1",
+  2: "grid-cols-2",
+  3: "grid-cols-3",
+  4: "grid-cols-4",
+};
+
+const smColumnClasses: Record<ColumnCount, string> = {
+  1: "sm:grid-cols-1",
+  2: "sm:grid-cols-2",
+  3: "sm:grid-cols-3",
+  4: "sm:grid-cols-4",
+};
+
+const mdColumnClasses: Record<ColumnCount, string> = {
+  1: "md:grid-cols-1",
+  2: "md:grid-cols-2",
+  3: "md:grid-cols-3",
+  4: "md:grid-cols-4",
+};
+
+const lgColumnClasses: Record<ColumnCount, string> = {
+  1: "lg:grid-cols-1",
+  2: "lg:grid-cols-2",
+  3: "lg:grid-cols-3",
+  4: "lg:grid-cols-4",
+};
+
+export function MetricStrip({
+  columns = { base: 1, md: 3 },
+  className,
+  ...props
+}: MetricStripProps) {
+  return (
+    <div
+      className={cn(
+        "grid gap-3",
+        baseColumnClasses[columns.base ?? 1],
+        columns.sm && smColumnClasses[columns.sm],
+        columns.md && mdColumnClasses[columns.md],
+        columns.lg && lgColumnClasses[columns.lg],
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/components/layout/screen/ScreenSection.tsx
+++ b/components/layout/screen/ScreenSection.tsx
@@ -1,0 +1,38 @@
+import { cn } from "@/lib/utils/cn";
+
+export function ScreenSection({
+  className,
+  ...props
+}: React.ComponentProps<"section">) {
+  return <section className={cn("space-y-3", className)} {...props} />;
+}
+
+interface SectionHeaderProps
+  extends Omit<React.ComponentProps<"div">, "title"> {
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  action?: React.ReactNode;
+}
+
+export function SectionHeader({
+  title,
+  description,
+  action,
+  className,
+  ...props
+}: SectionHeaderProps) {
+  return (
+    <div
+      className={cn("flex items-start justify-between gap-3 px-1", className)}
+      {...props}
+    >
+      <div className="min-w-0">
+        <h2 className="text-base font-semibold text-gray-900">{title}</h2>
+        {description && (
+          <p className="mt-0.5 text-sm text-gray-500">{description}</p>
+        )}
+      </div>
+      {action && <div className="shrink-0">{action}</div>}
+    </div>
+  );
+}

--- a/components/layout/screen/ScreenState.tsx
+++ b/components/layout/screen/ScreenState.tsx
@@ -1,0 +1,52 @@
+import { AlertCircle, Inbox, Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils/cn";
+
+type ScreenStateType = "empty" | "error" | "loading";
+
+interface ScreenStateProps extends Omit<React.ComponentProps<"div">, "title"> {
+  type: ScreenStateType;
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  action?: React.ReactNode;
+}
+
+const typeIcon = {
+  empty: Inbox,
+  error: AlertCircle,
+  loading: Loader2,
+};
+
+const typeIconClassName: Record<ScreenStateType, string> = {
+  empty: "text-gray-300",
+  error: "text-red-400",
+  loading: "animate-spin text-gray-300",
+};
+
+export function ScreenState({
+  type,
+  title,
+  description,
+  action,
+  className,
+  ...props
+}: ScreenStateProps) {
+  const Icon = typeIcon[type];
+
+  return (
+    <div
+      data-testid="screen-state"
+      className={cn(
+        "flex min-h-48 flex-col items-center justify-center rounded-xl border border-gray-100 bg-white px-6 py-10 text-center",
+        className,
+      )}
+      {...props}
+    >
+      <Icon className={cn("size-8", typeIconClassName[type])} />
+      <h2 className="mt-3 text-base font-semibold text-gray-900">{title}</h2>
+      {description && (
+        <p className="mt-1 max-w-sm text-sm text-gray-500">{description}</p>
+      )}
+      {action && <div className="mt-4">{action}</div>}
+    </div>
+  );
+}

--- a/components/layout/screen/index.ts
+++ b/components/layout/screen/index.ts
@@ -1,0 +1,7 @@
+export { AmountText, type AmountTone } from "./AmountText";
+export { EntryRow, type EntryRowAction } from "./EntryRow";
+export { GroupedList } from "./GroupedList";
+export { MetricBlock } from "./MetricBlock";
+export { MetricStrip } from "./MetricStrip";
+export { ScreenSection, SectionHeader } from "./ScreenSection";
+export { ScreenState } from "./ScreenState";

--- a/components/layout/screen/screen-primitives.test.tsx
+++ b/components/layout/screen/screen-primitives.test.tsx
@@ -1,0 +1,142 @@
+import { render, screen } from "@testing-library/react";
+import { Bell, Settings } from "lucide-react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  AmountText,
+  EntryRow,
+  GroupedList,
+  MetricBlock,
+  MetricStrip,
+  ScreenSection,
+  ScreenState,
+  SectionHeader,
+} from ".";
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe("screen primitives", () => {
+  it("renders EntryRow as a disclosure link with title, description, icon, and trailing content", () => {
+    render(
+      <EntryRow
+        href="/settings/notifications"
+        icon={Bell}
+        title="알림 설정"
+        description="Push 수신 여부 관리"
+        trailing={<span>켜짐</span>}
+      />,
+    );
+
+    const row = screen.getByRole("link", { name: /알림 설정/ });
+
+    expect(row).toHaveAttribute("href", "/settings/notifications");
+    expect(screen.getByText("Push 수신 여부 관리")).toBeInTheDocument();
+    expect(screen.getByText("켜짐")).toBeInTheDocument();
+    expect(row.querySelector(".lucide-bell")).toBeInTheDocument();
+    expect(row.querySelector(".lucide-chevron-right")).toBeInTheDocument();
+  });
+
+  it("renders EntryRow as a disabled row and suppresses the disclosure affordance", () => {
+    render(
+      <EntryRow
+        href="/settings/profile"
+        icon={Settings}
+        title="프로필"
+        description="준비 중"
+        disabled
+      />,
+    );
+
+    expect(
+      screen.queryByRole("link", { name: /프로필/ }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("준비 중")).toBeInTheDocument();
+    expect(screen.queryByText("준비 중")).toHaveClass("text-gray-500");
+  });
+
+  it("renders GroupedList as a quiet row surface without default shadow", () => {
+    render(
+      <GroupedList data-testid="grouped-list">
+        <EntryRow title="첫 번째" />
+        <EntryRow title="두 번째" />
+      </GroupedList>,
+    );
+
+    const list = screen.getByTestId("grouped-list");
+
+    expect(list).toHaveClass("divide-y");
+    expect(list.className).not.toContain("shadow");
+  });
+
+  it("renders ScreenSection and SectionHeader without wrapping the whole section in a card", () => {
+    render(
+      <ScreenSection data-testid="screen-section">
+        <SectionHeader title="기능" description="자주 쓰는 작업" />
+      </ScreenSection>,
+    );
+
+    const section = screen.getByTestId("screen-section");
+
+    expect(screen.getByRole("heading", { name: "기능" })).toBeInTheDocument();
+    expect(screen.getByText("자주 쓰는 작업")).toBeInTheDocument();
+    expect(section.className).not.toContain("bg-white");
+    expect(section.className).not.toContain("shadow");
+  });
+
+  it("renders ScreenState variants with optional action", () => {
+    render(
+      <ScreenState
+        type="error"
+        title="불러오지 못했어요"
+        description="잠시 후 다시 시도해주세요."
+        action={<button type="button">다시 시도</button>}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "불러오지 못했어요" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("잠시 후 다시 시도해주세요.")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "다시 시도" }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("screen-state")).toHaveClass("border");
+  });
+
+  it("formats AmountText with semantic tone, sign, compactness, and overflow-safe classes", () => {
+    render(<AmountText amount={1_250_000} compact sign="+" tone="income" />);
+
+    const amount = screen.getByText(/\+/);
+
+    expect(amount).toHaveClass("text-red-500");
+    expect(amount).toHaveClass("tabular-nums");
+    expect(amount).toHaveClass("[overflow-wrap:anywhere]");
+    expect(amount.textContent).toContain("₩");
+  });
+
+  it("renders MetricBlock and MetricStrip as a customizable metric layout", () => {
+    render(
+      <MetricStrip columns={{ base: 2, md: 3 }} data-testid="metric-strip">
+        <MetricBlock label="수입" value="3,200,000원" />
+        <MetricBlock label="남은 금액" value="1,350,000원" emphasis />
+      </MetricStrip>,
+    );
+
+    expect(screen.getByTestId("metric-strip")).toHaveClass("grid-cols-2");
+    expect(screen.getByTestId("metric-strip")).toHaveClass("md:grid-cols-3");
+    expect(screen.getByText("수입")).toBeInTheDocument();
+    expect(screen.getByText("1,350,000원")).toHaveClass("text-xl");
+  });
+});

--- a/components/records/AmountWithPopover.tsx
+++ b/components/records/AmountWithPopover.tsx
@@ -16,6 +16,11 @@ interface AmountWithPopoverProps {
   compactThreshold?: number;
 }
 
+/**
+ * @deprecated Use `AmountText` from `@/components/layout/screen` for base
+ * amount typography. Wrap it with a popover only when a screen explicitly
+ * needs full-amount disclosure.
+ */
 export function AmountWithPopover({
   amount,
   currency = "KRW",

--- a/components/settings/SettingsMenuItem.test.tsx
+++ b/components/settings/SettingsMenuItem.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import { User } from "lucide-react";
+import { describe, expect, it, vi } from "vitest";
+import { SettingsMenuItem } from "./SettingsMenuItem";
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe("SettingsMenuItem", () => {
+  it("renders enabled navigation items as links", () => {
+    render(
+      <SettingsMenuItem
+        icon={User}
+        label="가구 관리"
+        description="가구 이름, 구성원, 초대 관리"
+        href="/settings/household"
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: /가구 관리/ })).toHaveAttribute(
+      "href",
+      "/settings/household",
+    );
+    expect(
+      screen.getByText("가구 이름, 구성원, 초대 관리"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders disabled navigation items as non-interactive rows", () => {
+    render(
+      <SettingsMenuItem
+        icon={User}
+        label="프로필"
+        description="이름, 이메일 관리"
+        href="/settings/profile"
+        disabled
+      />,
+    );
+
+    expect(
+      screen.queryByRole("link", { name: /프로필/ }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("준비 중")).toBeInTheDocument();
+  });
+
+  it("renders action items as buttons and shows loading affordance", () => {
+    render(
+      <SettingsMenuItem
+        icon={User}
+        label="로그아웃"
+        onClick={vi.fn()}
+        isLoading
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: /로그아웃/ });
+
+    expect(button).toBeDisabled();
+    expect(button.querySelector(".lucide-loader-circle")).toBeInTheDocument();
+  });
+});

--- a/components/settings/SettingsMenuItem.tsx
+++ b/components/settings/SettingsMenuItem.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { ChevronRight, Loader2, type LucideIcon } from "lucide-react";
-import Link from "next/link";
-import { cn } from "@/lib/utils/cn";
+import type { LucideIcon } from "lucide-react";
+import { EntryRow } from "@/components/layout/screen";
 
 interface SettingsMenuItemProps {
   icon: LucideIcon;
@@ -23,60 +22,23 @@ export function SettingsMenuItem({
   disabled = false,
   isLoading = false,
 }: SettingsMenuItemProps) {
-  const content = (
-    <>
-      <div className="flex items-center gap-3 flex-1 min-w-0">
-        <div className="p-2 rounded-xl bg-gray-100 shrink-0">
-          <Icon className="w-5 h-5 text-gray-600" />
-        </div>
-        <div className="flex-1 min-w-0">
-          <p className="font-medium text-gray-900">{label}</p>
-          {description && (
-            <p className="text-sm text-gray-500 truncate">{description}</p>
-          )}
-        </div>
-      </div>
-      <div className="shrink-0">
-        {isLoading ? (
-          <Loader2 className="w-5 h-5 text-gray-400 animate-spin" />
-        ) : disabled ? (
-          <span className="text-xs text-gray-400 px-2 py-1 bg-gray-100 rounded-full">
+  return (
+    <EntryRow
+      icon={Icon}
+      title={label}
+      description={description}
+      href={href}
+      onClick={onClick}
+      disabled={disabled}
+      isLoading={isLoading}
+      trailing={
+        disabled ? (
+          <span className="rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-400">
             준비 중
           </span>
-        ) : (
-          <ChevronRight className="w-5 h-5 text-gray-400" />
-        )}
-      </div>
-    </>
-  );
-
-  const baseClassName = cn(
-    "flex items-center gap-3 w-full p-4 bg-white rounded-2xl shadow-sm transition-colors",
-    disabled
-      ? "opacity-60 cursor-not-allowed"
-      : "hover:bg-gray-50 active:bg-gray-100",
-  );
-
-  if (disabled) {
-    return <div className={baseClassName}>{content}</div>;
-  }
-
-  if (href) {
-    return (
-      <Link href={href} className={baseClassName}>
-        {content}
-      </Link>
-    );
-  }
-
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={isLoading}
-      className={cn(baseClassName, "text-left")}
-    >
-      {content}
-    </button>
+        ) : undefined
+      }
+      className="rounded-xl bg-white"
+    />
   );
 }


### PR DESCRIPTION
## Summary

Implements #384.

- Add oat-specific screen primitives for sections, grouped lists, rows, metrics, states, and amount text under `components/layout/screen`.
- Refactor `SettingsMenuItem` onto `EntryRow` as the first usage example without redesigning the settings route.
- Deprecate `AmountWithPopover` in favor of `AmountText` for base amount typography.
- Document screen primitive guidance for follow-up UI issues in `.claude/docs/SCREEN_PRIMITIVES.md` and link it from the existing docs.

## Validation

- `pnpm test components/layout/screen/screen-primitives.test.tsx components/settings/SettingsMenuItem.test.tsx components/settings/SettingsMenu.test.tsx`
- `pnpm type-check`
- `pnpm biome check components/layout/screen components/settings/SettingsMenuItem.tsx components/settings/SettingsMenuItem.test.tsx components/records/AmountWithPopover.tsx components/layout/index.ts CLAUDE.md .claude/docs/CONVENTIONS_FE.md .claude/docs/SCREEN_PRIMITIVES.md --write`
