### PR TITLE
feat(ui): centralize layout width policy with PageContainer (#387)

### DIFF
--- a/.claude/docs/CONVENTIONS_FE.md
+++ b/.claude/docs/CONVENTIONS_FE.md
@@ -353,7 +353,6 @@ import { PageContainer } from "@/components/layout";
 | Props | 타입 | 기본값 | 설명 |
 |-------|------|--------|------|
 | maxWidth | "default" \| "narrow" \| "medium" | "default" | 컨테이너 너비 (`default` = `max-w-5xl`, `medium` = `max-w-3xl`, `narrow` = `max-w-xl`) |
-| className | string | - | 추가적인 스타일 클래스 |
 
 #### PC 2-column 레이아웃 정책
 - 좌/우 2개의 명확한 콘텐츠 흐름이 존재하는 화면(예: 달력/요약 + 선택 날짜 목록 등)에만 2-column 그리드 레이아웃을 사용하며, 너비는 `default`를 적용합니다.

--- a/.claude/docs/CONVENTIONS_FE.md
+++ b/.claude/docs/CONVENTIONS_FE.md
@@ -324,45 +324,51 @@ ServiceHeader는 pathname으로 다음 정보를 계산합니다.
 
 ### PageContainer
 
-페이지 컨테이너 너비를 표준화합니다. 좁은 폼이나 설정 페이지에 사용합니다.
+페이지 콘텐츠의 최대 너비와 일관된 여백을 중앙 관리하는 컴포넌트입니다. `app/(main)/layout.tsx`는 레이아웃 패딩과 사이드바, 헤더 영역만 소유하며, 실제 콘텐츠의 최대 너비(max-width)는 개별 페이지 내의 `PageContainer`가 결정합니다.
+
+모든 `app/(main)` 페이지는 다음과 같이 `PageContainer`를 적용하거나 래핑하여 명시적인 너비 의도를 드러내야 합니다.
 
 ```tsx
 import { PageContainer } from "@/components/layout";
 
-// 좁은 너비 (설정, 폼 등) - max-w-lg
-<PageContainer maxWidth="narrow">
-  <SettingsMenu />
+// 기본 너비 (default) - max-w-5xl
+// 대시보드 홈, 가계부 메인, 자산 목록, 분석, 2컬럼 레이아웃 등 일반 화면
+<PageContainer maxWidth="default">
+  {children}
 </PageContainer>
 
-// 중간 너비 (가구 관리 등) - max-w-2xl
+// 중간 너비 (medium) - max-w-3xl
+// 설정 subpage, 계좌/결제수단/카테고리 관리 및 상세 화면, 알림 상세 등
 <PageContainer maxWidth="medium">
   <HouseholdSettings />
 </PageContainer>
 
-// 기본 너비 - 레이아웃의 max-w-4xl 사용 (래핑 없음)
-// default는 생략 가능하며, Fragment만 반환
-<PageContainer maxWidth="default">
-  {children}
+// 좁은 너비 (narrow) - max-w-xl
+// 수입/지출/거래 추가 등 작업(Task) 및 입력 폼 화면
+<PageContainer maxWidth="narrow">
+  <SettingsMenu />
 </PageContainer>
 ```
 
 | Props | 타입 | 기본값 | 설명 |
 |-------|------|--------|------|
-| maxWidth | "default" \| "narrow" \| "medium" | "default" | 컨테이너 너비 |
+| maxWidth | "default" \| "narrow" \| "medium" | "default" | 컨테이너 너비 (`default` = `max-w-5xl`, `medium` = `max-w-3xl`, `narrow` = `max-w-xl`) |
+| className | string | - | 추가적인 스타일 클래스 |
+
+#### PC 2-column 레이아웃 정책
+- 좌/우 2개의 명확한 콘텐츠 흐름이 존재하는 화면(예: 달력/요약 + 선택 날짜 목록 등)에만 2-column 그리드 레이아웃을 사용하며, 너비는 `default`를 적용합니다.
+- 단순히 넓은 화면을 채우기 위해 인위적으로 2컬럼 레이아웃을 구성해서는 안 됩니다. 단일 콘텐츠 흐름을 갖는 상세/관리 화면은 `medium`, 작업 폼은 `narrow`를 사용하여 중앙 정렬로 시각적 밀도를 유지합니다.
 
 ### 페이지별 적용 가이드
 
-| 페이지 | ServiceHeader | PageContainer |
-|--------|---------------|---------------|
-| `/home` | topLevel | default |
-| `/ledger` | topLevel | default |
-| `/assets` | topLevel | default |
-| `/settings` | topLevel | narrow |
-| `/household` | child, parent `/settings` | medium |
-| `/assets/stock/holdings` | child, breadcrumb `자산 > 주식 > 보유 종목` | default |
-| `/assets/stock/transactions` | child, breadcrumb `자산 > 주식 > 거래 내역` | default |
-| `/assets/stock/transactions/new/full` | task, close `/assets/stock/transactions` | narrow |
-| `/assets/stock/settings` | child, breadcrumb `자산 > 주식 > 종목 설정` | default |
+| 페이지 구분 | 대상 예시 경로 | ServiceHeader | PageContainer |
+|-------------|----------------|---------------|---------------|
+| **Top-level / Hub** | `/home`, `/ledger`, `/assets`, `/assets/stock` | topLevel | default (`max-w-5xl`) |
+| **Analysis** | `/ledger/analysis/**`, `/assets/stock/analysis/**` | child | default (`max-w-5xl`) |
+| **Records Calendar** | `/ledger/records`, `/assets/stock/records` | child | default (`max-w-5xl`) |
+| **Management / Settings** | `/settings`, `/settings/household`, `/settings/notifications`, `/settings/mcp`, `/ledger/categories`, `/ledger/payment-methods`, `/assets/accounts`, `/assets/stock/settings` | topLevel / child | medium (`max-w-3xl`) |
+| **Simple Detail** | `/ledger/records/[entryId]`, `/assets/stock/transactions/[transactionId]`, `/assets/accounts/[accountId]`, `/ledger/payment-methods/[paymentMethodId]` | child | medium (`max-w-3xl`) |
+| **Task / Form** | `/ledger/records/new/*`, `/assets/stock/transactions/new/*`, `/assets/accounts/new`, `/ledger/payment-methods/new` | task | narrow (`max-w-xl`) |
 
 ---
 

--- a/app/(main)/assets/page.tsx
+++ b/app/(main)/assets/page.tsx
@@ -1,5 +1,10 @@
 import { AssetsPageClient } from "@/components/assets";
+import { PageContainer } from "@/components/layout";
 
 export default function AssetsPage() {
-  return <AssetsPageClient />;
+  return (
+    <PageContainer maxWidth="default">
+      <AssetsPageClient />
+    </PageContainer>
+  );
 }

--- a/app/(main)/assets/stock/analysis/by-owner/page.tsx
+++ b/app/(main)/assets/stock/analysis/by-owner/page.tsx
@@ -5,6 +5,7 @@ import {
   StockOwnerHoldingsList,
   StockOwnerSummary,
 } from "@/components/assets/stock/analysis/by-owner";
+import { PageContainer } from "@/components/layout";
 import { useStockOwnerAnalysis } from "@/hooks/use-stock-owner-analysis";
 
 export default function StockOwnerAnalysisPage() {
@@ -13,7 +14,7 @@ export default function StockOwnerAnalysisPage() {
   const isEmpty = !isLoading && (!data || data.summary.length === 0);
 
   return (
-    <>
+    <PageContainer maxWidth="default">
       {/* 에러 상태 */}
       {error && (
         <div className="bg-white rounded-2xl p-6 shadow-sm">
@@ -52,6 +53,6 @@ export default function StockOwnerAnalysisPage() {
           />
         </>
       )}
-    </>
+    </PageContainer>
   );
 }

--- a/app/(main)/assets/stock/analysis/by-risk/page.tsx
+++ b/app/(main)/assets/stock/analysis/by-risk/page.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from "react";
 import { Cell, Pie, PieChart } from "recharts";
 import { StockRiskHoldingsList } from "@/components/assets/stock/analysis/by-risk";
+import { PageContainer } from "@/components/layout";
 import {
   type ChartConfig,
   ChartContainer,
@@ -77,7 +78,7 @@ export default function StockRiskAnalysisPage() {
   const isEmpty = !isLoading && (!data || data.totalValue === 0);
 
   return (
-    <>
+    <PageContainer maxWidth="default">
       {/* 로딩 상태 */}
       {isLoading && (
         <div className="space-y-4">
@@ -205,6 +206,6 @@ export default function StockRiskAnalysisPage() {
           <StockRiskHoldingsList data={sortedByRiskLevel} />
         </div>
       )}
-    </>
+    </PageContainer>
   );
 }

--- a/app/(main)/assets/stock/analysis/overview/page.tsx
+++ b/app/(main)/assets/stock/analysis/overview/page.tsx
@@ -6,16 +6,17 @@ import {
   StockOverviewSummarySection,
   StockOverviewTopPerformersSection,
 } from "@/components/assets/stock/analysis/overview";
+import { PageContainer } from "@/components/layout";
 
 export default function StockOverviewAnalysisPage() {
   return (
-    <>
+    <PageContainer maxWidth="default">
       <StockOverviewSummarySection />
       <StockOverviewAllocationSection />
       <StockOverviewMarketSection />
       <StockOverviewAccountSection />
       <StockOverviewAccountDistributionSection />
       <StockOverviewTopPerformersSection />
-    </>
+    </PageContainer>
   );
 }

--- a/app/(main)/assets/stock/analysis/page.tsx
+++ b/app/(main)/assets/stock/analysis/page.tsx
@@ -1,4 +1,5 @@
 import { BarChart3, Shield, Users } from "lucide-react";
+import { PageContainer } from "@/components/layout";
 import {
   EntryRow,
   GroupedList,
@@ -8,28 +9,30 @@ import {
 
 export default function StockAnalysisHubPage() {
   return (
-    <ScreenSection>
-      <SectionHeader title="분석 관점" />
-      <GroupedList>
-        <EntryRow
-          href="/assets/stock/analysis/overview"
-          icon={BarChart3}
-          title="종합 분석"
-          description="평가금액, 수익률, 비중, 상위 종목"
-        />
-        <EntryRow
-          href="/assets/stock/analysis/by-owner"
-          icon={Users}
-          title="소유자별"
-          description="가족 구성원별 평가액과 보유 종목"
-        />
-        <EntryRow
-          href="/assets/stock/analysis/by-risk"
-          icon={Shield}
-          title="위험도별"
-          description="안전, 중립, 공격 자산 구성"
-        />
-      </GroupedList>
-    </ScreenSection>
+    <PageContainer maxWidth="default">
+      <ScreenSection>
+        <SectionHeader title="분석 관점" />
+        <GroupedList>
+          <EntryRow
+            href="/assets/stock/analysis/overview"
+            icon={BarChart3}
+            title="종합 분석"
+            description="평가금액, 수익률, 비중, 상위 종목"
+          />
+          <EntryRow
+            href="/assets/stock/analysis/by-owner"
+            icon={Users}
+            title="소유자별"
+            description="가족 구성원별 평가액과 보유 종목"
+          />
+          <EntryRow
+            href="/assets/stock/analysis/by-risk"
+            icon={Shield}
+            title="위험도별"
+            description="안전, 중립, 공격 자산 구성"
+          />
+        </GroupedList>
+      </ScreenSection>
+    </PageContainer>
   );
 }

--- a/app/(main)/assets/stock/holdings/page.tsx
+++ b/app/(main)/assets/stock/holdings/page.tsx
@@ -1,7 +1,7 @@
 import { Plus } from "lucide-react";
 import Link from "next/link";
 import { HoldingsList } from "@/components/holdings/HoldingsList";
-import { PageActions } from "@/components/layout";
+import { PageActions, PageContainer } from "@/components/layout";
 import { Button } from "@/components/ui/button";
 import { getAccounts } from "@/lib/api/account";
 import { getHouseholdWithMembers } from "@/lib/api/household";
@@ -18,9 +18,11 @@ export default async function HoldingsPage() {
 
   if (!householdId) {
     return (
-      <p className="text-center text-gray-500 py-12">
-        가구 정보를 찾을 수 없습니다.
-      </p>
+      <PageContainer maxWidth="default">
+        <p className="text-center text-gray-500 py-12">
+          가구 정보를 찾을 수 없습니다.
+        </p>
+      </PageContainer>
     );
   }
 
@@ -34,7 +36,7 @@ export default async function HoldingsPage() {
   const accounts = accountsData.map((a) => ({ id: a.id, name: a.name }));
 
   return (
-    <>
+    <PageContainer maxWidth="default">
       <PageActions>
         <Button asChild size="sm">
           <Link href="/assets/stock/transactions/new/full">
@@ -46,6 +48,6 @@ export default async function HoldingsPage() {
 
       {/* 보유 현황 목록 */}
       <HoldingsList members={members} accounts={accounts} />
-    </>
+    </PageContainer>
   );
 }

--- a/app/(main)/assets/stock/market/page.tsx
+++ b/app/(main)/assets/stock/market/page.tsx
@@ -2,11 +2,12 @@ import {
   MarketTrendSection,
   OverseasMarketTrendSection,
 } from "@/components/assets/stock";
+import { PageContainer } from "@/components/layout";
 import { ScreenSection, SectionHeader } from "@/components/layout/screen";
 
 export default function StockMarketPage() {
   return (
-    <>
+    <PageContainer maxWidth="default">
       <ScreenSection>
         <SectionHeader
           title="시장 동향"
@@ -15,6 +16,6 @@ export default function StockMarketPage() {
       </ScreenSection>
       <MarketTrendSection />
       <OverseasMarketTrendSection />
-    </>
+    </PageContainer>
   );
 }

--- a/app/(main)/assets/stock/page.tsx
+++ b/app/(main)/assets/stock/page.tsx
@@ -1,10 +1,11 @@
 import { MyStockSection, PortfolioNavSection } from "@/components/assets/stock";
+import { PageContainer } from "@/components/layout";
 
 export default function StockMainPage() {
   return (
-    <>
+    <PageContainer maxWidth="default">
       <MyStockSection />
       <PortfolioNavSection />
-    </>
+    </PageContainer>
   );
 }

--- a/app/(main)/assets/stock/records/page.tsx
+++ b/app/(main)/assets/stock/records/page.tsx
@@ -1,3 +1,4 @@
+import { PageContainer } from "@/components/layout";
 import { StockRecordsClient } from "@/components/transactions/records/StockRecordsClient";
 import { getKstToday } from "@/lib/date";
 import { normalizeRecordDate } from "@/lib/stock-records/records";
@@ -16,5 +17,9 @@ export default async function StockRecordsPage({
   const { date } = await searchParams;
   const today = getKstToday();
 
-  return <StockRecordsClient initialDate={normalizeRecordDate(date, today)} />;
+  return (
+    <PageContainer maxWidth="default">
+      <StockRecordsClient initialDate={normalizeRecordDate(date, today)} />
+    </PageContainer>
+  );
 }

--- a/app/(main)/assets/stock/settings/page.tsx
+++ b/app/(main)/assets/stock/settings/page.tsx
@@ -1,3 +1,4 @@
+import { PageContainer } from "@/components/layout";
 import { StockSettingsList } from "@/components/stock-settings/StockSettingsList";
 import { getUserHouseholdId } from "@/lib/api/invitation";
 import { getStockSettings } from "@/lib/api/stock-settings";
@@ -13,9 +14,11 @@ export default async function StockSettingsPage() {
 
   if (!householdId) {
     return (
-      <p className="text-center text-gray-500 py-12">
-        가구 정보를 찾을 수 없습니다.
-      </p>
+      <PageContainer maxWidth="medium">
+        <p className="text-center text-gray-500 py-12">
+          가구 정보를 찾을 수 없습니다.
+        </p>
+      </PageContainer>
     );
   }
 
@@ -25,9 +28,9 @@ export default async function StockSettingsPage() {
   });
 
   return (
-    <>
+    <PageContainer maxWidth="medium">
       {/* 종목 설정 목록 */}
       <StockSettingsList initialData={initialData} />
-    </>
+    </PageContainer>
   );
 }

--- a/app/(main)/assets/stock/transactions/[transactionId]/page.tsx
+++ b/app/(main)/assets/stock/transactions/[transactionId]/page.tsx
@@ -1,3 +1,4 @@
+import { PageContainer } from "@/components/layout";
 import { TransactionDetailClient } from "@/components/transactions/TransactionDetailClient";
 import { requireUser } from "@/lib/supabase/auth";
 
@@ -13,5 +14,9 @@ export default async function TransactionDetailPage({
   await requireUser();
   const { transactionId } = await params;
 
-  return <TransactionDetailClient transactionId={transactionId} />;
+  return (
+    <PageContainer maxWidth="medium">
+      <TransactionDetailClient transactionId={transactionId} />
+    </PageContainer>
+  );
 }

--- a/app/(main)/assets/stock/transactions/page.tsx
+++ b/app/(main)/assets/stock/transactions/page.tsx
@@ -1,6 +1,6 @@
 import { Plus } from "lucide-react";
 import Link from "next/link";
-import { PageActions } from "@/components/layout";
+import { PageActions, PageContainer } from "@/components/layout";
 import { TransactionList } from "@/components/transactions/TransactionList";
 import { Button } from "@/components/ui/button";
 import { getHouseholdWithMembers } from "@/lib/api/household";
@@ -17,9 +17,11 @@ export default async function TransactionsPage() {
 
   if (!householdId) {
     return (
-      <p className="text-center text-gray-500 py-12">
-        가구 정보를 찾을 수 없습니다.
-      </p>
+      <PageContainer maxWidth="default">
+        <p className="text-center text-gray-500 py-12">
+          가구 정보를 찾을 수 없습니다.
+        </p>
+      </PageContainer>
     );
   }
 
@@ -29,7 +31,7 @@ export default async function TransactionsPage() {
     household?.members.map((m) => ({ id: m.userId, name: m.name })) ?? [];
 
   return (
-    <>
+    <PageContainer maxWidth="default">
       <PageActions>
         <Button asChild size="sm">
           <Link href="/assets/stock/transactions/new/full">
@@ -41,6 +43,6 @@ export default async function TransactionsPage() {
 
       {/* 거래 내역 목록 */}
       <TransactionList members={members} currentUserId={user.id} />
-    </>
+    </PageContainer>
   );
 }

--- a/app/(main)/home/page.tsx
+++ b/app/(main)/home/page.tsx
@@ -1,5 +1,10 @@
 import { HomePageClient } from "@/components/home";
+import { PageContainer } from "@/components/layout";
 
 export default function HomePage() {
-  return <HomePageClient />;
+  return (
+    <PageContainer maxWidth="default">
+      <HomePageClient />
+    </PageContainer>
+  );
 }

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -23,9 +23,7 @@ export default function MainLayout({
         <div className="size-full overflow-y-scroll overflow-x-clip relative z-0">
           <PageTransitionProvider>
             <PageTransition className="flex-1 pb-[calc(6rem+env(safe-area-inset-bottom))] pt-14 lg:pb-4 lg:pt-0">
-              <div className="p-4">
-                <div className="max-w-4xl mx-auto space-y-6">{children}</div>
-              </div>
+              <div className="px-4 py-4 sm:px-6 lg:px-8">{children}</div>
             </PageTransition>
           </PageTransitionProvider>
         </div>

--- a/app/(main)/ledger/analysis/by-category/page.tsx
+++ b/app/(main)/ledger/analysis/by-category/page.tsx
@@ -1,3 +1,4 @@
+import { PageContainer } from "@/components/layout";
 import { ByCategoryClient } from "@/components/ledger/analysis/ByCategoryClient";
 import type { StatsScope } from "@/lib/api/ledger-stats";
 
@@ -8,5 +9,9 @@ export default async function ByCategoryPage({
 }) {
   const { scope: rawScope } = await searchParams;
   const scope = (rawScope === "personal" ? "personal" : "shared") as StatsScope;
-  return <ByCategoryClient scope={scope} />;
+  return (
+    <PageContainer maxWidth="default">
+      <ByCategoryClient scope={scope} />
+    </PageContainer>
+  );
 }

--- a/app/(main)/ledger/analysis/by-member/page.tsx
+++ b/app/(main)/ledger/analysis/by-member/page.tsx
@@ -1,5 +1,10 @@
+import { PageContainer } from "@/components/layout";
 import { ByMemberClient } from "@/components/ledger/analysis/ByMemberClient";
 
 export default function ByMemberPage() {
-  return <ByMemberClient />;
+  return (
+    <PageContainer maxWidth="default">
+      <ByMemberClient />
+    </PageContainer>
+  );
 }

--- a/app/(main)/ledger/analysis/by-payment-method/page.tsx
+++ b/app/(main)/ledger/analysis/by-payment-method/page.tsx
@@ -1,3 +1,4 @@
+import { PageContainer } from "@/components/layout";
 import { ByPaymentMethodClient } from "@/components/ledger/analysis/ByPaymentMethodClient";
 import type { StatsScope } from "@/lib/api/ledger-stats";
 
@@ -8,5 +9,9 @@ export default async function ByPaymentMethodPage({
 }) {
   const { scope: rawScope } = await searchParams;
   const scope = (rawScope === "personal" ? "personal" : "shared") as StatsScope;
-  return <ByPaymentMethodClient scope={scope} />;
+  return (
+    <PageContainer maxWidth="default">
+      <ByPaymentMethodClient scope={scope} />
+    </PageContainer>
+  );
 }

--- a/app/(main)/ledger/analysis/daily/page.tsx
+++ b/app/(main)/ledger/analysis/daily/page.tsx
@@ -1,3 +1,4 @@
+import { PageContainer } from "@/components/layout";
 import { DailyClient } from "@/components/ledger/analysis/DailyClient";
 import type { StatsScope } from "@/lib/api/ledger-stats";
 
@@ -8,5 +9,9 @@ export default async function DailyPage({
 }) {
   const { scope: rawScope } = await searchParams;
   const scope = (rawScope === "personal" ? "personal" : "shared") as StatsScope;
-  return <DailyClient scope={scope} />;
+  return (
+    <PageContainer maxWidth="default">
+      <DailyClient scope={scope} />
+    </PageContainer>
+  );
 }

--- a/app/(main)/ledger/analysis/page.tsx
+++ b/app/(main)/ledger/analysis/page.tsx
@@ -7,6 +7,7 @@ import {
   Users,
 } from "lucide-react";
 import Link from "next/link";
+import { PageContainer } from "@/components/layout";
 import { LedgerAnalysisOverview } from "@/components/ledger/analysis/LedgerAnalysisOverview";
 import { ScopeTabs } from "@/components/ledger/analysis/ScopeTabs";
 import { getKstNow } from "@/lib/date";
@@ -87,7 +88,7 @@ export default async function LedgerAnalysisPage({
   );
 
   return (
-    <>
+    <PageContainer maxWidth="default">
       <ScopeTabs scope={scope} />
 
       <LedgerAnalysisOverview year={year} month={month} scope={scope} />
@@ -126,6 +127,6 @@ export default async function LedgerAnalysisPage({
           },
         )}
       </div>
-    </>
+    </PageContainer>
   );
 }

--- a/app/(main)/ledger/analysis/trend/page.tsx
+++ b/app/(main)/ledger/analysis/trend/page.tsx
@@ -1,3 +1,4 @@
+import { PageContainer } from "@/components/layout";
 import { TrendClient } from "@/components/ledger/analysis/TrendClient";
 import type { StatsScope } from "@/lib/api/ledger-stats";
 
@@ -8,5 +9,9 @@ export default async function TrendPage({
 }) {
   const { scope: rawScope } = await searchParams;
   const scope = (rawScope === "personal" ? "personal" : "shared") as StatsScope;
-  return <TrendClient scope={scope} />;
+  return (
+    <PageContainer maxWidth="default">
+      <TrendClient scope={scope} />
+    </PageContainer>
+  );
 }

--- a/app/(main)/ledger/page.tsx
+++ b/app/(main)/ledger/page.tsx
@@ -1,4 +1,5 @@
 import { CalendarDays, CreditCard, PieChart, Plus, Tags } from "lucide-react";
+import { PageContainer } from "@/components/layout";
 import {
   EntryRow,
   GroupedList,
@@ -17,7 +18,7 @@ export default async function LedgerPage() {
   const month = now.getMonth() + 1;
 
   return (
-    <>
+    <PageContainer maxWidth="default">
       <LedgerSummarySection year={year} month={month} />
 
       <ScreenSection>
@@ -67,6 +68,6 @@ export default async function LedgerPage() {
           />
         </GroupedList>
       </ScreenSection>
-    </>
+    </PageContainer>
   );
 }

--- a/app/(main)/ledger/records/[entryId]/page.tsx
+++ b/app/(main)/ledger/records/[entryId]/page.tsx
@@ -1,3 +1,4 @@
+import { PageContainer } from "@/components/layout";
 import { LedgerEntryDetailClient } from "@/components/ledger/records/LedgerEntryDetailClient";
 import { requireUser } from "@/lib/supabase/auth";
 
@@ -13,5 +14,9 @@ export default async function LedgerEntryDetailPage({
   await requireUser();
   const { entryId } = await params;
 
-  return <LedgerEntryDetailClient entryId={entryId} />;
+  return (
+    <PageContainer maxWidth="medium">
+      <LedgerEntryDetailClient entryId={entryId} />
+    </PageContainer>
+  );
 }

--- a/app/(main)/ledger/records/page.tsx
+++ b/app/(main)/ledger/records/page.tsx
@@ -1,3 +1,4 @@
+import { PageContainer } from "@/components/layout";
 import { LedgerRecordsClient } from "@/components/ledger/records/LedgerRecordsClient";
 import { getKstToday } from "@/lib/date";
 import { normalizeRecordDate } from "@/lib/stock-records/records";
@@ -16,5 +17,9 @@ export default async function LedgerRecordsPage({
   const { date } = await searchParams;
   const today = getKstToday();
 
-  return <LedgerRecordsClient initialDate={normalizeRecordDate(date, today)} />;
+  return (
+    <PageContainer maxWidth="default">
+      <LedgerRecordsClient initialDate={normalizeRecordDate(date, today)} />
+    </PageContainer>
+  );
 }

--- a/app/(main)/notifications/page.tsx
+++ b/app/(main)/notifications/page.tsx
@@ -6,7 +6,7 @@ export default async function NotificationsPage() {
   await requireUser();
 
   return (
-    <PageContainer maxWidth="narrow">
+    <PageContainer maxWidth="medium">
       <NotificationInboxClient />
     </PageContainer>
   );

--- a/app/(main)/notifications/requests/[id]/page.tsx
+++ b/app/(main)/notifications/requests/[id]/page.tsx
@@ -1,3 +1,4 @@
+import { PageContainer } from "@/components/layout";
 import { RecordChangeRequestDetailClient } from "@/components/notifications/RecordChangeRequestDetailClient";
 
 interface RecordChangeRequestDetailPageProps {
@@ -9,5 +10,9 @@ export default async function RecordChangeRequestDetailPage({
 }: RecordChangeRequestDetailPageProps) {
   const { id } = await params;
 
-  return <RecordChangeRequestDetailClient requestId={id} />;
+  return (
+    <PageContainer maxWidth="medium">
+      <RecordChangeRequestDetailClient requestId={id} />
+    </PageContainer>
+  );
 }

--- a/app/(main)/settings/notifications/page.tsx
+++ b/app/(main)/settings/notifications/page.tsx
@@ -6,7 +6,7 @@ export default async function NotificationSettingsPage() {
   await requireUser();
 
   return (
-    <PageContainer>
+    <PageContainer maxWidth="medium">
       <NotificationSettingsClient />
     </PageContainer>
   );

--- a/app/(main)/settings/page.tsx
+++ b/app/(main)/settings/page.tsx
@@ -7,7 +7,7 @@ const APP_VERSION = "0.1.0";
 export default function SettingsPage() {
   const mcpEnabled = isMcpEnabled();
   return (
-    <PageContainer maxWidth="narrow">
+    <PageContainer maxWidth="medium">
       {/* 설정 메뉴 */}
       <SettingsMenu mcpEnabled={mcpEnabled} />
 

--- a/components/layout/PageContainer.test.tsx
+++ b/components/layout/PageContainer.test.tsx
@@ -1,0 +1,44 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PageContainer } from "./PageContainer";
+
+describe("PageContainer", () => {
+  it("renders default width as the standard app content container", () => {
+    const { container } = render(
+      <PageContainer maxWidth="default">
+        <div>Content</div>
+      </PageContainer>,
+    );
+    const element = container.firstElementChild;
+    expect(element).toBeInTheDocument();
+    expect(element?.className).toContain("mx-auto");
+    expect(element?.className).toContain("w-full");
+    expect(element?.className).toContain("max-w-5xl");
+    expect(element?.className).toContain("space-y-6");
+  });
+
+  it("renders medium width as the compact management/detail container", () => {
+    const { container } = render(
+      <PageContainer maxWidth="medium">
+        <div>Content</div>
+      </PageContainer>,
+    );
+    const element = container.firstElementChild;
+    expect(element).toBeInTheDocument();
+    expect(element?.className).toContain("max-w-3xl");
+    expect(element?.className).not.toContain("max-w-5xl");
+    expect(element?.className).not.toContain("max-w-xl");
+  });
+
+  it("renders narrow width as the task/form container", () => {
+    const { container } = render(
+      <PageContainer maxWidth="narrow">
+        <div>Content</div>
+      </PageContainer>,
+    );
+    const element = container.firstElementChild;
+    expect(element).toBeInTheDocument();
+    expect(element?.className).toContain("max-w-xl");
+    expect(element?.className).not.toContain("max-w-3xl");
+  });
+});

--- a/components/layout/PageContainer.tsx
+++ b/components/layout/PageContainer.tsx
@@ -1,9 +1,6 @@
-import { cn } from "@/lib/utils/cn";
-
 interface PageContainerProps {
   children: React.ReactNode;
   maxWidth?: "default" | "narrow" | "medium";
-  className?: string;
 }
 
 const maxWidthClasses = {
@@ -15,16 +12,9 @@ const maxWidthClasses = {
 export function PageContainer({
   children,
   maxWidth = "default",
-  className,
 }: PageContainerProps) {
   return (
-    <div
-      className={cn(
-        "mx-auto w-full space-y-6",
-        maxWidthClasses[maxWidth],
-        className,
-      )}
-    >
+    <div className={`mx-auto w-full space-y-6 ${maxWidthClasses[maxWidth]}`}>
       {children}
     </div>
   );

--- a/components/layout/PageContainer.tsx
+++ b/components/layout/PageContainer.tsx
@@ -1,23 +1,31 @@
+import { cn } from "@/lib/utils/cn";
+
 interface PageContainerProps {
   children: React.ReactNode;
   maxWidth?: "default" | "narrow" | "medium";
+  className?: string;
 }
 
 const maxWidthClasses = {
-  default: "",
-  narrow: "max-w-lg mx-auto",
-  medium: "max-w-2xl mx-auto",
+  default: "max-w-5xl",
+  narrow: "max-w-xl",
+  medium: "max-w-3xl",
 };
 
 export function PageContainer({
   children,
   maxWidth = "default",
+  className,
 }: PageContainerProps) {
-  if (maxWidth === "default") {
-    return <>{children}</>;
-  }
-
   return (
-    <div className={`${maxWidthClasses[maxWidth]} space-y-6`}>{children}</div>
+    <div
+      className={cn(
+        "mx-auto w-full space-y-6",
+        maxWidthClasses[maxWidth],
+        className,
+      )}
+    >
+      {children}
+    </div>
   );
 }


### PR DESCRIPTION
### Summary
This PR centralizes the authenticated app content width policy into the PageContainer component, normalizing widths for settings, details, calendar pages, and task composers. It also removes the hidden max-w-4xl constraint from the main layout.

### Key Changes
- Updated `PageContainer` to handle standard width presets (`default` = `max-w-5xl`, `medium` = `max-w-3xl`, `narrow` = `max-w-xl`).
- Removed global max-width constraint from `app/(main)/layout.tsx`.
- Wrapped and normalized all main pages with explicit `PageContainer` widths matching the planned mapping.
- Updated `.claude/docs/CONVENTIONS_FE.md` with the new PageContainer width rules and PC 2-column layout guidelines.

### Verification
- All PageContainer unit tests, type checks, Biome checks, and Next.js production builds have passed successfully.