### PR TITLE
[codex] Unify financial task form surfaces

### DIFF
--- a/.claude/docs/CONVENTIONS_FE.md
+++ b/.claude/docs/CONVENTIONS_FE.md
@@ -158,6 +158,27 @@ lib/queries/index.ts  # 모든 쿼리 정의
 - 단순 검색 결과가 아니라 실제 화면 역할과 사용자 흐름 기준으로 묶습니다.
 - 인증/초대 화면은 전수조사에 포함하되, 로그인 후 메인 앱 개선 이슈와 별도 묶음으로 관리합니다.
 
+### 입력/제출 Task Surface
+
+사용자가 금융 데이터를 생성, 수정, 요청, 삭제 요청하거나 입력 중 참조 데이터를 인라인 생성하는 화면은 같은 task surface 문법을 따릅니다.
+
+적용 대상:
+
+- 가계부 기록 생성, 수정, 수정 요청, 삭제 요청
+- 주식 거래 생성, 수정, 수정 요청, 삭제 요청
+- 계좌/결제수단 신규 등록
+- 거래 입력 중 계좌, 결제수단, 카테고리 인라인 생성
+
+구현 기준:
+
+- 모바일에서 input이 있는 task flow는 full-screen drawer 또는 task screen을 우선합니다.
+- 모바일 input flow를 만들기 위해 `DialogContent`를 `100dvh`, `left-0`, `top-0`, `translate-x-0` 등으로 fullscreen처럼 강제하지 않습니다.
+- 데스크톱은 centered dialog를 사용할 수 있지만, 필드 구성, selector, footer action 문법은 모바일 task surface와 같은 순서를 유지합니다.
+- 계좌, 결제수단, 카테고리처럼 검색/생성이 필요한 선택은 plain `Select`보다 기존 combobox와 mobile picker drawer를 우선합니다.
+- 저장, 취소, 추가, 요청 보내기 같은 action은 화면 하단 task footer에 모으고, 모바일에서는 safe-area 여백을 고려합니다.
+- 금액 입력 label, prefix, preview는 `SCREEN_PRIMITIVES.md`의 `AmountText` 및 금액 포맷 정책과 충돌하지 않게 유지합니다.
+- 새 입력/요청 UI를 추가할 때는 기존 수정 drawer와 수정 요청 drawer의 모바일 keyboard, nested drawer, selector 흐름을 비교해 회귀를 확인합니다.
+
 ### 자산 유형별 계층 구조
 
 자산은 `/assets/[type]/...` 패턴으로 유형별 계층 구조를 따릅니다.

