### PR TITLE
Refactor UIs to use Screen primitives and unify add action placement (#391)

### DIFF
--- a/app/(main)/assets/accounts/page.tsx
+++ b/app/(main)/assets/accounts/page.tsx
@@ -1,27 +1,22 @@
 import { Plus } from "lucide-react";
 import Link from "next/link";
 import { AccountList } from "@/components/accounts";
-import { PageActions, PageContainer } from "@/components/layout";
+import { PageContainer } from "@/components/layout";
 import { Button } from "@/components/ui/button";
 
 export default function AccountsPage() {
   return (
     <PageContainer maxWidth="medium">
-      <PageActions>
-        <Button size="sm" asChild>
-          <Link href="/assets/accounts/new">
-            <Plus className="w-4 h-4 mr-1" />
-            계좌 추가
-          </Link>
-        </Button>
-      </PageActions>
-
-      <div className="space-y-8">
-        <section>
-          <h2 className="text-base font-semibold mb-3">자산 계좌</h2>
-          <AccountList />
-        </section>
-      </div>
+      <AccountList
+        action={
+          <Button size="sm" asChild>
+            <Link href="/assets/accounts/new">
+              <Plus className="w-4 h-4 mr-1" />
+              계좌 추가
+            </Link>
+          </Button>
+        }
+      />
     </PageContainer>
   );
 }

--- a/app/(main)/assets/stock/accounts/page.tsx
+++ b/app/(main)/assets/stock/accounts/page.tsx
@@ -3,7 +3,7 @@
 import { Plus } from "lucide-react";
 import { useState } from "react";
 import { AccountFormDialog, AccountList } from "@/components/accounts";
-import { PageActions, PageContainer } from "@/components/layout";
+import { PageContainer } from "@/components/layout";
 import { Button } from "@/components/ui/button";
 
 export default function AccountsPage() {
@@ -11,14 +11,15 @@ export default function AccountsPage() {
 
   return (
     <PageContainer maxWidth="medium">
-      <PageActions>
-        <Button size="sm" onClick={() => setIsFormOpen(true)}>
-          <Plus className="w-4 h-4 mr-1" />
-          계좌 추가
-        </Button>
-      </PageActions>
-
-      <AccountList filter="investment" />
+      <AccountList
+        filter="investment"
+        action={
+          <Button size="sm" onClick={() => setIsFormOpen(true)}>
+            <Plus className="w-4 h-4 mr-1" />
+            계좌 추가
+          </Button>
+        }
+      />
 
       <AccountFormDialog open={isFormOpen} onOpenChange={setIsFormOpen} />
     </PageContainer>

--- a/app/(main)/assets/stock/holdings/page.tsx
+++ b/app/(main)/assets/stock/holdings/page.tsx
@@ -1,7 +1,7 @@
 import { Plus } from "lucide-react";
 import Link from "next/link";
 import { HoldingsList } from "@/components/holdings/HoldingsList";
-import { PageActions, PageContainer } from "@/components/layout";
+import { PageContainer } from "@/components/layout";
 import { Button } from "@/components/ui/button";
 import { getAccounts } from "@/lib/api/account";
 import { getHouseholdWithMembers } from "@/lib/api/household";
@@ -37,17 +37,19 @@ export default async function HoldingsPage() {
 
   return (
     <PageContainer maxWidth="default">
-      <PageActions>
-        <Button asChild size="sm">
-          <Link href="/assets/stock/transactions/new/full">
-            <Plus className="w-4 h-4 mr-1" />
-            거래 추가
-          </Link>
-        </Button>
-      </PageActions>
-
       {/* 보유 현황 목록 */}
-      <HoldingsList members={members} accounts={accounts} />
+      <HoldingsList
+        members={members}
+        accounts={accounts}
+        action={
+          <Button asChild size="sm">
+            <Link href="/assets/stock/transactions/new/full">
+              <Plus className="w-4 h-4 mr-1" />
+              거래 추가
+            </Link>
+          </Button>
+        }
+      />
     </PageContainer>
   );
 }

--- a/app/(main)/assets/stock/transactions/page.tsx
+++ b/app/(main)/assets/stock/transactions/page.tsx
@@ -1,6 +1,6 @@
 import { Plus } from "lucide-react";
 import Link from "next/link";
-import { PageActions, PageContainer } from "@/components/layout";
+import { PageContainer } from "@/components/layout";
 import { TransactionList } from "@/components/transactions/TransactionList";
 import { Button } from "@/components/ui/button";
 import { getHouseholdWithMembers } from "@/lib/api/household";
@@ -32,17 +32,19 @@ export default async function TransactionsPage() {
 
   return (
     <PageContainer maxWidth="default">
-      <PageActions>
-        <Button asChild size="sm">
-          <Link href="/assets/stock/transactions/new/full">
-            <Plus className="w-4 h-4 mr-1" />
-            거래 추가
-          </Link>
-        </Button>
-      </PageActions>
-
       {/* 거래 내역 목록 */}
-      <TransactionList members={members} currentUserId={user.id} />
+      <TransactionList
+        members={members}
+        currentUserId={user.id}
+        action={
+          <Button asChild size="sm">
+            <Link href="/assets/stock/transactions/new/full">
+              <Plus className="w-4 h-4 mr-1" />
+              거래 추가
+            </Link>
+          </Button>
+        }
+      />
     </PageContainer>
   );
 }

--- a/app/(main)/ledger/payment-methods/page.tsx
+++ b/app/(main)/ledger/payment-methods/page.tsx
@@ -1,26 +1,22 @@
 import { Plus } from "lucide-react";
 import Link from "next/link";
 import { PaymentMethodList } from "@/components/accounts";
-import { PageActions, PageContainer } from "@/components/layout";
+import { PageContainer } from "@/components/layout";
 import { Button } from "@/components/ui/button";
 
 export default function PaymentMethodsPage() {
   return (
     <PageContainer maxWidth="medium">
-      <PageActions>
-        <Button size="sm" asChild>
-          <Link href="/ledger/payment-methods/new?returnUrl=/ledger/payment-methods">
-            <Plus className="w-4 h-4 mr-1" />
-            결제수단 추가
-          </Link>
-        </Button>
-      </PageActions>
-
-      <div className="space-y-8">
-        <section>
-          <PaymentMethodList />
-        </section>
-      </div>
+      <PaymentMethodList
+        action={
+          <Button size="sm" asChild>
+            <Link href="/ledger/payment-methods/new?returnUrl=/ledger/payment-methods">
+              <Plus className="w-4 h-4 mr-1" />
+              결제수단 추가
+            </Link>
+          </Button>
+        }
+      />
     </PageContainer>
   );
 }

--- a/components/accounts/AccountList.test.tsx
+++ b/components/accounts/AccountList.test.tsx
@@ -40,6 +40,23 @@ const account: AccountWithOwner = {
   updatedAt: "2026-05-01T00:00:00.000Z",
 };
 
+const bankAccount: AccountWithOwner = {
+  id: "account-2",
+  householdId: "household-1",
+  ownerId: "user-1",
+  ownerName: "진호",
+  name: "카카오뱅크",
+  broker: "카카오뱅크",
+  lastFour: "5678",
+  accountType: "checking",
+  category: "bank",
+  balance: null,
+  balanceUpdatedAt: null,
+  memo: null,
+  createdAt: "2026-05-01T00:00:00.000Z",
+  updatedAt: "2026-05-01T00:00:00.000Z",
+};
+
 describe("AccountList", () => {
   it("renders grouped account rows with bank/investment grouping", () => {
     mocks.accounts = [account];
@@ -52,6 +69,23 @@ describe("AccountList", () => {
     expect(screen.getByText("NH투자증권")).toBeInTheDocument();
     expect(screen.getByText("ISA")).toBeInTheDocument();
     expect(screen.getByText("끝 1234")).toBeInTheDocument();
+  });
+
+  it("renders a single section header for unfiltered list with both bank and investment subgroups", () => {
+    mocks.accounts = [bankAccount, account];
+    const action = <button type="button">계좌 추가</button>;
+
+    render(<AccountList title="계좌" action={action} />);
+
+    // Verify there is only one "계좌" heading and one "계좌 추가" button
+    expect(screen.getAllByRole("heading", { name: "계좌" })).toHaveLength(1);
+    expect(screen.getAllByRole("button", { name: "계좌 추가" })).toHaveLength(
+      1,
+    );
+
+    // Verify both subgroup headings are visible
+    expect(screen.getByText("은행 계좌")).toBeInTheDocument();
+    expect(screen.getByText("투자 계좌")).toBeInTheDocument();
   });
 
   it("renders screen-state when empty", () => {

--- a/components/accounts/AccountList.test.tsx
+++ b/components/accounts/AccountList.test.tsx
@@ -61,7 +61,7 @@ describe("AccountList", () => {
   it("renders grouped account rows with bank/investment grouping", () => {
     mocks.accounts = [account];
 
-    render(<AccountList />);
+    const { container } = render(<AccountList />);
 
     expect(screen.queryByRole("table")).not.toBeInTheDocument();
     expect(screen.getByText("투자 계좌")).toBeInTheDocument();
@@ -69,6 +69,11 @@ describe("AccountList", () => {
     expect(screen.getByText("NH투자증권")).toBeInTheDocument();
     expect(screen.getByText("ISA")).toBeInTheDocument();
     expect(screen.getByText("끝 1234")).toBeInTheDocument();
+
+    // Assert no credit card icon is rendered
+    expect(
+      container.querySelector(".lucide-credit-card"),
+    ).not.toBeInTheDocument();
   });
 
   it("renders a single section header for unfiltered list with both bank and investment subgroups", () => {

--- a/components/accounts/AccountList.test.tsx
+++ b/components/accounts/AccountList.test.tsx
@@ -41,7 +41,7 @@ const account: AccountWithOwner = {
 };
 
 describe("AccountList", () => {
-  it("renders accounts as grouped collection cards instead of a table", () => {
+  it("renders grouped account rows with bank/investment grouping", () => {
     mocks.accounts = [account];
 
     render(<AccountList />);
@@ -52,5 +52,14 @@ describe("AccountList", () => {
     expect(screen.getByText("NH투자증권")).toBeInTheDocument();
     expect(screen.getByText("ISA")).toBeInTheDocument();
     expect(screen.getByText("끝 1234")).toBeInTheDocument();
+  });
+
+  it("renders screen-state when empty", () => {
+    mocks.accounts = [];
+
+    render(<AccountList />);
+
+    expect(screen.getByTestId("screen-state")).toBeInTheDocument();
+    expect(screen.getByText("등록된 계좌가 없습니다.")).toBeInTheDocument();
   });
 });

--- a/components/accounts/AccountList.tsx
+++ b/components/accounts/AccountList.tsx
@@ -10,6 +10,12 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
+import {
+  GroupedList,
+  ScreenSection,
+  ScreenState,
+  SectionHeader,
+} from "@/components/layout/screen";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -53,6 +59,8 @@ function isInvestmentAccountType(
 
 interface AccountListProps {
   filter?: "bank" | "investment";
+  title?: React.ReactNode;
+  action?: React.ReactNode;
 }
 
 interface AccountCollectionProps {
@@ -71,7 +79,7 @@ function AccountCollection({
   onDelete,
 }: AccountCollectionProps) {
   return (
-    <div className="overflow-hidden rounded-2xl bg-white shadow-sm ring-1 ring-gray-100">
+    <GroupedList>
       {accounts.map((account) => {
         const isOwner = currentUserId === account.ownerId;
         const accountTypeLabel = account.accountType
@@ -84,7 +92,7 @@ function AccountCollection({
         return (
           <article
             key={account.id}
-            className="flex min-h-[96px] items-center gap-3 border-gray-100 border-t px-4 py-4 first:border-t-0 sm:px-5"
+            className="flex min-h-[96px] items-center gap-3 px-4 py-3.5 sm:px-5"
           >
             <Link
               href={`/assets/accounts/${account.id}`}
@@ -158,11 +166,11 @@ function AccountCollection({
           </article>
         );
       })}
-    </div>
+    </GroupedList>
   );
 }
 
-export function AccountList({ filter }: AccountListProps) {
+export function AccountList({ filter, title, action }: AccountListProps) {
   const { data: accounts, isLoading, error } = useAccounts();
   const { userId: currentUserId } = useCurrentUserId();
 
@@ -196,23 +204,12 @@ export function AccountList({ filter }: AccountListProps) {
   };
 
   if (isLoading) {
-    return (
-      <div className="bg-white rounded-2xl shadow-sm p-8">
-        <div className="animate-pulse space-y-4">
-          <div className="h-4 bg-gray-200 rounded w-1/4" />
-          <div className="h-10 bg-gray-100 rounded" />
-          <div className="h-10 bg-gray-100 rounded" />
-          <div className="h-10 bg-gray-100 rounded" />
-        </div>
-      </div>
-    );
+    return <ScreenState type="loading" title="계좌 목록을 불러오는 중입니다" />;
   }
 
   if (error) {
     return (
-      <div className="bg-white rounded-2xl shadow-sm p-8 text-center">
-        <p className="text-destructive">계좌 목록을 불러오는데 실패했습니다.</p>
-      </div>
+      <ScreenState type="error" title="계좌 목록을 불러오는데 실패했습니다" />
     );
   }
 
@@ -228,17 +225,26 @@ export function AccountList({ filter }: AccountListProps) {
 
     if (filtered.length === 0) {
       return (
-        <div className="bg-white rounded-2xl shadow-sm p-8 text-center">
-          <p className="text-gray-500">등록된 계좌가 없습니다.</p>
-          <p className="text-sm text-gray-400 mt-1">
-            상단의 &quot;계좌 추가&quot; 버튼으로 계좌를 등록해보세요.
-          </p>
-        </div>
+        <ScreenSection>
+          <SectionHeader
+            title={title ?? (filter === "bank" ? "은행 계좌" : "투자 계좌")}
+            action={action}
+          />
+          <ScreenState
+            type="empty"
+            title="등록된 계좌가 없습니다."
+            description="상단의 &quot;계좌 추가&quot; 버튼으로 계좌를 등록해보세요."
+          />
+        </ScreenSection>
       );
     }
 
     return (
-      <>
+      <ScreenSection>
+        <SectionHeader
+          title={title ?? (filter === "bank" ? "은행 계좌" : "투자 계좌")}
+          action={action}
+        />
         <AccountCollection
           accounts={filtered}
           currentUserId={currentUserId}
@@ -258,7 +264,7 @@ export function AccountList({ filter }: AccountListProps) {
           open={!!deletingAccount}
           onOpenChange={(open) => !open && setDeletingAccount(null)}
         />
-      </>
+      </ScreenSection>
     );
   }
 
@@ -272,23 +278,26 @@ export function AccountList({ filter }: AccountListProps) {
 
   if (!hasAnyAccount) {
     return (
-      <div className="bg-white rounded-2xl shadow-sm p-8 text-center">
-        <p className="text-gray-500">등록된 계좌가 없습니다.</p>
-        <p className="text-sm text-gray-400 mt-1">
-          상단의 &quot;계좌 추가&quot; 버튼으로 계좌를 등록해보세요.
-        </p>
-      </div>
+      <ScreenSection>
+        <SectionHeader title={title ?? "계좌"} action={action} />
+        <ScreenState
+          type="empty"
+          title="등록된 계좌가 없습니다."
+          description="상단의 &quot;계좌 추가&quot; 버튼으로 계좌를 등록해보세요."
+        />
+      </ScreenSection>
     );
   }
 
+  const bankAction = bankAccounts.length > 0 ? action : undefined;
+  const investmentAction = bankAccounts.length === 0 ? action : undefined;
+
   return (
     <>
-      <div className="space-y-4">
+      <div className="space-y-6">
         {bankAccounts.length > 0 && (
-          <div>
-            <h3 className="text-sm font-medium text-gray-500 mb-2 px-1">
-              은행 계좌
-            </h3>
+          <ScreenSection>
+            <SectionHeader title="은행 계좌" action={bankAction} />
             <AccountCollection
               accounts={bankAccounts}
               currentUserId={currentUserId}
@@ -296,22 +305,22 @@ export function AccountList({ filter }: AccountListProps) {
               onEdit={handleEdit}
               onDelete={handleDelete}
             />
-          </div>
+          </ScreenSection>
         )}
 
         {investmentAccounts.length > 0 && (
-          <div>
-            <h3 className="text-sm font-medium text-gray-500 mb-2 px-1">
-              투자 계좌
-            </h3>
-            <AccountCollection
-              accounts={investmentAccounts}
-              currentUserId={currentUserId}
-              category="investment"
-              onEdit={handleEdit}
-              onDelete={handleDelete}
-            />
-          </div>
+          <ScreenSection>
+            <ScreenSection>
+              <SectionHeader title="투자 계좌" action={investmentAction} />
+              <AccountCollection
+                accounts={investmentAccounts}
+                currentUserId={currentUserId}
+                category="investment"
+                onEdit={handleEdit}
+                onDelete={handleDelete}
+              />
+            </ScreenSection>
+          </ScreenSection>
         )}
       </div>
 

--- a/components/accounts/AccountList.tsx
+++ b/components/accounts/AccountList.tsx
@@ -289,15 +289,16 @@ export function AccountList({ filter, title, action }: AccountListProps) {
     );
   }
 
-  const bankAction = bankAccounts.length > 0 ? action : undefined;
-  const investmentAction = bankAccounts.length === 0 ? action : undefined;
-
   return (
-    <>
+    <ScreenSection>
+      <SectionHeader title={title ?? "계좌"} action={action} />
+
       <div className="space-y-6">
         {bankAccounts.length > 0 && (
-          <ScreenSection>
-            <SectionHeader title="은행 계좌" action={bankAction} />
+          <div className="space-y-2">
+            <h3 className="text-sm font-medium text-gray-500 px-1">
+              은행 계좌
+            </h3>
             <AccountCollection
               accounts={bankAccounts}
               currentUserId={currentUserId}
@@ -305,22 +306,22 @@ export function AccountList({ filter, title, action }: AccountListProps) {
               onEdit={handleEdit}
               onDelete={handleDelete}
             />
-          </ScreenSection>
+          </div>
         )}
 
         {investmentAccounts.length > 0 && (
-          <ScreenSection>
-            <ScreenSection>
-              <SectionHeader title="투자 계좌" action={investmentAction} />
-              <AccountCollection
-                accounts={investmentAccounts}
-                currentUserId={currentUserId}
-                category="investment"
-                onEdit={handleEdit}
-                onDelete={handleDelete}
-              />
-            </ScreenSection>
-          </ScreenSection>
+          <div className="space-y-2">
+            <h3 className="text-sm font-medium text-gray-500 px-1">
+              투자 계좌
+            </h3>
+            <AccountCollection
+              accounts={investmentAccounts}
+              currentUserId={currentUserId}
+              category="investment"
+              onEdit={handleEdit}
+              onDelete={handleDelete}
+            />
+          </div>
         )}
       </div>
 
@@ -336,6 +337,6 @@ export function AccountList({ filter, title, action }: AccountListProps) {
         open={!!deletingAccount}
         onOpenChange={(open) => !open && setDeletingAccount(null)}
       />
-    </>
+    </ScreenSection>
   );
 }

--- a/components/accounts/AccountList.tsx
+++ b/components/accounts/AccountList.tsx
@@ -2,7 +2,6 @@
 
 import {
   Building2,
-  CreditCard,
   MoreHorizontal,
   Pencil,
   Trash2,
@@ -98,10 +97,6 @@ function AccountCollection({
               href={`/assets/accounts/${account.id}`}
               className="flex min-w-0 flex-1 items-center gap-3"
             >
-              <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-gray-100 text-gray-500">
-                <CreditCard className="size-5" />
-              </div>
-
               <div className="min-w-0 flex-1">
                 <div className="flex min-w-0 flex-wrap items-center gap-2">
                   <h4 className="truncate font-semibold text-gray-900">

--- a/components/accounts/PaymentMethodList.test.tsx
+++ b/components/accounts/PaymentMethodList.test.tsx
@@ -47,7 +47,7 @@ const paymentMethod: PaymentMethodWithDetails = {
 };
 
 describe("PaymentMethodList", () => {
-  it("renders payment methods as collection cards instead of a table", () => {
+  it("renders payment methods as grouped rows with details", () => {
     mocks.paymentMethods = [paymentMethod];
 
     render(<PaymentMethodList />);
@@ -58,5 +58,14 @@ describe("PaymentMethodList", () => {
     expect(screen.getByText("Hyundai")).toBeInTheDocument();
     expect(screen.getByText("1234")).toBeInTheDocument();
     expect(screen.getByText("생활비 통장")).toBeInTheDocument();
+  });
+
+  it("renders screen-state when empty", () => {
+    mocks.paymentMethods = [];
+
+    render(<PaymentMethodList />);
+
+    expect(screen.getByTestId("screen-state")).toBeInTheDocument();
+    expect(screen.getByText("등록된 결제수단이 없습니다.")).toBeInTheDocument();
   });
 });

--- a/components/accounts/PaymentMethodList.test.tsx
+++ b/components/accounts/PaymentMethodList.test.tsx
@@ -50,7 +50,7 @@ describe("PaymentMethodList", () => {
   it("renders payment methods as grouped rows with details", () => {
     mocks.paymentMethods = [paymentMethod];
 
-    render(<PaymentMethodList />);
+    const { container } = render(<PaymentMethodList />);
 
     expect(screen.queryByRole("table")).not.toBeInTheDocument();
     expect(screen.getByText("현대카드")).toBeInTheDocument();
@@ -58,6 +58,11 @@ describe("PaymentMethodList", () => {
     expect(screen.getByText("Hyundai")).toBeInTheDocument();
     expect(screen.getByText("1234")).toBeInTheDocument();
     expect(screen.getByText("생활비 통장")).toBeInTheDocument();
+
+    // Assert no credit card icon is rendered
+    expect(
+      container.querySelector(".lucide-credit-card"),
+    ).not.toBeInTheDocument();
   });
 
   it("renders screen-state when empty", () => {

--- a/components/accounts/PaymentMethodList.tsx
+++ b/components/accounts/PaymentMethodList.tsx
@@ -10,6 +10,12 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
+import {
+  GroupedList,
+  ScreenSection,
+  ScreenState,
+  SectionHeader,
+} from "@/components/layout/screen";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -38,7 +44,11 @@ const AUXILIARY_PAYMENT_METHOD_TYPES = new Set([
   "cash",
 ]);
 
-export function PaymentMethodList() {
+interface PaymentMethodListProps {
+  action?: React.ReactNode;
+}
+
+export function PaymentMethodList({ action }: PaymentMethodListProps) {
   const { data: paymentMethods, isLoading, error } = usePaymentMethods();
   const { userId: currentUserId } = useCurrentUserId();
 
@@ -64,47 +74,49 @@ export function PaymentMethodList() {
 
   if (isLoading) {
     return (
-      <div className="bg-white rounded-2xl shadow-sm p-8">
-        <div className="animate-pulse space-y-4">
-          <div className="h-4 bg-gray-200 rounded w-1/4" />
-          <div className="h-10 bg-gray-100 rounded" />
-          <div className="h-10 bg-gray-100 rounded" />
-        </div>
-      </div>
+      <ScreenSection>
+        <SectionHeader title="결제수단" action={action} />
+        <ScreenState type="loading" title="결제수단 목록을 불러오는 중입니다" />
+      </ScreenSection>
     );
   }
 
   if (error) {
     return (
-      <div className="bg-white rounded-2xl shadow-sm p-8 text-center">
-        <p className="text-destructive">
-          결제수단 목록을 불러오는데 실패했습니다.
-        </p>
-      </div>
+      <ScreenSection>
+        <SectionHeader title="결제수단" action={action} />
+        <ScreenState
+          type="error"
+          title="결제수단 목록을 불러오는데 실패했습니다"
+        />
+      </ScreenSection>
     );
   }
 
   if (!paymentMethods || paymentMethods.length === 0) {
     return (
-      <div className="bg-white rounded-2xl shadow-sm p-8 text-center">
-        <p className="text-gray-500">등록된 결제수단이 없습니다.</p>
-        <p className="text-sm text-gray-400 mt-1">
-          상단의 &quot;추가&quot; 버튼으로 결제수단을 등록해보세요.
-        </p>
-      </div>
+      <ScreenSection>
+        <SectionHeader title="결제수단" action={action} />
+        <ScreenState
+          type="empty"
+          title="등록된 결제수단이 없습니다."
+          description="상단의 &quot;추가&quot; 버튼으로 결제수단을 등록해보세요."
+        />
+      </ScreenSection>
     );
   }
 
   return (
-    <>
-      <div className="overflow-hidden rounded-2xl bg-white shadow-sm ring-1 ring-gray-100">
+    <ScreenSection>
+      <SectionHeader title="결제수단" action={action} />
+      <GroupedList>
         {paymentMethods.map((method) => {
           const isOwner = currentUserId === method.ownerId;
           const hasBalance = AUXILIARY_PAYMENT_METHOD_TYPES.has(method.type);
           return (
             <article
               key={method.id}
-              className="flex min-h-[96px] items-center gap-3 border-gray-100 border-t px-4 py-4 first:border-t-0 sm:px-5"
+              className="flex min-h-[96px] items-center gap-3 px-4 py-3.5 sm:px-5"
             >
               <Link
                 href={`/ledger/payment-methods/${method.id}`}
@@ -190,7 +202,7 @@ export function PaymentMethodList() {
             </article>
           );
         })}
-      </div>
+      </GroupedList>
 
       <PaymentMethodFormDialog
         open={isFormOpen}
@@ -203,6 +215,6 @@ export function PaymentMethodList() {
         open={!!deletingMethod}
         onOpenChange={(open) => !open && setDeletingMethod(null)}
       />
-    </>
+    </ScreenSection>
   );
 }

--- a/components/accounts/PaymentMethodList.tsx
+++ b/components/accounts/PaymentMethodList.tsx
@@ -1,13 +1,6 @@
 "use client";
 
-import {
-  CreditCard,
-  Link2,
-  MoreHorizontal,
-  Pencil,
-  Trash2,
-  UserRound,
-} from "lucide-react";
+import { Link2, MoreHorizontal, Pencil, Trash2, UserRound } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
 import {
@@ -122,10 +115,6 @@ export function PaymentMethodList({ action }: PaymentMethodListProps) {
                 href={`/ledger/payment-methods/${method.id}`}
                 className="flex min-w-0 flex-1 items-center gap-3"
               >
-                <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-gray-100 text-gray-500">
-                  <CreditCard className="size-5" />
-                </div>
-
                 <div className="min-w-0 flex-1">
                   <div className="flex min-w-0 flex-wrap items-center gap-2">
                     <h4 className="truncate font-semibold text-gray-900">

--- a/components/holdings/HoldingsList.tsx
+++ b/components/holdings/HoldingsList.tsx
@@ -2,6 +2,11 @@
 
 import { useState } from "react";
 import {
+  ScreenSection,
+  ScreenState,
+  SectionHeader,
+} from "@/components/layout/screen";
+import {
   Pagination,
   PaginationContent,
   PaginationItem,
@@ -27,18 +32,18 @@ interface Account {
 interface HoldingsListProps {
   members: Member[];
   accounts: Account[];
+  action?: React.ReactNode;
 }
 
 function HoldingsListSkeleton() {
   return (
     <div className="space-y-3">
-      <Skeleton className="h-10 rounded-xl bg-gray-200" />
       <Skeleton className="h-64 rounded-xl bg-gray-200" />
     </div>
   );
 }
 
-export function HoldingsList({ members, accounts }: HoldingsListProps) {
+export function HoldingsList({ members, accounts, action }: HoldingsListProps) {
   const [filters, setFilters] = useState<Filters>({});
   const [page, setPage] = useState(1);
 
@@ -68,29 +73,27 @@ export function HoldingsList({ members, accounts }: HoldingsListProps) {
 
   if (isLoading) {
     return (
-      <div className="space-y-4">
+      <ScreenSection>
+        <SectionHeader title="보유 현황" action={action} />
         {filterControls}
         <HoldingsListSkeleton />
-      </div>
+      </ScreenSection>
     );
   }
 
   if (error || !data) {
     return (
-      <div className="space-y-4">
+      <ScreenSection>
+        <SectionHeader title="보유 현황" action={action} />
         {filterControls}
-        <div className="rounded-xl bg-white p-6 text-center shadow-sm">
-          <p className="text-sm text-gray-500">
-            보유 현황을 불러오지 못했습니다.
-          </p>
-        </div>
-      </div>
+        <ScreenState type="error" title="보유 현황을 불러오지 못했습니다" />
+      </ScreenSection>
     );
   }
 
   return (
-    <div className="space-y-4">
-      <p className="text-sm text-gray-500">총 {data.total}개 종목 보유 중</p>
+    <ScreenSection>
+      <SectionHeader title="보유 현황" action={action} />
 
       {filterControls}
 
@@ -129,6 +132,6 @@ export function HoldingsList({ members, accounts }: HoldingsListProps) {
           </PaginationContent>
         </Pagination>
       )}
-    </div>
+    </ScreenSection>
   );
 }

--- a/components/holdings/HoldingsTable.test.tsx
+++ b/components/holdings/HoldingsTable.test.tsx
@@ -22,8 +22,8 @@ const holdings: HoldingWithDetails[] = [
 ];
 
 describe("HoldingsTable", () => {
-  it("renders holdings as collection cards instead of a table", () => {
-    render(<HoldingsTable data={holdings} />);
+  it("renders holdings as one grouped list, not a card grid", () => {
+    const { container } = render(<HoldingsTable data={holdings} />);
 
     expect(screen.queryByRole("table")).not.toBeInTheDocument();
     expect(screen.getByText("삼성전자")).toBeInTheDocument();
@@ -31,12 +31,23 @@ describe("HoldingsTable", () => {
     expect(screen.getByText("10주")).toBeInTheDocument();
     expect(screen.getByText("ISA")).toBeInTheDocument();
     expect(screen.getByText("70만원")).toBeInTheDocument();
+
+    // Assert sort controls exist
+    expect(screen.getByText("투자금")).toBeInTheDocument();
+    expect(screen.getByText("수량")).toBeInTheDocument();
+    expect(screen.getByText("종목명")).toBeInTheDocument();
+
+    // Assert no desktop grid-cols-2 card-grid class
+    expect(
+      container.querySelector(".lg\\:grid-cols-2"),
+    ).not.toBeInTheDocument();
   });
 
   it("shows an empty collection state", () => {
     render(<HoldingsTable data={[]} />);
 
     expect(screen.queryByRole("table")).not.toBeInTheDocument();
+    expect(screen.getByTestId("screen-state")).toBeInTheDocument();
     expect(screen.getByText("보유 종목이 없습니다.")).toBeInTheDocument();
   });
 });

--- a/components/holdings/HoldingsTable.tsx
+++ b/components/holdings/HoldingsTable.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { ArrowDownUp, Building2, UserRound, WalletCards } from "lucide-react";
+import { ArrowDownUp, Building2, UserRound } from "lucide-react";
 import { useMemo, useState } from "react";
+import { GroupedList, ScreenState } from "@/components/layout/screen";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -47,13 +48,11 @@ export function HoldingsTable({ data }: HoldingsTableProps) {
 
   if (data.length === 0) {
     return (
-      <div className="rounded-2xl bg-white px-6 py-12 text-center shadow-sm ring-1 ring-gray-100">
-        <WalletCards className="mx-auto mb-3 size-8 text-gray-300" />
-        <p className="font-medium text-gray-700">보유 종목이 없습니다.</p>
-        <p className="mt-1 text-gray-400 text-sm">
-          거래를 등록하면 보유 종목이 여기에 표시됩니다.
-        </p>
-      </div>
+      <ScreenState
+        type="empty"
+        title="보유 종목이 없습니다."
+        description="거래를 등록하면 보유 종목이 여기에 표시됩니다."
+      />
     );
   }
 
@@ -81,11 +80,11 @@ export function HoldingsTable({ data }: HoldingsTableProps) {
         </div>
       </div>
 
-      <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+      <GroupedList>
         {sortedHoldings.map((holding) => (
           <article
             key={`${holding.owner.id}:${holding.account.id ?? "none"}:${holding.ticker}`}
-            className="flex flex-col gap-2 rounded-2xl bg-white p-4 shadow-sm ring-1 ring-gray-100"
+            className="flex flex-col gap-2 px-4 py-3.5 sm:px-5"
           >
             <div className="flex min-w-0 items-center justify-between gap-3">
               <div className="flex min-w-0 flex-1 items-center gap-2">
@@ -155,7 +154,7 @@ export function HoldingsTable({ data }: HoldingsTableProps) {
             </div>
           </article>
         ))}
-      </div>
+      </GroupedList>
     </div>
   );
 }

--- a/components/ledger/CategoryList.test.tsx
+++ b/components/ledger/CategoryList.test.tsx
@@ -87,8 +87,9 @@ describe("CategoryList", () => {
 
     render(<CategoryList />);
 
-    // System category should show a lock/default indicator and no menus
+    // System category should show a lock/default indicator and status text
     expect(screen.getByTestId("lock-icon")).toBeInTheDocument();
+    expect(screen.getByText("기본")).toBeInTheDocument();
 
     // Custom category has menu trigger (e.g. MoreHorizontal or equivalent button)
     const menuButtons = screen.getAllByRole("button", { name: /메뉴 열기/i });
@@ -104,5 +105,14 @@ describe("CategoryList", () => {
     fireEvent.click(addButton);
 
     expect(screen.getByTestId("category-form-dialog")).toBeInTheDocument();
+  });
+
+  it("renders screen-state when empty", () => {
+    mocks.categories = [];
+
+    render(<CategoryList />);
+
+    expect(screen.getByTestId("screen-state")).toBeInTheDocument();
+    expect(screen.getByText("등록된 카테고리가 없습니다.")).toBeInTheDocument();
   });
 });

--- a/components/ledger/CategoryList.test.tsx
+++ b/components/ledger/CategoryList.test.tsx
@@ -1,0 +1,108 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { Category } from "@/types";
+import { CategoryList } from "./CategoryList";
+
+const mocks = vi.hoisted(() => ({
+  categories: [] as Category[],
+}));
+
+vi.mock("@/hooks/use-categories", () => ({
+  useCategories: () => ({ data: mocks.categories, isLoading: false }),
+}));
+
+vi.mock("./CategoryFormDialog", () => ({
+  CategoryFormDialog: ({
+    open,
+    onOpenChange,
+  }: {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+  }) => {
+    if (!open) return null;
+    return (
+      <div data-testid="category-form-dialog">
+        CategoryFormDialog
+        <button type="button" onClick={() => onOpenChange(false)}>
+          Close
+        </button>
+      </div>
+    );
+  },
+}));
+
+vi.mock("./CategoryDeleteDialog", () => ({
+  CategoryDeleteDialog: ({ open }: { open: boolean }) => {
+    if (!open) return null;
+    return <div data-testid="category-delete-dialog">CategoryDeleteDialog</div>;
+  },
+}));
+
+vi.mock("./CategoryIcon", () => ({
+  CategoryIcon: ({ iconName }: { iconName: string }) => (
+    <span>Icon: {iconName}</span>
+  ),
+}));
+
+const systemCategory: Category = {
+  id: "cat-sys",
+  household_id: "house-1",
+  name: "식비",
+  type: "expense",
+  icon: "food",
+  is_system: true,
+  display_order: 0,
+  created_at: "2026-05-01T00:00:00.000Z",
+  updated_at: "2026-05-01T00:00:00.000Z",
+};
+
+const customCategory: Category = {
+  id: "cat-cust",
+  household_id: "house-1",
+  name: "배달",
+  type: "expense",
+  icon: "delivery",
+  is_system: false,
+  display_order: 1,
+  created_at: "2026-05-01T00:00:00.000Z",
+  updated_at: "2026-05-01T00:00:00.000Z",
+};
+
+describe("CategoryList", () => {
+  it("renders categories as grouped list rows", () => {
+    mocks.categories = [systemCategory, customCategory];
+
+    render(<CategoryList />);
+
+    expect(screen.getByText("지출")).toBeInTheDocument();
+    expect(screen.getByText("수입")).toBeInTheDocument();
+    expect(screen.getByText("식비")).toBeInTheDocument();
+    expect(screen.getByText("배달")).toBeInTheDocument();
+    expect(screen.getByText("Icon: food")).toBeInTheDocument();
+    expect(screen.getByText("Icon: delivery")).toBeInTheDocument();
+  });
+
+  it("shows custom category edit and delete actions but keeps system category locked", () => {
+    mocks.categories = [systemCategory, customCategory];
+
+    render(<CategoryList />);
+
+    // System category should show a lock/default indicator and no menus
+    expect(screen.getByTestId("lock-icon")).toBeInTheDocument();
+
+    // Custom category has menu trigger (e.g. MoreHorizontal or equivalent button)
+    const menuButtons = screen.getAllByRole("button", { name: /메뉴 열기/i });
+    expect(menuButtons).toHaveLength(1); // Only 1 custom category menu button
+  });
+
+  it("opens create dialog from the section header add action", () => {
+    mocks.categories = [systemCategory];
+
+    render(<CategoryList />);
+
+    const addButton = screen.getByRole("button", { name: /추가/ });
+    fireEvent.click(addButton);
+
+    expect(screen.getByTestId("category-form-dialog")).toBeInTheDocument();
+  });
+});

--- a/components/ledger/CategoryList.tsx
+++ b/components/ledger/CategoryList.tsx
@@ -1,11 +1,22 @@
 "use client";
 
-import { LockIcon, PencilIcon, Plus, Trash2Icon } from "lucide-react";
+import {
+  LockIcon,
+  MoreHorizontal,
+  PencilIcon,
+  Plus,
+  Trash2Icon,
+} from "lucide-react";
 import { useState } from "react";
+import {
+  GroupedList,
+  ScreenSection,
+  SectionHeader,
+} from "@/components/layout/screen";
 import { CategoryDeleteDialog } from "@/components/ledger/CategoryDeleteDialog";
 import { CategoryFormDialog } from "@/components/ledger/CategoryFormDialog";
 import { CategoryIcon } from "@/components/ledger/CategoryIcon";
-import { Avatar, AvatarBadge, AvatarFallback } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -25,53 +36,95 @@ export function CategoryList() {
 
   const { data: categories = [], isLoading } = useCategories(activeTab);
 
-  const renderGrid = () => {
+  const renderList = () => {
     if (isLoading) {
       return (
-        <div className="grid grid-cols-4 gap-x-2 gap-y-5 pt-4">
-          {Array.from({ length: 8 }).map((_, i) => (
-            // biome-ignore lint/suspicious/noArrayIndexKey: 스켈레톤은 순서 변경 없음
-            <div key={i} className="flex flex-col items-center gap-2">
-              <Skeleton className="size-16 rounded-full" />
-              <Skeleton className="h-3 w-10 rounded" />
+        <GroupedList>
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div
+              // biome-ignore lint/suspicious/noArrayIndexKey: 스켈레톤은 순서 변경 없음
+              key={i}
+              className="flex items-center gap-3 px-4 py-3.5 sm:px-5"
+            >
+              <Skeleton className="size-10 rounded-full shrink-0" />
+              <Skeleton className="h-4 w-24 rounded" />
             </div>
           ))}
-        </div>
+        </GroupedList>
       );
     }
 
     return (
-      <div className="grid grid-cols-4 gap-x-2 gap-y-5 pt-4">
-        {categories.map((category) =>
-          category.is_system ? (
-            <SystemCategoryItem key={category.id} category={category} />
-          ) : (
-            <CustomCategoryItem
-              key={category.id}
-              category={category}
-              onEdit={() => setEditTarget(category)}
-              onDelete={() => setDeleteTarget(category)}
-            />
-          ),
-        )}
+      <GroupedList>
+        {categories.map((category) => (
+          <article
+            key={category.id}
+            className="flex items-center justify-between gap-3 px-4 py-3.5 sm:px-5"
+          >
+            <div className="flex items-center gap-3 min-w-0">
+              <div
+                className={`flex size-10 shrink-0 items-center justify-center rounded-full ${
+                  category.is_system
+                    ? "bg-gray-100 text-gray-500"
+                    : "bg-primary/10 text-primary"
+                }`}
+              >
+                <CategoryIcon iconName={category.icon} className="size-5" />
+              </div>
+              <span className="font-semibold text-gray-900 text-sm truncate">
+                {category.name}
+              </span>
+            </div>
 
-        {/* 추가 버튼 */}
-        <button
-          type="button"
-          onClick={() => setIsCreateOpen(true)}
-          className="flex flex-col items-center gap-2 group"
-        >
-          <div className="size-16 rounded-full border-2 border-dashed border-gray-300 flex items-center justify-center group-hover:border-primary/50 transition-colors">
-            <Plus className="w-6 h-6 text-gray-400 group-hover:text-primary/60 transition-colors" />
-          </div>
-          <span className="text-xs text-gray-400">추가</span>
-        </button>
-      </div>
+            {category.is_system ? (
+              <div className="flex size-9 items-center justify-center text-gray-400">
+                <LockIcon data-testid="lock-icon" className="size-4" />
+              </div>
+            ) : (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-9"
+                    aria-label="메뉴 열기"
+                  >
+                    <MoreHorizontal className="size-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem onClick={() => setEditTarget(category)}>
+                    <PencilIcon className="w-4 h-4 mr-2" />
+                    수정
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    className="text-red-500 focus:text-red-500 focus:bg-red-50"
+                    onClick={() => setDeleteTarget(category)}
+                  >
+                    <Trash2Icon className="w-4 h-4 mr-2" />
+                    삭제
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
+          </article>
+        ))}
+      </GroupedList>
     );
   };
 
   return (
-    <>
+    <ScreenSection>
+      <SectionHeader
+        title="카테고리"
+        action={
+          <Button size="sm" onClick={() => setIsCreateOpen(true)}>
+            <Plus className="mr-1 size-4" />
+            추가
+          </Button>
+        }
+      />
+
       <Tabs
         value={activeTab}
         onValueChange={(v) => setActiveTab(v as CategoryType)}
@@ -84,8 +137,12 @@ export function CategoryList() {
             수입
           </TabsTrigger>
         </TabsList>
-        <TabsContent value="expense">{renderGrid()}</TabsContent>
-        <TabsContent value="income">{renderGrid()}</TabsContent>
+        <TabsContent value="expense" className="mt-4">
+          {renderList()}
+        </TabsContent>
+        <TabsContent value="income" className="mt-4">
+          {renderList()}
+        </TabsContent>
       </Tabs>
 
       <CategoryFormDialog
@@ -112,75 +169,6 @@ export function CategoryList() {
           if (!open) setDeleteTarget(null);
         }}
       />
-    </>
-  );
-}
-
-function SystemCategoryItem({ category }: { category: Category }) {
-  return (
-    <div className="flex flex-col items-center gap-2">
-      <Avatar className="size-16">
-        <AvatarFallback className="bg-gray-100">
-          <CategoryIcon
-            iconName={category.icon}
-            className="w-7 h-7 text-gray-500"
-          />
-        </AvatarFallback>
-        <AvatarBadge className="size-5 bg-white ring-gray-200 [&>svg]:size-3">
-          <LockIcon />
-        </AvatarBadge>
-      </Avatar>
-      <span className="text-xs text-gray-600 text-center w-full truncate px-1">
-        {category.name}
-      </span>
-    </div>
-  );
-}
-
-interface CustomCategoryItemProps {
-  category: Category;
-  onEdit: () => void;
-  onDelete: () => void;
-}
-
-function CustomCategoryItem({
-  category,
-  onEdit,
-  onDelete,
-}: CustomCategoryItemProps) {
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <button
-          type="button"
-          className="flex flex-col items-center gap-2 group outline-none"
-        >
-          <Avatar className="size-16 group-hover:opacity-75 transition-opacity">
-            <AvatarFallback className="bg-primary/10">
-              <CategoryIcon
-                iconName={category.icon}
-                className="w-7 h-7 text-primary"
-              />
-            </AvatarFallback>
-          </Avatar>
-          <span className="text-xs text-gray-700 text-center w-full truncate px-1">
-            {category.name}
-          </span>
-        </button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="center">
-        <DropdownMenuItem onClick={onEdit}>
-          <PencilIcon className="w-4 h-4 mr-2" />
-          수정
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          className="text-red-500 focus:text-red-500 focus:bg-red-50"
-          onClick={onDelete}
-        >
-          <Trash2Icon className="w-4 h-4 mr-2" />
-          삭제
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    </ScreenSection>
   );
 }

--- a/components/ledger/CategoryList.tsx
+++ b/components/ledger/CategoryList.tsx
@@ -11,11 +11,13 @@ import { useState } from "react";
 import {
   GroupedList,
   ScreenSection,
+  ScreenState,
   SectionHeader,
 } from "@/components/layout/screen";
 import { CategoryDeleteDialog } from "@/components/ledger/CategoryDeleteDialog";
 import { CategoryFormDialog } from "@/components/ledger/CategoryFormDialog";
 import { CategoryIcon } from "@/components/ledger/CategoryIcon";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -54,6 +56,16 @@ export function CategoryList() {
       );
     }
 
+    if (categories.length === 0) {
+      return (
+        <ScreenState
+          type="empty"
+          title="등록된 카테고리가 없습니다."
+          description="카테고리를 추가하여 거래를 분류해보세요."
+        />
+      );
+    }
+
     return (
       <GroupedList>
         {categories.map((category) => (
@@ -77,8 +89,16 @@ export function CategoryList() {
             </div>
 
             {category.is_system ? (
-              <div className="flex size-9 items-center justify-center text-gray-400">
-                <LockIcon data-testid="lock-icon" className="size-4" />
+              <div className="flex items-center gap-2 text-gray-400">
+                <Badge
+                  variant="outline"
+                  className="text-gray-400 border-gray-200 text-[10px] px-1.5 py-0 h-5"
+                >
+                  기본
+                </Badge>
+                <div className="flex size-9 items-center justify-center">
+                  <LockIcon data-testid="lock-icon" className="size-4" />
+                </div>
               </div>
             ) : (
               <DropdownMenu>

--- a/components/stock-settings/StockSettingsList.tsx
+++ b/components/stock-settings/StockSettingsList.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { ScreenSection, SectionHeader } from "@/components/layout/screen";
 import {
   Pagination,
   PaginationContent,
@@ -44,7 +45,9 @@ export function StockSettingsList({ initialData }: StockSettingsListProps) {
   };
 
   return (
-    <div className="space-y-4">
+    <ScreenSection>
+      <SectionHeader title="종목 설정" />
+
       <StockSettingsFilters
         filters={filters}
         onFiltersChange={handleFiltersChange}
@@ -85,6 +88,6 @@ export function StockSettingsList({ initialData }: StockSettingsListProps) {
           </PaginationContent>
         </Pagination>
       )}
-    </div>
+    </ScreenSection>
   );
 }

--- a/components/stock-settings/StockSettingsTable.test.tsx
+++ b/components/stock-settings/StockSettingsTable.test.tsx
@@ -21,7 +21,7 @@ const settings: StockSettingWithDetails[] = [
 ];
 
 describe("StockSettingsTable", () => {
-  it("renders settings as compact collection rows instead of a table", () => {
+  it("renders stock settings as compact grouped rows", () => {
     render(<StockSettingsTable data={settings} />);
 
     expect(screen.queryByRole("table")).not.toBeInTheDocument();
@@ -36,6 +36,7 @@ describe("StockSettingsTable", () => {
     render(<StockSettingsTable data={[]} />);
 
     expect(screen.queryByRole("table")).not.toBeInTheDocument();
+    expect(screen.getByTestId("screen-state")).toBeInTheDocument();
     expect(screen.getByText("등록된 종목이 없습니다.")).toBeInTheDocument();
   });
 });

--- a/components/stock-settings/StockSettingsTable.tsx
+++ b/components/stock-settings/StockSettingsTable.tsx
@@ -2,6 +2,7 @@
 
 import { Pencil, Settings2 } from "lucide-react";
 import { useMemo, useState } from "react";
+import { GroupedList, ScreenState } from "@/components/layout/screen";
 import { StockSettingEditDialog } from "@/components/stock-settings/StockSettingEditDialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -38,7 +39,7 @@ export function StockSettingsTable({ data }: StockSettingsTableProps) {
   return (
     <>
       {sortedSettings.length > 0 ? (
-        <div className="overflow-hidden rounded-2xl bg-white shadow-sm ring-1 ring-gray-100">
+        <GroupedList>
           {sortedSettings.map((setting) => {
             const riskLabel = setting.riskLevel
               ? (RISK_LEVEL_LABELS[setting.riskLevel] ?? setting.riskLevel)
@@ -47,7 +48,7 @@ export function StockSettingsTable({ data }: StockSettingsTableProps) {
             return (
               <article
                 key={setting.id}
-                className="flex min-h-[84px] items-center gap-3 border-gray-100 border-t px-4 py-4 first:border-t-0 sm:px-5"
+                className="flex min-h-[84px] items-center gap-3 px-4 py-3.5 sm:px-5"
               >
                 <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-gray-100 text-gray-500">
                   <Settings2 className="size-5" />
@@ -97,15 +98,13 @@ export function StockSettingsTable({ data }: StockSettingsTableProps) {
               </article>
             );
           })}
-        </div>
+        </GroupedList>
       ) : (
-        <div className="rounded-2xl bg-white px-6 py-12 text-center shadow-sm ring-1 ring-gray-100">
-          <Settings2 className="mx-auto mb-3 size-8 text-gray-300" />
-          <p className="font-medium text-gray-700">등록된 종목이 없습니다.</p>
-          <p className="mt-1 text-gray-400 text-sm">
-            첫 거래를 등록하면 종목 설정이 자동으로 만들어집니다.
-          </p>
-        </div>
+        <ScreenState
+          type="empty"
+          title="등록된 종목이 없습니다."
+          description="첫 거래를 등록하면 종목 설정이 자동으로 만들어집니다."
+        />
       )}
 
       <StockSettingEditDialog

--- a/components/transactions/TransactionList.tsx
+++ b/components/transactions/TransactionList.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { ScreenSection, SectionHeader } from "@/components/layout/screen";
 import {
   Pagination,
   PaginationContent,
@@ -21,11 +22,13 @@ interface Member {
 interface TransactionListProps {
   members: Member[];
   currentUserId?: string;
+  action?: React.ReactNode;
 }
 
 export function TransactionList({
   members,
   currentUserId: _currentUserId,
+  action,
 }: TransactionListProps) {
   const [filters, setFilters] = useState<Filters>({});
   const [page, setPage] = useState(1);
@@ -50,7 +53,9 @@ export function TransactionList({
   const detailQueryString = buildTransactionDetailQueryString(filters, page);
 
   return (
-    <div className="space-y-4">
+    <ScreenSection>
+      <SectionHeader title="거래 내역" action={action} />
+
       <TransactionFilters
         filters={filters}
         onFiltersChange={handleFiltersChange}
@@ -95,7 +100,7 @@ export function TransactionList({
           </PaginationContent>
         </Pagination>
       )}
-    </div>
+    </ScreenSection>
   );
 }
 

--- a/components/transactions/TransactionTable.test.tsx
+++ b/components/transactions/TransactionTable.test.tsx
@@ -61,7 +61,7 @@ const transactions: TransactionWithDetails[] = [
 ];
 
 describe("TransactionTable", () => {
-  it("renders transactions as date-grouped collection items instead of a table", () => {
+  it("renders date-grouped transactions with grouped list grammar", () => {
     render(
       <TransactionTable
         data={transactions}
@@ -112,6 +112,7 @@ describe("TransactionTable", () => {
     );
 
     expect(screen.queryByRole("table")).not.toBeInTheDocument();
+    expect(screen.getByTestId("screen-state")).toBeInTheDocument();
     expect(screen.getByText("거래 내역이 없습니다.")).toBeInTheDocument();
   });
 });

--- a/components/transactions/TransactionTable.tsx
+++ b/components/transactions/TransactionTable.tsx
@@ -1,9 +1,15 @@
 "use client";
 
-import { CalendarDays, User, Wallet } from "lucide-react";
+import { User, Wallet } from "lucide-react";
 import Link from "next/link";
 import { useMemo } from "react";
-import { AmountText } from "@/components/layout/screen";
+import {
+  AmountText,
+  GroupedList,
+  ScreenSection,
+  ScreenState,
+  SectionHeader,
+} from "@/components/layout/screen";
 import { Badge } from "@/components/ui/badge";
 import type { TransactionWithDetails } from "@/lib/api/transaction";
 import { formatCurrency, formatDate, formatDateISO } from "@/lib/utils/format";
@@ -56,7 +62,7 @@ function TransactionItem({
   const detailHref = `/assets/stock/transactions/${transaction.id}?${detailQueryString}`;
 
   return (
-    <article className="border-gray-100 border-t first:border-t-0">
+    <article>
       <Link
         href={detailHref}
         className="flex min-h-[72px] flex-col justify-center px-4 py-3.5 transition-colors hover:bg-gray-50 sm:px-5"
@@ -113,22 +119,16 @@ export function TransactionTable({
   return (
     <>
       {groups.length > 0 ? (
-        <div className="space-y-4">
+        <div className="space-y-6">
           {groups.map((group) => (
-            <section
-              key={group.dateKey}
-              className="overflow-hidden rounded-2xl bg-white shadow-sm ring-1 ring-gray-100"
-            >
-              <div className="flex items-center justify-between gap-3 bg-gray-50/70 px-4 py-3 sm:px-5">
-                <div className="flex min-w-0 items-center gap-2">
-                  <CalendarDays className="size-4 shrink-0 text-gray-400" />
-                  <h3 className="truncate font-semibold text-gray-900 text-sm">
-                    {group.label}
-                  </h3>
-                </div>
-                <Badge variant="outline">{group.transactions.length}건</Badge>
-              </div>
-              <div>
+            <ScreenSection key={group.dateKey}>
+              <SectionHeader
+                title={group.label}
+                action={
+                  <Badge variant="outline">{group.transactions.length}건</Badge>
+                }
+              />
+              <GroupedList>
                 {group.transactions.map((transaction) => (
                   <TransactionItem
                     key={transaction.id}
@@ -136,18 +136,16 @@ export function TransactionTable({
                     detailQueryString={detailQueryString}
                   />
                 ))}
-              </div>
-            </section>
+              </GroupedList>
+            </ScreenSection>
           ))}
         </div>
       ) : (
-        <div className="rounded-2xl bg-white px-6 py-12 text-center shadow-sm ring-1 ring-gray-100">
-          <CalendarDays className="mx-auto mb-3 size-8 text-gray-300" />
-          <p className="font-medium text-gray-700">거래 내역이 없습니다.</p>
-          <p className="mt-1 text-gray-400 text-sm">
-            필터를 바꾸거나 새 거래를 추가해보세요.
-          </p>
-        </div>
+        <ScreenState
+          type="empty"
+          title="거래 내역이 없습니다."
+          description="필터를 바꾸거나 새 거래를 추가해보세요."
+        />
       )}
     </>
   );


### PR DESCRIPTION
### Summary
This PR refactors various asset and ledger management list screens to share the same compact grouped list grammar for a calmer, more polished application UI.

### Changes
- Refactored , , , , , and  to use screen primitives (, , , ).
- Moved add actions from page-level  into list section headers ( action prop) so that the actions live near the lists they modify.
- Resolved reviewer feedback regarding 's default/system marker and empty state rendering.
- Simplified unfiltered  headers to avoid duplicate header text and nested  wrappers.
- Removed row icons ( icon) from  and  rows for a cleaner text-centric appearance based on user feedback.

Closes #391