--- a/components/accounts/AccountNewForm.tsx
+++ b/components/accounts/AccountNewForm.tsx
@@ -77,13 +77,13 @@ function CategoryCard({
     <button
       type="button"
       onClick={onClick}
-      className="w-full flex items-center gap-4 p-4 rounded-2xl border-2 border-gray-100 bg-white hover:border-primary/30 hover:bg-primary/5 transition-colors text-left"
+      className="w-full flex items-center gap-3 px-4 py-3 bg-white hover:bg-gray-50 transition-colors text-left"
     >
-      <div className="w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
+      <div className="size-10 rounded-lg bg-primary/10 flex items-center justify-center shrink-0">
         {icon}
       </div>
-      <div>
-        <p className="text-lg font-semibold text-gray-900">{title}</p>
+      <div className="min-w-0">
+        <p className="text-sm font-semibold text-gray-900">{title}</p>
         <p className="text-sm text-gray-500">{description}</p>
       </div>
     </button>
@@ -232,15 +232,21 @@ function DetailForm({ category, onBack }: DetailFormProps) {
 
       <div className="space-y-2">
         <Label htmlFor="balanceStr">잔액</Label>
-        <Input
-          id="balanceStr"
-          type="number"
-          inputMode="numeric"
-          min="0"
-          placeholder="예: 1000000"
-          {...register("balanceStr")}
-          aria-invalid={!!errors.balanceStr}
-        />
+        <div className="relative">
+          <Input
+            id="balanceStr"
+            type="number"
+            inputMode="numeric"
+            min="0"
+            placeholder="예: 1000000"
+            className="pr-10"
+            {...register("balanceStr")}
+            aria-invalid={!!errors.balanceStr}
+          />
+          <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-sm text-gray-500">
+            원
+          </span>
+        </div>
         {errors.balanceStr && (
           <p className="text-sm text-destructive">
             {errors.balanceStr.message}
@@ -294,7 +300,7 @@ export function AccountNewFormInner() {
   return (
     <div className="space-y-6">
       <p className="text-gray-500">어떤 계좌를 추가하시겠어요?</p>
-      <div className="space-y-3">
+      <div className="overflow-hidden rounded-xl bg-white ring-1 ring-gray-100 divide-y divide-gray-100">
         <CategoryCard
           onClick={() => setCategory("bank")}
           icon={<Building2 className="w-6 h-6 text-primary" />}

--- a/components/accounts/PaymentMethodNewForm.tsx
+++ b/components/accounts/PaymentMethodNewForm.tsx
@@ -97,13 +97,13 @@ function CategoryCard({
     <button
       type="button"
       onClick={onClick}
-      className="w-full flex items-center gap-4 p-4 rounded-2xl border-2 border-gray-100 bg-white hover:border-primary/30 hover:bg-primary/5 transition-colors text-left"
+      className="w-full flex items-center gap-3 px-4 py-3 bg-white hover:bg-gray-50 transition-colors text-left"
     >
-      <div className="w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
+      <div className="size-10 rounded-lg bg-primary/10 flex items-center justify-center shrink-0">
         {icon}
       </div>
-      <div>
-        <p className="text-lg font-semibold text-gray-900">{title}</p>
+      <div className="min-w-0">
+        <p className="text-sm font-semibold text-gray-900">{title}</p>
         <p className="text-sm text-gray-500">{description}</p>
       </div>
     </button>
@@ -261,15 +261,21 @@ function DetailForm({ type, onBack }: DetailFormProps) {
       {showAuxiliaryBalance && (
         <div className="space-y-2">
           <Label htmlFor="pm-balance">보조잔액</Label>
-          <Input
-            id="pm-balance"
-            type="number"
-            inputMode="numeric"
-            min="0"
-            placeholder="예: 30000"
-            {...register("balanceStr")}
-            aria-invalid={!!errors.balanceStr}
-          />
+          <div className="relative">
+            <Input
+              id="pm-balance"
+              type="number"
+              inputMode="numeric"
+              min="0"
+              placeholder="예: 30000"
+              className="pr-10"
+              {...register("balanceStr")}
+              aria-invalid={!!errors.balanceStr}
+            />
+            <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-sm text-gray-500">
+              원
+            </span>
+          </div>
           {errors.balanceStr && (
             <p className="text-sm text-destructive">
               {errors.balanceStr.message}
@@ -348,7 +354,7 @@ function PaymentMethodNewFormInner() {
   return (
     <div className="space-y-6">
       <p className="text-gray-500">어떤 결제수단을 추가하시겠어요?</p>
-      <div className="space-y-3">
+      <div className="overflow-hidden rounded-xl bg-white ring-1 ring-gray-100 divide-y divide-gray-100">
         <CategoryCard
           onClick={() => setType("credit_card")}
           icon={<CreditCard className="w-6 h-6 text-primary" />}

--- a/components/layout/SegmentedChoiceGroup.tsx
+++ b/components/layout/SegmentedChoiceGroup.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { cn } from "@/lib/utils/cn";
+
+export interface SegmentedChoiceOption<T extends string> {
+  value: T;
+  label: string;
+  selectedClassName?: string;
+}
+
+interface SegmentedChoiceGroupProps<T extends string> {
+  value: T;
+  options: readonly SegmentedChoiceOption<T>[];
+  onValueChange: (value: T) => void;
+  columns?: 2 | 3 | 4;
+  className?: string;
+}
+
+export function SegmentedChoiceGroup<T extends string>({
+  value,
+  options,
+  onValueChange,
+  columns,
+  className,
+}: SegmentedChoiceGroupProps<T>) {
+  const columnCount = columns ?? options.length;
+
+  return (
+    <div
+      className={cn(
+        "grid gap-2",
+        columnCount === 2 && "grid-cols-2",
+        columnCount === 3 && "grid-cols-3",
+        columnCount === 4 && "grid-cols-2 sm:grid-cols-4",
+        className,
+      )}
+    >
+      {options.map((option) => {
+        const selected = value === option.value;
+
+        return (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => onValueChange(option.value)}
+            className={cn(
+              "h-11 rounded-xl px-3 font-medium text-sm transition-colors",
+              selected
+                ? (option.selectedClassName ?? "bg-primary text-white")
+                : "bg-gray-100 text-gray-600 hover:bg-gray-200",
+            )}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/layout/TaskFormSurface.test.tsx
+++ b/components/layout/TaskFormSurface.test.tsx
@@ -90,6 +90,9 @@ describe("TaskFormSurface", () => {
     expect(content).toHaveAttribute("data-slot", "drawer-content");
     expect(content).toHaveAttribute("data-show-handle", "false");
     expect(content).toHaveClass("h-[100dvh]");
+    expect(
+      screen.getByRole("heading", { name: "거래 수정 요청", level: 2 }),
+    ).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "닫기" }));
 

--- a/components/layout/TaskFormSurface.test.tsx
+++ b/components/layout/TaskFormSurface.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { useMediaQuery } from "@/hooks/use-media-query";
+import { TaskFormSurface } from "./TaskFormSurface";
+
+vi.mock("@/hooks/use-media-query", () => ({
+  useMediaQuery: vi.fn(),
+}));
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children }: { children: ReactNode }) => (
+    <div data-slot="dialog">{children}</div>
+  ),
+  DialogContent: ({ children }: { children: ReactNode }) => (
+    <div data-slot="dialog-content">{children}</div>
+  ),
+  DialogDescription: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogHeader: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+}));
+
+vi.mock("@/components/ui/drawer", () => ({
+  Drawer: ({ children }: { children: ReactNode }) => (
+    <div data-slot="drawer">{children}</div>
+  ),
+  DrawerContent: ({
+    children,
+    className,
+    showHandle,
+  }: {
+    children: ReactNode;
+    className?: string;
+    showHandle?: boolean;
+  }) => (
+    <div
+      data-show-handle={String(showHandle)}
+      data-slot="drawer-content"
+      className={className}
+    >
+      {children}
+    </div>
+  ),
+}));
+
+describe("TaskFormSurface", () => {
+  it("renders desktop input tasks as a dialog", () => {
+    vi.mocked(useMediaQuery).mockReturnValue(true);
+
+    render(
+      <TaskFormSurface
+        open
+        title="거래 수정 요청"
+        description="거래 소유자에게 요청 내용이 전달됩니다."
+        onOpenChange={() => undefined}
+      >
+        <div>요청 입력</div>
+      </TaskFormSurface>,
+    );
+
+    expect(screen.getByText("거래 수정 요청")).toBeInTheDocument();
+    expect(screen.getByText("요청 입력")).toBeInTheDocument();
+    expect(
+      screen.getByText("요청 입력").closest("[data-slot]"),
+    ).toHaveAttribute("data-slot", "dialog-content");
+  });
+
+  it("renders mobile input tasks as a full-screen drawer with close action", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    vi.mocked(useMediaQuery).mockReturnValue(false);
+
+    render(
+      <TaskFormSurface
+        open
+        title="거래 수정 요청"
+        description="거래 소유자에게 요청 내용이 전달됩니다."
+        onOpenChange={onOpenChange}
+      >
+        <div>요청 입력</div>
+      </TaskFormSurface>,
+    );
+
+    const content = screen.getByText("요청 입력").closest("[data-slot]");
+    expect(content).toHaveAttribute("data-slot", "drawer-content");
+    expect(content).toHaveAttribute("data-show-handle", "false");
+    expect(content).toHaveClass("h-[100dvh]");
+
+    await user.click(screen.getByRole("button", { name: "닫기" }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/components/layout/TaskFormSurface.tsx
+++ b/components/layout/TaskFormSurface.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { XIcon } from "lucide-react";
+import type { ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Drawer, DrawerContent } from "@/components/ui/drawer";
+import { useMediaQuery } from "@/hooks/use-media-query";
+import { cn } from "@/lib/utils/cn";
+
+interface TaskFormSurfaceProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description?: ReactNode;
+  children: ReactNode;
+  desktopClassName?: string;
+  mobileContentClassName?: string;
+}
+
+export function TaskFormSurface({
+  open,
+  onOpenChange,
+  title,
+  description,
+  children,
+  desktopClassName,
+  mobileContentClassName,
+}: TaskFormSurfaceProps) {
+  const isDesktop = useMediaQuery("(min-width: 768px)");
+
+  if (isDesktop) {
+    return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className={cn("sm:max-w-md", desktopClassName)}>
+          <DialogHeader>
+            <DialogTitle>{title}</DialogTitle>
+            {description ? (
+              <DialogDescription>{description}</DialogDescription>
+            ) : null}
+          </DialogHeader>
+          {children}
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent
+        className={cn(
+          "h-[100dvh] max-h-[100dvh] rounded-none border-t-0 p-0 flex flex-col data-[vaul-drawer-direction=bottom]:mt-0 data-[vaul-drawer-direction=bottom]:max-h-[100dvh] data-[vaul-drawer-direction=bottom]:rounded-none data-[vaul-drawer-direction=bottom]:border-t-0",
+          mobileContentClassName,
+        )}
+        showHandle={false}
+        onOpenAutoFocus={(event) => event.preventDefault()}
+      >
+        <Button
+          type="button"
+          variant="ghost"
+          aria-label="닫기"
+          onClick={() => onOpenChange(false)}
+          className="absolute right-2 top-2 z-10 inline-flex size-11 items-center justify-center rounded-full text-gray-700 transition-colors hover:bg-gray-100"
+        >
+          <XIcon className="size-5" />
+        </Button>
+
+        <div className="flex-1 overflow-y-auto px-4 pt-16 pb-[calc(1rem+env(safe-area-inset-bottom))] space-y-4">
+          <div className="space-y-1">
+            <h3 className="text-lg font-bold text-gray-900">{title}</h3>
+            {description ? (
+              <div className="text-sm text-gray-500">{description}</div>
+            ) : null}
+          </div>
+          {children}
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/components/layout/TaskFormSurface.tsx
+++ b/components/layout/TaskFormSurface.tsx
@@ -61,23 +61,25 @@ export function TaskFormSurface({
         showHandle={false}
         onOpenAutoFocus={(event) => event.preventDefault()}
       >
-        <Button
-          type="button"
-          variant="ghost"
-          aria-label="닫기"
-          onClick={() => onOpenChange(false)}
-          className="absolute right-2 top-2 z-10 inline-flex size-11 items-center justify-center rounded-full text-gray-700 transition-colors hover:bg-gray-100"
-        >
-          <XIcon className="size-5" />
-        </Button>
+        <div className="flex h-14 shrink-0 items-center justify-between gap-3 border-b border-gray-100 px-4">
+          <h2 className="min-w-0 truncate text-base font-semibold text-gray-900">
+            {title}
+          </h2>
+          <Button
+            type="button"
+            variant="ghost"
+            aria-label="닫기"
+            onClick={() => onOpenChange(false)}
+            className="-mr-2 inline-flex size-11 shrink-0 items-center justify-center rounded-full text-gray-700 transition-colors hover:bg-gray-100"
+          >
+            <XIcon className="size-5" />
+          </Button>
+        </div>
 
-        <div className="flex-1 overflow-y-auto px-4 pt-16 pb-[calc(1rem+env(safe-area-inset-bottom))] space-y-4">
-          <div className="space-y-1">
-            <h3 className="text-lg font-bold text-gray-900">{title}</h3>
-            {description ? (
-              <div className="text-sm text-gray-500">{description}</div>
-            ) : null}
-          </div>
+        <div className="flex-1 overflow-y-auto px-4 py-4 pb-[calc(1rem+env(safe-area-inset-bottom))] space-y-4">
+          {description ? (
+            <div className="text-sm text-gray-500">{description}</div>
+          ) : null}
           {children}
         </div>
       </DrawerContent>

--- a/components/layout/index.ts
+++ b/components/layout/index.ts
@@ -4,6 +4,11 @@ export { PageActions } from "./PageActions";
 export { PageContainer } from "./PageContainer";
 export { PageTransition } from "./PageTransition";
 export { PageTransitionProvider } from "./PageTransitionProvider";
+export {
+  SegmentedChoiceGroup,
+  type SegmentedChoiceOption,
+} from "./SegmentedChoiceGroup";
 export { ServiceHeader } from "./ServiceHeader";
 export { Sidebar } from "./Sidebar";
 export * from "./screen";
+export { TaskFormSurface } from "./TaskFormSurface";

--- a/components/ledger/LedgerEntryChangeRequestDialog.tsx
+++ b/components/ledger/LedgerEntryChangeRequestDialog.tsx
@@ -1,29 +1,28 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
+import { TaskFormSurface } from "@/components/layout";
+import {
+  LedgerCategoryCombobox,
+  LedgerCategoryPickerPanel,
+  LedgerCategoryTrigger,
+} from "@/components/ledger/LedgerCategoryCombobox";
+import {
+  getLedgerMoneySourceLabel,
+  LedgerMoneySourceCombobox,
+  LedgerMoneySourcePickerPanel,
+  LedgerMoneySourceTrigger,
+} from "@/components/ledger/LedgerMoneySourceCombobox";
 import { Button } from "@/components/ui/button";
 import { DatePickerInput } from "@/components/ui/date-picker";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { Drawer, DrawerContent } from "@/components/ui/drawer";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { useAccounts } from "@/hooks/use-accounts";
 import { useCategories } from "@/hooks/use-categories";
+import { useMediaQuery } from "@/hooks/use-media-query";
 import { usePaymentMethods } from "@/hooks/use-payment-methods";
 import { useCreateRecordChangeRequest } from "@/hooks/use-record-change-requests";
 import type { LedgerEntryWithDetails } from "@/lib/api/ledger";
@@ -36,6 +35,7 @@ import { formatCurrency } from "@/lib/utils/format";
 import type { CategoryType } from "@/types";
 
 type RequestMode = "update" | "delete";
+type MobileRequestView = "form" | "categoryPicker" | "moneySourcePicker";
 
 interface LedgerEntryChangeRequestDialogProps {
   entry: LedgerEntryWithDetails | null;
@@ -79,9 +79,11 @@ export function LedgerEntryChangeRequestDialog({
   onOpenChange,
 }: LedgerEntryChangeRequestDialogProps) {
   const createMutation = useCreateRecordChangeRequest();
+  const isDesktop = useMediaQuery("(min-width: 768px)");
   const [values, setValues] =
     useState<LedgerRecordUpdateRequestFormValues | null>(null);
   const [message, setMessage] = useState("");
+  const [mobileView, setMobileView] = useState<MobileRequestView>("form");
 
   const categoryType =
     entry?.type === "transfer" || entry?.type === "non_expense_withdrawal"
@@ -96,26 +98,8 @@ export function LedgerEntryChangeRequestDialog({
     if (!entry || !open) return;
     setValues(getInitialValues(entry));
     setMessage("");
+    setMobileView("form");
   }, [entry, open]);
-
-  const moneySourceOptions = useMemo(
-    () => [
-      { value: "none", label: "선택 안함" },
-      ...paymentMethods
-        .filter((item) => item.ownerId === entry?.ownerId)
-        .map((item) => ({
-          value: `pm:${item.id}`,
-          label: item.name,
-        })),
-      ...accounts
-        .filter((item) => item.ownerId === entry?.ownerId)
-        .map((item) => ({
-          value: `acc:${item.id}`,
-          label: item.name,
-        })),
-    ],
-    [accounts, paymentMethods, entry?.ownerId],
-  );
 
   if (!entry || !values) return null;
 
@@ -175,17 +159,38 @@ export function LedgerEntryChangeRequestDialog({
   ) =>
     setValues((current) => (current ? { ...current, [key]: value } : current));
 
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent
-        className="left-0 top-0 flex h-[100dvh] max-h-[100dvh] w-full max-w-full translate-x-0 translate-y-0 flex-col overflow-y-auto rounded-none border-0 p-5 sm:left-[50%] sm:top-[50%] sm:h-auto sm:max-h-[85dvh] sm:max-w-md sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-lg sm:border sm:p-6"
-        onOpenAutoFocus={(event) => event.preventDefault()}
-      >
-        <DialogHeader>
-          <DialogTitle>{title}</DialogTitle>
-          <DialogDescription>{description}</DialogDescription>
-        </DialogHeader>
+  const moneySourceMode =
+    entry.type === "expense" || entry.type === "non_expense_withdrawal"
+      ? "expense"
+      : "income";
+  const moneySourcePlaceholder =
+    entry.type === "non_expense_withdrawal" ? "선택" : "선택 안함";
+  const moneySourceLabel = getLedgerMoneySourceLabel({
+    mode: moneySourceMode,
+    value: values.moneySourceId === "none" ? "" : values.moneySourceId,
+    paymentMethods,
+    accounts,
+    ownerId: entry.ownerId,
+    placeholder: moneySourcePlaceholder,
+  });
+  const selectedCategoryLabel =
+    categories.find((category) => category.id === values.categoryId)?.name ??
+    "선택";
+  const handleMoneySourceChange = (value: string) => {
+    updateValue("moneySourceId", value || "none");
+  };
+  const canEditCategory =
+    entry.type !== "transfer" && entry.type !== "non_expense_withdrawal";
+  const canEditMoneySource = entry.type !== "transfer";
 
+  return (
+    <>
+      <TaskFormSurface
+        open={open}
+        onOpenChange={onOpenChange}
+        title={title}
+        description={description}
+      >
         <div className="rounded-md border p-3 text-sm">
           <div className="flex items-center justify-between gap-3">
             <span className="font-medium">
@@ -203,17 +208,23 @@ export function LedgerEntryChangeRequestDialog({
         {isUpdate ? (
           <div className="space-y-4">
             <div className="space-y-2">
-              <Label htmlFor="request-amount">금액 (원)</Label>
-              <Input
-                id="request-amount"
-                type="number"
-                inputMode="numeric"
-                min="0"
-                value={values.amount}
-                onChange={(event) =>
-                  updateValue("amount", Number(event.target.value))
-                }
-              />
+              <Label htmlFor="request-amount">금액</Label>
+              <div className="relative">
+                <Input
+                  id="request-amount"
+                  type="number"
+                  inputMode="numeric"
+                  min="0"
+                  className="pr-10"
+                  value={values.amount}
+                  onChange={(event) =>
+                    updateValue("amount", Number(event.target.value))
+                  }
+                />
+                <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-sm text-gray-500">
+                  원
+                </span>
+              </div>
             </div>
 
             <div className="space-y-2">
@@ -225,62 +236,71 @@ export function LedgerEntryChangeRequestDialog({
               />
             </div>
 
-            <div
-              className={
-                entry.type === "non_expense_withdrawal"
-                  ? "grid grid-cols-1"
-                  : "grid grid-cols-2 gap-3"
-              }
-            >
-              {entry.type !== "non_expense_withdrawal" && (
-                <div className="space-y-2">
-                  <Label>카테고리</Label>
-                  <Select
-                    value={values.categoryId ?? "none"}
-                    onValueChange={(value) =>
-                      updateValue("categoryId", value === "none" ? null : value)
-                    }
-                  >
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="none">선택 안함</SelectItem>
-                      {categories.map((category) => (
-                        <SelectItem key={category.id} value={category.id}>
-                          {category.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              )}
+            {(canEditCategory || canEditMoneySource) && (
+              <div
+                className={
+                  entry.type === "non_expense_withdrawal"
+                    ? "grid grid-cols-1"
+                    : "grid grid-cols-2 gap-3"
+                }
+              >
+                {canEditCategory && (
+                  <div className="space-y-2">
+                    <Label>카테고리</Label>
+                    {isDesktop ? (
+                      <LedgerCategoryCombobox
+                        value={values.categoryId ?? ""}
+                        categories={categories}
+                        type={categoryType as CategoryType}
+                        placeholder="선택"
+                        onValueChange={(value) =>
+                          updateValue("categoryId", value)
+                        }
+                      />
+                    ) : (
+                      <LedgerCategoryTrigger
+                        label={selectedCategoryLabel}
+                        placeholder="선택"
+                        onClick={() => setMobileView("categoryPicker")}
+                      />
+                    )}
+                  </div>
+                )}
 
-              <div className="space-y-2">
-                <Label>
-                  {entry.type === "expense"
-                    ? "결제 방법"
-                    : entry.type === "non_expense_withdrawal"
-                      ? "출금처"
-                      : "입금 계좌"}
-                </Label>
-                <Select
-                  value={values.moneySourceId}
-                  onValueChange={(value) => updateValue("moneySourceId", value)}
-                >
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {moneySourceOptions.map((option) => (
-                      <SelectItem key={option.value} value={option.value}>
-                        {option.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                {canEditMoneySource && (
+                  <div className="space-y-2">
+                    <Label>
+                      {entry.type === "expense"
+                        ? "결제 방법"
+                        : entry.type === "non_expense_withdrawal"
+                          ? "출금처"
+                          : "입금 계좌"}
+                    </Label>
+                    {isDesktop ? (
+                      <LedgerMoneySourceCombobox
+                        mode={moneySourceMode}
+                        value={
+                          values.moneySourceId === "none"
+                            ? ""
+                            : values.moneySourceId
+                        }
+                        paymentMethods={paymentMethods}
+                        accounts={accounts}
+                        ownerId={entry.ownerId}
+                        placeholder={moneySourcePlaceholder}
+                        onValueChange={handleMoneySourceChange}
+                      />
+                    ) : (
+                      <LedgerMoneySourceTrigger
+                        label={moneySourceLabel}
+                        placeholder={moneySourcePlaceholder}
+                        onClick={() => setMobileView("moneySourcePicker")}
+                      />
+                    )}
+                  </div>
+                )}
               </div>
-            </div>
+            )}
 
             <div className="space-y-2">
               <Label htmlFor="request-date">날짜</Label>
@@ -322,7 +342,7 @@ export function LedgerEntryChangeRequestDialog({
           />
         </div>
 
-        <DialogFooter className="mt-auto">
+        <div className="flex flex-col-reverse gap-2 pt-4 sm:flex-row sm:justify-end">
           <Button
             type="button"
             variant="outline"
@@ -338,8 +358,72 @@ export function LedgerEntryChangeRequestDialog({
           >
             {createMutation.isPending ? "요청 중..." : "요청 보내기"}
           </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+        </div>
+      </TaskFormSurface>
+
+      {!isDesktop && canEditCategory && (
+        <Drawer
+          open={open && mobileView === "categoryPicker"}
+          onOpenChange={(nextOpen) => {
+            if (!nextOpen) setMobileView("form");
+          }}
+        >
+          <DrawerContent
+            className="h-[85dvh] max-h-[85dvh] p-0 flex flex-col data-[vaul-drawer-direction=bottom]:mt-0 data-[vaul-drawer-direction=bottom]:max-h-[85dvh]"
+            onOpenAutoFocus={(event) => event.preventDefault()}
+          >
+            <LedgerCategoryPickerPanel
+              value={values.categoryId ?? ""}
+              categories={categories}
+              type={categoryType as CategoryType}
+              title="카테고리 선택"
+              searchPlaceholder="카테고리 이름 검색"
+              onBack={() => setMobileView("form")}
+              onValueChange={(value) => {
+                updateValue("categoryId", value);
+                setMobileView("form");
+              }}
+            />
+          </DrawerContent>
+        </Drawer>
+      )}
+
+      {!isDesktop && canEditMoneySource && (
+        <Drawer
+          open={open && mobileView === "moneySourcePicker"}
+          onOpenChange={(nextOpen) => {
+            if (!nextOpen) setMobileView("form");
+          }}
+        >
+          <DrawerContent
+            className="h-[85dvh] max-h-[85dvh] p-0 flex flex-col data-[vaul-drawer-direction=bottom]:mt-0 data-[vaul-drawer-direction=bottom]:max-h-[85dvh]"
+            onOpenAutoFocus={(event) => event.preventDefault()}
+          >
+            <LedgerMoneySourcePickerPanel
+              mode={moneySourceMode}
+              value={
+                values.moneySourceId === "none" ? "" : values.moneySourceId
+              }
+              paymentMethods={paymentMethods}
+              accounts={accounts}
+              ownerId={entry.ownerId}
+              title={
+                entry.type === "expense"
+                  ? "결제 방법 선택"
+                  : entry.type === "non_expense_withdrawal"
+                    ? "출금처 선택"
+                    : "입금 계좌 선택"
+              }
+              searchPlaceholder="이름, 기관, 소유자 검색"
+              onBack={() => setMobileView("form")}
+              onValueChange={(value) => {
+                handleMoneySourceChange(value);
+                setMobileView("form");
+              }}
+            />
+          </DrawerContent>
+        </Drawer>
+      )}
+    </>
   );
 }

--- a/components/ledger/LedgerEntryEditDialog.tsx
+++ b/components/ledger/LedgerEntryEditDialog.tsx
@@ -328,7 +328,7 @@ export function LedgerEntryEditDialog({
     <>
       {/* 금액 */}
       <div className="space-y-2">
-        <Label htmlFor="edit-amount">금액 (원) *</Label>
+        <Label htmlFor="edit-amount">금액 *</Label>
         <div className="relative">
           <Input
             id="edit-amount"
@@ -336,8 +336,12 @@ export function LedgerEntryEditDialog({
             inputMode="numeric"
             step="any"
             min="0"
+            className="pr-10"
             {...register("amount")}
           />
+          <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-sm text-gray-500">
+            원
+          </span>
         </div>
         {errors.amount && (
           <p className="text-sm text-destructive">{errors.amount.message}</p>

--- a/components/ledger/LedgerMoneySourceCombobox.tsx
+++ b/components/ledger/LedgerMoneySourceCombobox.tsx
@@ -52,7 +52,9 @@ import {
   type LedgerMoneySourceAccount,
   type LedgerMoneySourceGroup,
   type LedgerMoneySourceMode,
+  type LedgerMoneySourceOwnerScope,
   type LedgerMoneySourcePaymentMethod,
+  scopeLedgerMoneySources,
 } from "@/lib/ledger/money-source-options";
 import { cn } from "@/lib/utils/cn";
 import type { Account, PaymentMethod, PaymentMethodType } from "@/types";
@@ -65,6 +67,8 @@ interface LedgerMoneySourceBaseProps {
   ownerId?: string | null;
   includeClearOption?: boolean;
   excludedValues?: string[];
+  accountOwnerScope?: LedgerMoneySourceOwnerScope;
+  paymentMethodOwnerScope?: LedgerMoneySourceOwnerScope;
 }
 
 interface LedgerMoneySourceComboboxProps extends LedgerMoneySourceBaseProps {
@@ -108,15 +112,19 @@ function useMoneySourceGroups({
   ownerId,
   includeClearOption = true,
   excludedValues = [],
+  accountOwnerScope,
+  paymentMethodOwnerScope,
 }: LedgerMoneySourceBaseProps): LedgerMoneySourceGroup[] {
   return useMemo(() => {
     const excluded = new Set(excludedValues);
-    const scopedPaymentMethods = ownerId
-      ? paymentMethods.filter((item) => item.ownerId === ownerId)
-      : paymentMethods;
-    const scopedAccounts = ownerId
-      ? accounts.filter((item) => item.ownerId === ownerId)
-      : accounts;
+    const { paymentMethods: scopedPaymentMethods, accounts: scopedAccounts } =
+      scopeLedgerMoneySources({
+        ownerId,
+        paymentMethods,
+        accounts,
+        accountOwnerScope,
+        paymentMethodOwnerScope,
+      });
     return buildLedgerMoneySourceGroups({
       mode,
       paymentMethods: scopedPaymentMethods,
@@ -135,6 +143,8 @@ function useMoneySourceGroups({
     ownerId,
     includeClearOption,
     excludedValues,
+    accountOwnerScope,
+    paymentMethodOwnerScope,
   ]);
 }
 
@@ -555,6 +565,8 @@ export function LedgerMoneySourceCombobox({
   ownerId,
   includeClearOption = true,
   excludedValues,
+  accountOwnerScope,
+  paymentMethodOwnerScope,
   placeholder,
   onValueChange,
 }: LedgerMoneySourceComboboxProps) {
@@ -562,9 +574,11 @@ export function LedgerMoneySourceCombobox({
   const [search, setSearch] = useState("");
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [createInitialName, setCreateInitialName] = useState("");
-  const scopedAccounts = ownerId
-    ? accounts.filter((account) => account.ownerId === ownerId)
-    : accounts;
+  const { accounts: createScopedAccounts } = scopeLedgerMoneySources({
+    ownerId,
+    paymentMethods,
+    accounts,
+  });
   const groups = useMoneySourceGroups({
     mode,
     value,
@@ -573,6 +587,8 @@ export function LedgerMoneySourceCombobox({
     ownerId,
     includeClearOption,
     excludedValues,
+    accountOwnerScope,
+    paymentMethodOwnerScope,
   });
   const selectedLabel = findSelectedLabel(groups, value) ?? placeholder;
   const createQuery = search.trim();
@@ -642,7 +658,7 @@ export function LedgerMoneySourceCombobox({
         open={createDialogOpen}
         mode={mode}
         initialName={createInitialName}
-        accounts={scopedAccounts}
+        accounts={createScopedAccounts}
         onOpenChange={setCreateDialogOpen}
         onCreated={onValueChange}
       />
@@ -658,6 +674,8 @@ export function LedgerMoneySourcePickerPanel({
   ownerId,
   includeClearOption = true,
   excludedValues,
+  accountOwnerScope,
+  paymentMethodOwnerScope,
   searchPlaceholder,
   onValueChange,
 }: LedgerMoneySourcePickerPanelProps) {
@@ -665,9 +683,11 @@ export function LedgerMoneySourcePickerPanel({
   const [target, setTarget] = useState<MoneySourceCreateTarget | null>(null);
   const shouldReduceMotion = useReducedMotion();
   const [createInitialName, setCreateInitialName] = useState("");
-  const scopedAccounts = ownerId
-    ? accounts.filter((account) => account.ownerId === ownerId)
-    : accounts;
+  const { accounts: createScopedAccounts } = scopeLedgerMoneySources({
+    ownerId,
+    paymentMethods,
+    accounts,
+  });
   const groups = useMoneySourceGroups({
     mode,
     value,
@@ -676,6 +696,8 @@ export function LedgerMoneySourcePickerPanel({
     ownerId,
     includeClearOption,
     excludedValues,
+    accountOwnerScope,
+    paymentMethodOwnerScope,
   });
   const createQuery = search.trim();
   const createLabel = createQuery
@@ -843,7 +865,7 @@ export function LedgerMoneySourcePickerPanel({
                   initialName={createInitialName}
                   type={target.type}
                   typeLabel={target.label}
-                  accounts={scopedAccounts}
+                  accounts={createScopedAccounts}
                   onCreated={(paymentMethod) =>
                     onValueChange(`pm:${paymentMethod.id}`)
                   }

--- a/components/ledger/entry-composer/ComposerFormStep.tsx
+++ b/components/ledger/entry-composer/ComposerFormStep.tsx
@@ -3,6 +3,7 @@
 import { XIcon } from "lucide-react";
 import { useState } from "react";
 import { useFormContext } from "react-hook-form";
+import { SegmentedChoiceGroup } from "@/components/layout";
 import {
   LedgerCategoryCombobox,
   LedgerCategoryPickerPanel,
@@ -20,13 +21,6 @@ import { DatePickerInput } from "@/components/ui/date-picker";
 import { Drawer, DrawerContent } from "@/components/ui/drawer";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { useAccounts } from "@/hooks/use-accounts";
 import { useCategories } from "@/hooks/use-categories";
@@ -135,50 +129,46 @@ export function ComposerFormStep({
       {/* Form Content */}
       <div className="flex-1 overflow-y-auto px-4 pt-16 pb-[calc(1rem+env(safe-area-inset-bottom))] space-y-4">
         <div className="grid grid-cols-2 gap-2">
-          <div className="min-w-0 space-y-1">
+          <div className="min-w-0 space-y-2 col-span-2">
             <Label className="text-sm text-gray-700">유형</Label>
-            <Select
+            <SegmentedChoiceGroup
               value={itemType}
-              onValueChange={(value) =>
-                handleTypeChange(
-                  value as
-                    | "expense"
-                    | "income"
-                    | "transfer"
-                    | "non_expense_withdrawal",
-                )
-              }
-            >
-              <SelectTrigger className="h-10 w-full">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="expense">지출</SelectItem>
-                <SelectItem value="income">수입</SelectItem>
-                <SelectItem value="transfer">내부이체</SelectItem>
-                <SelectItem value="non_expense_withdrawal">
-                  비지출 출금
-                </SelectItem>
-              </SelectContent>
-            </Select>
+              columns={4}
+              onValueChange={handleTypeChange}
+              options={[
+                {
+                  value: "expense",
+                  label: "지출",
+                  selectedClassName: "bg-[#3182F6] text-white",
+                },
+                {
+                  value: "income",
+                  label: "수입",
+                  selectedClassName: "bg-[#F04452] text-white",
+                },
+                { value: "transfer", label: "내부이체" },
+                {
+                  value: "non_expense_withdrawal",
+                  label: "비지출",
+                  selectedClassName: "bg-gray-800 text-white",
+                },
+              ]}
+            />
           </div>
 
-          <div className="min-w-0 space-y-1">
+          <div className="min-w-0 space-y-2 col-span-2">
             <Label className="text-sm text-gray-700">공개범위</Label>
-            <Select
+            <SegmentedChoiceGroup
               value={itemIsShared ? "shared" : "private"}
+              columns={2}
               onValueChange={(value) =>
                 form.setValue(`items.${index}.isShared`, value === "shared")
               }
-            >
-              <SelectTrigger className="h-10 w-full">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="shared">공용</SelectItem>
-                <SelectItem value="private">개인</SelectItem>
-              </SelectContent>
-            </Select>
+              options={[
+                { value: "shared", label: "공용" },
+                { value: "private", label: "개인" },
+              ]}
+            />
           </div>
         </div>
 
@@ -260,13 +250,19 @@ export function ComposerFormStep({
 
         <div className="grid grid-cols-2 gap-2">
           <div className="space-y-1">
-            <Label className="text-sm text-gray-700">금액 (원) *</Label>
-            <Input
-              type="number"
-              inputMode="numeric"
-              placeholder="0"
-              {...form.register(`items.${index}.amount`)}
-            />
+            <Label className="text-sm text-gray-700">금액 *</Label>
+            <div className="relative">
+              <Input
+                type="number"
+                inputMode="numeric"
+                placeholder="0"
+                className="pr-10"
+                {...form.register(`items.${index}.amount`)}
+              />
+              <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-sm text-gray-500">
+                원
+              </span>
+            </div>
             {errors?.amount && (
               <p className="text-xs text-red-500">{errors.amount.message}</p>
             )}

--- a/components/ledger/entry-composer/ComposerFormStep.tsx
+++ b/components/ledger/entry-composer/ComposerFormStep.tsx
@@ -366,6 +366,7 @@ export function ComposerFormStep({
                   paymentMethods={paymentMethods}
                   accounts={accounts}
                   ownerId={userId}
+                  accountOwnerScope="household"
                   includeClearOption={false}
                   excludedValues={fromValue ? [fromValue] : []}
                   placeholder="선택"
@@ -520,6 +521,7 @@ export function ComposerFormStep({
                 paymentMethods={paymentMethods}
                 accounts={accounts}
                 ownerId={userId}
+                accountOwnerScope="household"
                 includeClearOption={false}
                 excludedValues={fromValue ? [fromValue] : []}
                 title="어디로"

--- a/components/ledger/entry-composer/ComposerListStep.tsx
+++ b/components/ledger/entry-composer/ComposerListStep.tsx
@@ -4,6 +4,8 @@ import { PlusIcon, X } from "lucide-react";
 import { useRef, useState } from "react";
 import { useFieldArray, useFormContext, useWatch } from "react-hook-form";
 import { toast } from "sonner";
+import { SegmentedChoiceGroup } from "@/components/layout/SegmentedChoiceGroup";
+import { AmountText } from "@/components/layout/screen";
 import { Button } from "@/components/ui/button";
 import { DatePickerInput } from "@/components/ui/date-picker";
 import {
@@ -15,13 +17,6 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { useAccounts } from "@/hooks/use-accounts";
 import { useCategories } from "@/hooks/use-categories";
 import { usePaymentMethods } from "@/hooks/use-payment-methods";
@@ -158,54 +153,49 @@ export function ComposerListStep({
 
   return (
     <div className="space-y-5 pb-[calc(1rem+env(safe-area-inset-bottom))]">
-      <div className="rounded-2xl bg-white p-4 shadow-sm space-y-4">
+      <div className="rounded-xl border border-gray-100 bg-white p-4 space-y-4">
         <div className="space-y-4">
-          <div className="grid grid-cols-2 gap-2">
-            <div className="min-w-0 space-y-1">
+          <div className="space-y-2">
+            <div className="min-w-0 space-y-2">
               <Label className="text-sm text-gray-700">유형</Label>
-              <Select
+              <SegmentedChoiceGroup
                 value={defaultType}
-                onValueChange={(value) => {
-                  form.setValue(
-                    "defaultType",
-                    value as
-                      | "expense"
-                      | "income"
-                      | "transfer"
-                      | "non_expense_withdrawal",
-                  );
-                }}
-              >
-                <SelectTrigger className="h-10 w-full">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="expense">지출</SelectItem>
-                  <SelectItem value="income">수입</SelectItem>
-                  <SelectItem value="transfer">내부이체</SelectItem>
-                  <SelectItem value="non_expense_withdrawal">
-                    비지출 출금
-                  </SelectItem>
-                </SelectContent>
-              </Select>
+                columns={4}
+                onValueChange={(value) => form.setValue("defaultType", value)}
+                options={[
+                  {
+                    value: "expense",
+                    label: "지출",
+                    selectedClassName: "bg-[#3182F6] text-white",
+                  },
+                  {
+                    value: "income",
+                    label: "수입",
+                    selectedClassName: "bg-[#F04452] text-white",
+                  },
+                  { value: "transfer", label: "내부이체" },
+                  {
+                    value: "non_expense_withdrawal",
+                    label: "비지출",
+                    selectedClassName: "bg-gray-800 text-white",
+                  },
+                ]}
+              />
             </div>
 
-            <div className="min-w-0 space-y-1">
+            <div className="min-w-0 space-y-2">
               <Label className="text-sm text-gray-700">공개범위</Label>
-              <Select
+              <SegmentedChoiceGroup
                 value={defaultIsShared ? "shared" : "private"}
+                columns={2}
                 onValueChange={(value) =>
                   form.setValue("defaultIsShared", value === "shared")
                 }
-              >
-                <SelectTrigger className="h-10 w-full">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="shared">공용</SelectItem>
-                  <SelectItem value="private">개인</SelectItem>
-                </SelectContent>
-              </Select>
+                options={[
+                  { value: "shared", label: "공용" },
+                  { value: "private", label: "개인" },
+                ]}
+              />
             </div>
           </div>
           <div className="min-w-0 space-y-1">
@@ -234,91 +224,97 @@ export function ComposerListStep({
       </div>
 
       <div className="space-y-4">
-        <div className="space-y-2">
-          {fields.map((field, index) => {
-            const item = items[index];
-            if (!item) return null;
-            const typeLabel =
-              item.type === "income"
-                ? "수입"
-                : item.type === "transfer"
-                  ? "내부이체"
-                  : item.type === "non_expense_withdrawal"
-                    ? "비지출 출금"
-                    : "지출";
-            const typeColor =
-              item.type === "income"
-                ? "text-blue-600"
-                : item.type === "transfer"
-                  ? "text-gray-600"
-                  : item.type === "non_expense_withdrawal"
-                    ? "text-purple-600"
-                    : "text-red-600";
-            const hasError = !!form.formState.errors.items?.[index];
+        {fields.length > 0 && (
+          <div className="overflow-hidden rounded-xl bg-white ring-1 ring-gray-100 divide-y divide-gray-100">
+            {fields.map((field, index) => {
+              const item = items[index];
+              if (!item) return null;
+              const typeLabel =
+                item.type === "income"
+                  ? "수입"
+                  : item.type === "transfer"
+                    ? "내부이체"
+                    : item.type === "non_expense_withdrawal"
+                      ? "비지출 출금"
+                      : "지출";
+              const typeColor =
+                item.type === "income"
+                  ? "text-blue-600"
+                  : item.type === "transfer"
+                    ? "text-gray-600"
+                    : item.type === "non_expense_withdrawal"
+                      ? "text-purple-600"
+                      : "text-red-600";
+              const hasError = !!form.formState.errors.items?.[index];
 
-            return (
-              <div
-                key={field.id}
-                className={cn(
-                  "relative mt-2 flex items-center gap-2 rounded-2xl border p-4 shadow-sm transition-colors",
-                  hasError
-                    ? "border-red-200 bg-red-50/10 hover:border-red-300"
-                    : "border-gray-100 bg-white hover:border-gray-200",
-                )}
-              >
-                {/* biome-ignore lint/a11y/useKeyWithClickEvents: non-navigation item click */}
-                {/* biome-ignore lint/a11y/noStaticElementInteractions: list item wrapper click */}
+              return (
                 <div
-                  className="flex-1 flex items-center justify-between cursor-pointer"
-                  onClick={() => onEditItem(index)}
+                  key={field.id}
+                  className={cn(
+                    "flex items-center gap-3 p-4 transition-colors",
+                    hasError ? "bg-red-50/60" : "bg-white hover:bg-gray-50/70",
+                  )}
                 >
-                  <div>
-                    <div className="flex items-center gap-2 mb-1">
-                      <span className={`text-xs font-semibold ${typeColor}`}>
-                        {typeLabel}
-                      </span>
-                      <span
-                        className={`text-[10px] px-1.5 py-0.5 rounded-full font-medium ${item.isShared ? "bg-indigo-50 text-indigo-600" : "bg-gray-100 text-gray-600"}`}
-                      >
-                        {item.isShared ? "공유" : "개인"}
-                      </span>
-                      <span className="text-sm font-medium text-gray-900">
-                        {item.title || "내용을 입력해주세요"}
-                      </span>
-                    </div>
-                    <div className="text-xs text-gray-500">
-                      {getCategoryName(item.type, item.categoryId)}
-                    </div>
-                    {hasError && (
-                      <div className="text-[11px] text-red-500 mt-1 font-medium">
-                        필수 입력 사항이 누락되었습니다.
+                  <button
+                    type="button"
+                    className="min-w-0 flex-1 flex items-center justify-between gap-3 text-left"
+                    onClick={() => onEditItem(index)}
+                  >
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2 mb-1">
+                        <span className={`text-xs font-semibold ${typeColor}`}>
+                          {typeLabel}
+                        </span>
+                        <span
+                          className={`text-[10px] px-1.5 py-0.5 rounded-full font-medium ${item.isShared ? "bg-indigo-50 text-indigo-600" : "bg-gray-100 text-gray-600"}`}
+                        >
+                          {item.isShared ? "공유" : "개인"}
+                        </span>
+                        <span className="text-sm font-medium text-gray-900">
+                          {item.title || "내용을 입력해주세요"}
+                        </span>
                       </div>
-                    )}
-                  </div>
-                  <div className="text-right flex items-center gap-3">
-                    <span className="text-sm font-bold text-gray-900">
-                      {item.amount
-                        ? formatCurrency(Number(item.amount))
-                        : "0원"}
-                    </span>
-                  </div>
-                </div>
+                      <div className="text-xs text-gray-500">
+                        {getCategoryName(item.type, item.categoryId)}
+                      </div>
+                      {hasError && (
+                        <div className="text-[11px] text-red-500 mt-1 font-medium">
+                          필수 입력 사항이 누락되었습니다.
+                        </div>
+                      )}
+                    </div>
+                    <div className="text-right flex items-center gap-3">
+                      <AmountText
+                        amount={Number(item.amount) || 0}
+                        tone={
+                          item.type === "income"
+                            ? "income"
+                            : item.type === "expense"
+                              ? "expense"
+                              : "neutral"
+                        }
+                        className="text-sm font-bold"
+                      />
+                    </div>
+                  </button>
 
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    remove(index);
-                  }}
-                  className="absolute -top-2.5 -right-2.5 flex h-6 w-6 items-center justify-center rounded-full bg-gray-400 text-white shadow-md hover:bg-red-500 transition-colors z-10"
-                >
-                  <X className="h-3 w-3" strokeWidth={3} />
-                </button>
-              </div>
-            );
-          })}
-        </div>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      remove(index);
+                    }}
+                    className="flex size-9 shrink-0 items-center justify-center rounded-full text-gray-400 transition-colors hover:bg-red-50 hover:text-red-500"
+                    aria-label="내역 삭제"
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+        )}
 
         <Button
           type="button"

--- a/components/ledger/funnel/AddTransferStep.tsx
+++ b/components/ledger/funnel/AddTransferStep.tsx
@@ -224,6 +224,7 @@ export function AddTransferStep({
                 paymentMethods={paymentMethods}
                 accounts={accounts}
                 ownerId={userId}
+                accountOwnerScope="household"
                 includeClearOption={false}
                 excludedValues={fromValue ? [fromValue] : []}
                 placeholder="선택"

--- a/components/transactions/StockComposerListStep.tsx
+++ b/components/transactions/StockComposerListStep.tsx
@@ -68,7 +68,7 @@ export function StockComposerListStep({
 
   return (
     <div className="space-y-4 pb-[calc(1rem+env(safe-area-inset-bottom))]">
-      <div className="bg-white rounded-2xl shadow-sm p-4 space-y-4">
+      <div className="rounded-xl border border-gray-100 bg-white p-4 space-y-4">
         <TransactionTypeSelector control={form.control} variant="inline" />
 
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
@@ -112,7 +112,7 @@ export function StockComposerListStep({
       </div>
 
       {fields.length === 0 ? (
-        <div className="bg-white rounded-2xl shadow-sm p-8 flex flex-col items-center justify-center text-center space-y-4">
+        <div className="rounded-xl border border-dashed border-gray-200 bg-white p-8 flex flex-col items-center justify-center text-center space-y-4">
           <div className="w-16 h-16 rounded-full bg-gray-100 flex items-center justify-center">
             <PackagePlusIcon className="h-8 w-8 text-gray-400" />
           </div>
@@ -128,7 +128,7 @@ export function StockComposerListStep({
         </div>
       ) : (
         <div className="space-y-4">
-          <div className="space-y-2">
+          <div className="overflow-hidden rounded-xl bg-white ring-1 ring-gray-100 divide-y divide-gray-100">
             {fields.map((field, index) => {
               const item = watchItems[index];
               if (!item) return null;
@@ -143,21 +143,18 @@ export function StockComposerListStep({
                 <div
                   key={field.id}
                   className={cn(
-                    "relative mt-2 flex items-center gap-2 rounded-2xl border p-4 shadow-sm transition-colors",
-                    hasError
-                      ? "border-red-200 bg-red-50/10 hover:border-red-300"
-                      : "border-gray-100 bg-white hover:border-gray-200",
+                    "flex items-center gap-3 p-4 transition-colors",
+                    hasError ? "bg-red-50/60" : "bg-white hover:bg-gray-50/70",
                   )}
                 >
-                  {/* biome-ignore lint/a11y/useKeyWithClickEvents: non-navigation item click */}
-                  {/* biome-ignore lint/a11y/noStaticElementInteractions: list item wrapper click */}
-                  <div
-                    className="flex-1 flex items-center justify-between cursor-pointer"
+                  <button
+                    type="button"
+                    className="min-w-0 flex-1 flex items-center justify-between gap-3 text-left"
                     onClick={() => onEditItem(index)}
                   >
-                    <div>
+                    <div className="min-w-0">
                       <div className="flex items-center gap-2 mb-1">
-                        <span className="text-sm font-medium text-gray-900">
+                        <span className="truncate text-sm font-medium text-gray-900">
                           {label}
                         </span>
                       </div>
@@ -188,7 +185,7 @@ export function StockComposerListStep({
                         className="text-sm font-bold"
                       />
                     </div>
-                  </div>
+                  </button>
 
                   <button
                     type="button"
@@ -197,9 +194,10 @@ export function StockComposerListStep({
                       e.stopPropagation();
                       remove(index);
                     }}
-                    className="absolute -top-2.5 -right-2.5 flex h-6 w-6 items-center justify-center rounded-full bg-gray-400 text-white shadow-md hover:bg-red-500 transition-colors z-10"
+                    className="flex size-9 shrink-0 items-center justify-center rounded-full text-gray-400 transition-colors hover:bg-red-50 hover:text-red-500"
+                    aria-label="종목 삭제"
                   >
-                    <X className="h-3 w-3" strokeWidth={3} />
+                    <X className="h-4 w-4" />
                   </button>
                 </div>
               );

--- a/components/transactions/TransactionChangeRequestDialog.tsx
+++ b/components/transactions/TransactionChangeRequestDialog.tsx
@@ -6,18 +6,11 @@ import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
+import { TaskFormSurface } from "@/components/layout";
 import { AccountSelector } from "@/components/transactions/AccountSelector";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { DatePickerInput } from "@/components/ui/date-picker";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -165,181 +158,178 @@ export function TransactionChangeRequestDialog({
     }
   };
 
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent
-        className="left-0 top-0 flex h-[100dvh] max-h-[100dvh] w-full max-w-full translate-x-0 translate-y-0 flex-col overflow-y-auto rounded-none border-0 p-5 sm:left-[50%] sm:top-[50%] sm:h-auto sm:max-h-[85dvh] sm:max-w-md sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-lg sm:border sm:p-6"
-        onOpenAutoFocus={(event) => event.preventDefault()}
-      >
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            {!isUpdate && (
-              <AlertTriangleIcon className="h-5 w-5 text-destructive" />
-            )}
-            {isUpdate ? "거래 수정 요청" : "거래 삭제 요청"}
-          </DialogTitle>
-          <DialogDescription>
-            거래 소유자에게 요청 내용이 전달됩니다.
-          </DialogDescription>
-        </DialogHeader>
+  const surfaceTitle = isUpdate ? "거래 수정 요청" : "거래 삭제 요청";
+  const surfaceDescription = "거래 소유자에게 요청 내용이 전달됩니다.";
 
-        <div className="rounded-md border p-4 space-y-2">
-          <div className="flex items-center justify-between">
-            <span className="font-medium">{transaction.stockName}</span>
-            <Badge variant={typeVariant}>{typeLabel}</Badge>
+  return (
+    <TaskFormSurface
+      open={open}
+      onOpenChange={onOpenChange}
+      title={surfaceTitle}
+      description={surfaceDescription}
+    >
+      {!isUpdate && (
+        <div className="flex items-start gap-2 rounded-md bg-destructive/10 p-3 text-destructive text-sm">
+          <AlertTriangleIcon className="mt-0.5 h-4 w-4 shrink-0" />
+          <p>삭제 요청은 소유자가 승인하면 거래가 삭제됩니다.</p>
+        </div>
+      )}
+      <div className="rounded-md border p-4 space-y-2">
+        <div className="flex items-center justify-between">
+          <span className="font-medium">{transaction.stockName}</span>
+          <Badge variant={typeVariant}>{typeLabel}</Badge>
+        </div>
+        <div className="space-y-1 text-muted-foreground text-sm">
+          <div className="flex justify-between">
+            <span>수량</span>
+            <span>{transaction.quantity.toLocaleString()}주</span>
           </div>
-          <div className="space-y-1 text-muted-foreground text-sm">
-            <div className="flex justify-between">
-              <span>수량</span>
-              <span>{transaction.quantity.toLocaleString()}주</span>
-            </div>
-            <div className="flex justify-between">
-              <span>단가</span>
-              <span>
-                {formatCurrency(transaction.price, transaction.currency)}
-              </span>
-            </div>
-            <div className="flex justify-between">
-              <span>소유자</span>
-              <span>{transaction.owner.name}</span>
-            </div>
+          <div className="flex justify-between">
+            <span>단가</span>
+            <span>
+              {formatCurrency(transaction.price, transaction.currency)}
+            </span>
+          </div>
+          <div className="flex justify-between">
+            <span>소유자</span>
+            <span>{transaction.owner.name}</span>
           </div>
         </div>
+      </div>
 
-        {isUpdate ? (
-          <form onSubmit={handleUpdateSubmit} className="space-y-4">
-            <div className="flex items-start gap-2 rounded-md bg-muted/50 p-3 text-muted-foreground text-sm">
-              <InfoIcon className="mt-0.5 h-4 w-4 shrink-0" />
-              <p>종목이나 매수/매도 유형 변경은 삭제 요청으로 처리해주세요.</p>
-            </div>
-
-            <div className="grid grid-cols-2 gap-3">
-              <div className="space-y-2">
-                <Label htmlFor="request-quantity">수량</Label>
-                <Input
-                  id="request-quantity"
-                  type="number"
-                  inputMode="numeric"
-                  step="any"
-                  min="0"
-                  {...form.register("quantity")}
-                />
-                {form.formState.errors.quantity && (
-                  <p className="text-destructive text-sm">
-                    {form.formState.errors.quantity.message}
-                  </p>
-                )}
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="request-price">
-                  단가 ({transaction.currency === "KRW" ? "원" : "$"})
-                </Label>
-                <Input
-                  id="request-price"
-                  type="number"
-                  inputMode="decimal"
-                  step="any"
-                  min="0"
-                  {...form.register("price")}
-                />
-                {form.formState.errors.price && (
-                  <p className="text-destructive text-sm">
-                    {form.formState.errors.price.message}
-                  </p>
-                )}
-              </div>
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="request-transacted-at">거래일</Label>
-              <DatePickerInput
-                id="request-transacted-at"
-                value={watchTransactedAt ?? ""}
-                onChange={(value) =>
-                  form.setValue("transactedAt", value, {
-                    shouldValidate: true,
-                  })
-                }
-              />
-            </div>
-
-            <AccountSelector
-              control={form.control}
-              name="accountId"
-              variant="inline"
-              placeholder="계좌 선택"
-              ownerId={transaction.owner.id}
-            />
-
-            <div className="space-y-2">
-              <Label htmlFor="request-memo">메모</Label>
-              <Textarea
-                id="request-memo"
-                rows={2}
-                className="resize-none"
-                {...form.register("memo")}
-              />
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="request-message">요청 메시지 (선택)</Label>
-              <Textarea
-                id="request-message"
-                rows={3}
-                className="resize-none"
-                placeholder="소유자가 확인할 수 있는 설명을 남겨주세요."
-                {...form.register("message")}
-              />
-            </div>
-
-            <DialogFooter className="mt-auto">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => onOpenChange(false)}
-                disabled={createMutation.isPending}
-              >
-                취소
-              </Button>
-              <Button type="submit" disabled={createMutation.isPending}>
-                {createMutation.isPending ? "요청 중..." : "요청 보내기"}
-              </Button>
-            </DialogFooter>
-          </form>
-        ) : (
-          <div className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="delete-request-message">삭제 사유</Label>
-              <Textarea
-                id="delete-request-message"
-                rows={3}
-                className="resize-none"
-                placeholder="삭제가 필요한 이유를 입력해주세요."
-                {...form.register("message")}
-              />
-            </div>
-
-            <DialogFooter className="mt-auto">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => onOpenChange(false)}
-                disabled={createMutation.isPending}
-              >
-                취소
-              </Button>
-              <Button
-                type="button"
-                onClick={handleDeleteSubmit}
-                disabled={createMutation.isPending}
-              >
-                {createMutation.isPending ? "요청 중..." : "요청 보내기"}
-              </Button>
-            </DialogFooter>
+      {isUpdate ? (
+        <form onSubmit={handleUpdateSubmit} className="space-y-4">
+          <div className="flex items-start gap-2 rounded-md bg-muted/50 p-3 text-muted-foreground text-sm">
+            <InfoIcon className="mt-0.5 h-4 w-4 shrink-0" />
+            <p>종목이나 매수/매도 유형 변경은 삭제 요청으로 처리해주세요.</p>
           </div>
-        )}
-      </DialogContent>
-    </Dialog>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-2">
+              <Label htmlFor="request-quantity">수량</Label>
+              <Input
+                id="request-quantity"
+                type="number"
+                inputMode="numeric"
+                step="any"
+                min="0"
+                {...form.register("quantity")}
+              />
+              {form.formState.errors.quantity && (
+                <p className="text-destructive text-sm">
+                  {form.formState.errors.quantity.message}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="request-price">
+                단가 ({transaction.currency === "KRW" ? "원" : "$"})
+              </Label>
+              <Input
+                id="request-price"
+                type="number"
+                inputMode="decimal"
+                step="any"
+                min="0"
+                {...form.register("price")}
+              />
+              {form.formState.errors.price && (
+                <p className="text-destructive text-sm">
+                  {form.formState.errors.price.message}
+                </p>
+              )}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="request-transacted-at">거래일</Label>
+            <DatePickerInput
+              id="request-transacted-at"
+              value={watchTransactedAt ?? ""}
+              onChange={(value) =>
+                form.setValue("transactedAt", value, {
+                  shouldValidate: true,
+                })
+              }
+            />
+          </div>
+
+          <AccountSelector
+            control={form.control}
+            name="accountId"
+            variant="inline"
+            placeholder="계좌 선택"
+            ownerId={transaction.owner.id}
+          />
+
+          <div className="space-y-2">
+            <Label htmlFor="request-memo">메모</Label>
+            <Textarea
+              id="request-memo"
+              rows={2}
+              className="resize-none"
+              {...form.register("memo")}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="request-message">요청 메시지 (선택)</Label>
+            <Textarea
+              id="request-message"
+              rows={3}
+              className="resize-none"
+              placeholder="소유자가 확인할 수 있는 설명을 남겨주세요."
+              {...form.register("message")}
+            />
+          </div>
+
+          <div className="flex flex-col-reverse gap-2 pt-4 sm:flex-row sm:justify-end">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={createMutation.isPending}
+            >
+              취소
+            </Button>
+            <Button type="submit" disabled={createMutation.isPending}>
+              {createMutation.isPending ? "요청 중..." : "요청 보내기"}
+            </Button>
+          </div>
+        </form>
+      ) : (
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="delete-request-message">삭제 사유</Label>
+            <Textarea
+              id="delete-request-message"
+              rows={3}
+              className="resize-none"
+              placeholder="삭제가 필요한 이유를 입력해주세요."
+              {...form.register("message")}
+            />
+          </div>
+
+          <div className="flex flex-col-reverse gap-2 pt-4 sm:flex-row sm:justify-end">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={createMutation.isPending}
+            >
+              취소
+            </Button>
+            <Button
+              type="button"
+              onClick={handleDeleteSubmit}
+              disabled={createMutation.isPending}
+            >
+              {createMutation.isPending ? "요청 중..." : "요청 보내기"}
+            </Button>
+          </div>
+        </div>
+      )}
+    </TaskFormSurface>
   );
 }

--- a/components/transactions/TransactionSummary.tsx
+++ b/components/transactions/TransactionSummary.tsx
@@ -32,7 +32,7 @@ export function TransactionSummary({ items, type }: TransactionSummaryProps) {
   const typeText = type === "buy" ? "매수" : "매도";
 
   return (
-    <div className="bg-gray-50 rounded-2xl p-5 space-y-3">
+    <div className="rounded-xl border border-gray-100 bg-white p-4 space-y-3">
       <div className="flex items-center justify-between">
         <span className="text-gray-500">등록할 거래</span>
         <span className="font-medium text-gray-900">{validCount}건</span>

--- a/components/transactions/TransactionTypeSelector.tsx
+++ b/components/transactions/TransactionTypeSelector.tsx
@@ -2,6 +2,7 @@
 
 import type { Control, FieldValues, Path } from "react-hook-form";
 import { useController } from "react-hook-form";
+import { SegmentedChoiceGroup } from "@/components/layout";
 import { Label } from "@/components/ui/label";
 
 interface TransactionTypeSelectorProps<T extends FieldValues> {
@@ -21,34 +22,28 @@ export function TransactionTypeSelector<
     control,
     name,
   });
+  const selectedType = field.value as "buy" | "sell";
 
   const content = (
     <>
       <Label className="text-gray-700">거래 유형</Label>
-      <div className="grid grid-cols-2 gap-2">
-        <button
-          type="button"
-          onClick={() => field.onChange("buy")}
-          className={`h-11 rounded-xl font-medium transition-colors ${
-            field.value === "buy"
-              ? "bg-[#F04452] text-white"
-              : "bg-gray-100 text-gray-600 hover:bg-gray-200"
-          }`}
-        >
-          매수
-        </button>
-        <button
-          type="button"
-          onClick={() => field.onChange("sell")}
-          className={`h-11 rounded-xl font-medium transition-colors ${
-            field.value === "sell"
-              ? "bg-[#3182F6] text-white"
-              : "bg-gray-100 text-gray-600 hover:bg-gray-200"
-          }`}
-        >
-          매도
-        </button>
-      </div>
+      <SegmentedChoiceGroup
+        value={selectedType}
+        onValueChange={(nextValue) => field.onChange(nextValue)}
+        columns={2}
+        options={[
+          {
+            value: "buy",
+            label: "매수",
+            selectedClassName: "bg-[#F04452] text-white",
+          },
+          {
+            value: "sell",
+            label: "매도",
+            selectedClassName: "bg-[#3182F6] text-white",
+          },
+        ]}
+      />
     </>
   );
 

--- a/lib/api/ledger.test.ts
+++ b/lib/api/ledger.test.ts
@@ -441,6 +441,38 @@ describe("assertLedgerFinancialSourceOwnership", () => {
       ),
     );
   });
+
+  it("household 계좌로 허용한 계좌는 기록 소유자가 달라도 허용한다", async () => {
+    const supabase = createFinancialSourceSupabaseMock({
+      accounts: [{ id: "acc-1", owner_id: "other-user" }],
+    });
+
+    await expect(
+      assertLedgerFinancialSourceOwnership(supabase as never, {
+        householdId: "household-1",
+        ownerId: "user-1",
+        householdAccountIds: ["acc-1"],
+      }),
+    ).resolves.toBeUndefined();
+    expect(supabase.accountsBuilder.in).toHaveBeenCalledWith("id", ["acc-1"]);
+  });
+
+  it("household 계좌 허용은 결제수단에는 적용하지 않는다", async () => {
+    const supabase = createFinancialSourceSupabaseMock({
+      paymentMethods: [{ id: "pm-1", owner_id: "other-user" }],
+    });
+
+    await expect(
+      assertLedgerFinancialSourceOwnership(supabase as never, {
+        householdId: "household-1",
+        ownerId: "user-1",
+        paymentMethodIds: ["pm-1"],
+      }),
+    ).rejects.toMatchObject({
+      code: "LEDGER_FINANCIAL_SOURCE_FORBIDDEN",
+      statusCode: 403,
+    });
+  });
 });
 
 describe("getOwnLedgerActivity", () => {

--- a/lib/api/ledger.ts
+++ b/lib/api/ledger.ts
@@ -179,6 +179,7 @@ interface LedgerFinancialSourceOwnershipInput {
   householdId: string;
   ownerId: string;
   accountIds?: Array<string | null | undefined>;
+  householdAccountIds?: Array<string | null | undefined>;
   paymentMethodIds?: Array<string | null | undefined>;
 }
 
@@ -191,15 +192,17 @@ export async function assertLedgerFinancialSourceOwnership(
   input: LedgerFinancialSourceOwnershipInput,
 ): Promise<void> {
   const accountIds = uniqueDefined(input.accountIds ?? []);
+  const householdAccountIds = uniqueDefined(input.householdAccountIds ?? []);
+  const allAccountIds = uniqueDefined([...accountIds, ...householdAccountIds]);
   const paymentMethodIds = uniqueDefined(input.paymentMethodIds ?? []);
 
   const [accountsResult, paymentMethodsResult] = await Promise.all([
-    accountIds.length > 0
+    allAccountIds.length > 0
       ? supabase
           .from("accounts")
           .select("id, owner_id")
           .eq("household_id", input.householdId)
-          .in("id", accountIds)
+          .in("id", allAccountIds)
       : Promise.resolve({ data: [], error: null }),
     paymentMethodIds.length > 0
       ? supabase
@@ -228,11 +231,18 @@ export async function assertLedgerFinancialSourceOwnership(
   const hasInvalidAccount = accountIds.some(
     (id) => accountMap.get(id) !== input.ownerId,
   );
+  const hasInvalidHouseholdAccount = householdAccountIds.some(
+    (id) => !accountMap.has(id),
+  );
   const hasInvalidPaymentMethod = paymentMethodIds.some(
     (id) => paymentMethodMap.get(id) !== input.ownerId,
   );
 
-  if (hasInvalidAccount || hasInvalidPaymentMethod) {
+  if (
+    hasInvalidAccount ||
+    hasInvalidHouseholdAccount ||
+    hasInvalidPaymentMethod
+  ) {
     throw new APIError(
       "LEDGER_FINANCIAL_SOURCE_FORBIDDEN",
       "본인의 계좌 또는 결제수단만 기록에 사용할 수 있습니다.",
@@ -887,10 +897,18 @@ export async function createLedgerEntryWithBalanceSync(
   supabase: SupabaseClient<Database>,
   params: CreateLedgerEntryParams,
 ): Promise<LedgerEntry> {
+  const ownerScopedAccountIds =
+    params.type === "transfer"
+      ? [params.fromAccountId]
+      : [params.fromAccountId, params.toAccountId];
+  const householdScopedAccountIds =
+    params.type === "transfer" ? [params.toAccountId] : [];
+
   await assertLedgerFinancialSourceOwnership(supabase, {
     householdId: params.householdId,
     ownerId: params.ownerId,
-    accountIds: [params.fromAccountId, params.toAccountId],
+    accountIds: ownerScopedAccountIds,
+    householdAccountIds: householdScopedAccountIds,
     paymentMethodIds: [params.fromPaymentMethodId, params.toPaymentMethodId],
   });
 

--- a/lib/ledger/money-source-options.test.ts
+++ b/lib/ledger/money-source-options.test.ts
@@ -4,11 +4,13 @@ import {
   getLedgerMoneySourceValue,
   type LedgerMoneySourceAccount,
   type LedgerMoneySourcePaymentMethod,
+  scopeLedgerMoneySources,
 } from "./money-source-options";
 
 const bankAccount: LedgerMoneySourceAccount = {
   id: "bank-1",
   name: "국민은행 생활비",
+  ownerId: "user-1",
   ownerName: "진호",
   broker: "국민은행",
   lastFour: "1222",
@@ -19,6 +21,7 @@ const bankAccount: LedgerMoneySourceAccount = {
 const legacyBankAccount: LedgerMoneySourceAccount = {
   id: "legacy-bank-1",
   name: "신한 적금",
+  ownerId: "user-1",
   ownerName: "진호",
   broker: "신한은행",
   lastFour: null,
@@ -29,6 +32,7 @@ const legacyBankAccount: LedgerMoneySourceAccount = {
 const investmentAccount: LedgerMoneySourceAccount = {
   id: "investment-1",
   name: "토스증권",
+  ownerId: "user-2",
   ownerName: "수진",
   broker: "토스증권",
   lastFour: "3444",
@@ -39,6 +43,7 @@ const investmentAccount: LedgerMoneySourceAccount = {
 const legacyInvestmentAccount: LedgerMoneySourceAccount = {
   id: "legacy-investment-1",
   name: "ISA 계좌",
+  ownerId: "user-2",
   ownerName: "수진",
   broker: "미래에셋",
   lastFour: null,
@@ -49,6 +54,7 @@ const legacyInvestmentAccount: LedgerMoneySourceAccount = {
 const creditCard: LedgerMoneySourcePaymentMethod = {
   id: "pm-card-1",
   name: "현대카드",
+  ownerId: "user-1",
   ownerName: "진호",
   type: "credit_card",
   issuer: "현대카드",
@@ -58,6 +64,7 @@ const creditCard: LedgerMoneySourcePaymentMethod = {
 const cash: LedgerMoneySourcePaymentMethod = {
   id: "pm-cash-1",
   name: "현금",
+  ownerId: "user-2",
   ownerName: "수진",
   type: "cash",
   issuer: null,
@@ -135,6 +142,28 @@ describe("buildLedgerMoneySourceGroups", () => {
       "legacy-investment-1",
       "pm-cash-1",
     ]);
+  });
+});
+
+describe("scopeLedgerMoneySources", () => {
+  it("account scope만 household로 풀면 모든 계좌와 본인 결제수단만 남긴다", () => {
+    const scoped = scopeLedgerMoneySources({
+      ownerId: "user-1",
+      accounts,
+      paymentMethods,
+      accountOwnerScope: "household",
+      paymentMethodOwnerScope: "owner",
+    });
+
+    expect(scoped.accounts.map((account) => account.id)).toEqual([
+      "bank-1",
+      "legacy-bank-1",
+      "investment-1",
+      "legacy-investment-1",
+    ]);
+    expect(
+      scoped.paymentMethods.map((paymentMethod) => paymentMethod.id),
+    ).toEqual(["pm-card-1"]);
   });
 });
 

--- a/lib/ledger/money-source-options.ts
+++ b/lib/ledger/money-source-options.ts
@@ -38,6 +38,16 @@ export interface LedgerMoneySourceGroup {
   options: LedgerMoneySourceOption[];
 }
 
+export type LedgerMoneySourceOwnerScope = "owner" | "household";
+
+interface ScopeLedgerMoneySourcesParams {
+  ownerId?: string | null;
+  paymentMethods: LedgerMoneySourcePaymentMethod[];
+  accounts: LedgerMoneySourceAccount[];
+  paymentMethodOwnerScope?: LedgerMoneySourceOwnerScope;
+  accountOwnerScope?: LedgerMoneySourceOwnerScope;
+}
+
 interface BuildLedgerMoneySourceGroupsParams {
   mode: LedgerMoneySourceMode;
   paymentMethods: LedgerMoneySourcePaymentMethod[];
@@ -147,6 +157,27 @@ export function getLedgerMoneySourceValue({
   if (paymentMethodId) return `pm:${paymentMethodId}`;
   if (accountId) return `acc:${accountId}`;
   return "";
+}
+
+export function scopeLedgerMoneySources({
+  ownerId,
+  paymentMethods,
+  accounts,
+  paymentMethodOwnerScope = "owner",
+  accountOwnerScope = "owner",
+}: ScopeLedgerMoneySourcesParams) {
+  if (!ownerId) return { paymentMethods, accounts };
+
+  return {
+    paymentMethods:
+      paymentMethodOwnerScope === "household"
+        ? paymentMethods
+        : paymentMethods.filter((item) => item.ownerId === ownerId),
+    accounts:
+      accountOwnerScope === "household"
+        ? accounts
+        : accounts.filter((item) => item.ownerId === ownerId),
+  };
 }
 
 export function buildLedgerMoneySourceGroups({


### PR DESCRIPTION
## Summary

Implements #393.

- Add shared task form primitives for financial input/request surfaces.
- Replace mobile fullscreen DialogContent hacks in ledger and stock change request dialogs with a common task surface.
- Align ledger/stock composer lists, type selectors, amount inputs, and account/payment-method create choices with the same task UI language.
- Use ledger combobox/mobile picker flows for change request category and money source selection.
- Allow internal transfer destinations to include other household members' accounts while keeping transfer sources and payment methods owner-scoped.
- Document the input/submission task surface convention to reduce future UI drift.

## Validation

- pnpm type-check
- pnpm test -- components/layout/TaskFormSurface.test.tsx components/ledger/LedgerMoneySourceCombobox.test.tsx components/ledger/LedgerCategoryCombobox.test.tsx components/transactions/AccountSelector.test.tsx components/notifications/RecordChangeRequestDetailClient.test.tsx components/layout/screen/screen-primitives.test.tsx
- pnpm test -- lib/api/ledger.test.ts lib/ledger/money-source-options.test.ts components/ledger/LedgerMoneySourceCombobox.test.tsx
- pnpm build
- pnpm biome check . (exit 0; existing unrelated warnings remain)

## Notes

Local dev server reached Ready, but curl to localhost/127.0.0.1:3000 was refused in this execution environment, so browser-level route inspection was not completed.
