### PR TITLE
feat: recompose settings, notifications, household, and mcp ui

### DIFF
--- a/components/household/HouseholdMembersCard.test.tsx
+++ b/components/household/HouseholdMembersCard.test.tsx
@@ -1,0 +1,114 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  useCancelInvitation,
+  useInvitations,
+  useSendInvitation,
+} from "@/hooks/use-invitation";
+import type { HouseholdMemberInfo } from "@/lib/api/household";
+import { HouseholdMembersCard } from "./HouseholdMembersCard";
+
+vi.mock("@/hooks/use-invitation", () => ({
+  useInvitations: vi.fn(),
+  useSendInvitation: vi.fn(),
+  useCancelInvitation: vi.fn(),
+}));
+
+const mockMembers: HouseholdMemberInfo[] = [
+  {
+    userId: "user-1",
+    name: "진호",
+    email: "jinho@example.com",
+    role: "owner",
+    joinedAt: "2026-05-01T00:00:00.000Z",
+  },
+];
+
+describe("HouseholdMembersCard", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("owner under member limit: shows invite button, clicking it renders InviteFormInline", () => {
+    vi.mocked(useInvitations).mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof useInvitations>);
+
+    const mockSendMutate = vi.fn();
+    vi.mocked(useSendInvitation).mockReturnValue({
+      mutate: mockSendMutate,
+      reset: vi.fn(),
+      isPending: false,
+      error: null,
+      isSuccess: false,
+    } as unknown as ReturnType<typeof useSendInvitation>);
+
+    vi.mocked(useCancelInvitation).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useCancelInvitation>);
+
+    render(
+      <HouseholdMembersCard
+        members={mockMembers}
+        currentUserId="user-1"
+        isOwner={true}
+      />,
+    );
+
+    // 1. Render GroupedList or layout primitives (checking data-testid)
+    const groupedList = screen.getByTestId("grouped-list");
+    expect(groupedList).toBeInTheDocument();
+
+    // 2. Invite button is visible
+    const inviteBtn = screen.getByRole("button", { name: "초대" });
+    expect(inviteBtn).toBeInTheDocument();
+
+    // 3. Invite form is hidden initially
+    expect(
+      screen.queryByPlaceholderText("초대할 이메일 주소"),
+    ).not.toBeInTheDocument();
+
+    // 4. Click invite button to show form
+    fireEvent.click(inviteBtn);
+    const emailInput = screen.getByPlaceholderText("초대할 이메일 주소");
+    expect(emailInput).toBeInTheDocument();
+
+    const cancelBtn = screen.getByRole("button", { name: "취소" });
+    expect(cancelBtn).toBeInTheDocument();
+  });
+
+  it("non-owner: does not show invite button", () => {
+    vi.mocked(useInvitations).mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof useInvitations>);
+
+    vi.mocked(useSendInvitation).mockReturnValue({
+      mutate: vi.fn(),
+      reset: vi.fn(),
+      isPending: false,
+      error: null,
+      isSuccess: false,
+    } as unknown as ReturnType<typeof useSendInvitation>);
+
+    vi.mocked(useCancelInvitation).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useCancelInvitation>);
+
+    render(
+      <HouseholdMembersCard
+        members={mockMembers}
+        currentUserId="user-1"
+        isOwner={false}
+      />,
+    );
+
+    // Invite button should not exist
+    expect(
+      screen.queryByRole("button", { name: "초대" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/components/household/HouseholdMembersCard.tsx
+++ b/components/household/HouseholdMembersCard.tsx
@@ -1,15 +1,12 @@
 "use client";
 
-import { User, UserPlus } from "lucide-react";
+import { UserPlus } from "lucide-react";
 import { useState } from "react";
-import { Button } from "@/components/ui/button";
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+  ScreenSection,
+  SectionHeader,
+} from "@/components/layout/screen/ScreenSection";
+import { Button } from "@/components/ui/button";
 import { MAX_HOUSEHOLD_MEMBERS } from "@/constants/household";
 import {
   useCancelInvitation,
@@ -54,21 +51,17 @@ export function HouseholdMembersCard({
   };
 
   return (
-    <Card>
-      <CardHeader>
-        <div className="flex items-center justify-between">
-          <div>
-            <CardTitle className="flex items-center gap-2">
-              <User className="size-5" />
-              구성원
-            </CardTitle>
-            <CardDescription>
-              {members.length}명 / 최대 {MAX_HOUSEHOLD_MEMBERS}명
-              {pendingInvitations.length > 0 &&
-                ` (대기 중 ${pendingInvitations.length}명)`}
-            </CardDescription>
-          </div>
-          {canInvite && !showInviteForm && (
+    <ScreenSection>
+      <SectionHeader
+        title="구성원"
+        description={`${members.length}명 / 최대 ${MAX_HOUSEHOLD_MEMBERS}명${
+          pendingInvitations.length > 0
+            ? ` (대기 중 ${pendingInvitations.length}명)`
+            : ""
+        }`}
+        action={
+          canInvite &&
+          !showInviteForm && (
             <Button
               variant="outline"
               size="sm"
@@ -77,10 +70,10 @@ export function HouseholdMembersCard({
               <UserPlus className="size-4 mr-2" />
               초대
             </Button>
-          )}
-        </div>
-      </CardHeader>
-      <CardContent className="space-y-4">
+          )
+        }
+      />
+      <div className="space-y-4">
         {showInviteForm && (
           <InviteFormInline
             onSubmit={handleSendInvite}
@@ -99,7 +92,7 @@ export function HouseholdMembersCard({
           onCancelInvitation={(id) => cancelMutation.mutate(id)}
           isCancelling={cancelMutation.isPending}
         />
-      </CardContent>
-    </Card>
+      </div>
+    </ScreenSection>
   );
 }

--- a/components/household/HouseholdSettings.test.tsx
+++ b/components/household/HouseholdSettings.test.tsx
@@ -1,0 +1,84 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useRouter } from "next/navigation";
+import { describe, expect, it, vi } from "vitest";
+import { useUpdateHouseholdName } from "@/hooks/use-household";
+import { HouseholdSettings } from "./HouseholdSettings";
+
+vi.mock("next/navigation", () => ({
+  useRouter: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-household", () => ({
+  useUpdateHouseholdName: vi.fn(),
+}));
+
+describe("HouseholdSettings", () => {
+  it("owner view: renders household name with an edit button and toggles editing form", () => {
+    const mockRouter = { refresh: vi.fn() };
+    vi.mocked(useRouter).mockReturnValue(mockRouter as any);
+
+    const mockMutate = vi.fn();
+    vi.mocked(useUpdateHouseholdName).mockReturnValue({
+      mutate: mockMutate,
+      isPending: false,
+    } as any);
+
+    render(
+      <HouseholdSettings
+        householdId="household-1"
+        householdName="우리 집"
+        isOwner={true}
+      />,
+    );
+
+    // 1. Title is rendered
+    expect(screen.getByText("가구 설정")).toBeInTheDocument();
+
+    // 2. Household name and edit button (Pencil icon) are visible
+    expect(screen.getByText("우리 집")).toBeInTheDocument();
+
+    // We expect GroupedList is used (fail check)
+    const groupedList = screen.getByTestId("grouped-list");
+    expect(groupedList).toBeInTheDocument();
+
+    const editBtn = screen.getByRole("button"); // edit button should exist
+    expect(editBtn).toBeInTheDocument();
+
+    // 3. Clicking edit reveals input, save (Check), and cancel (X) buttons
+    fireEvent.click(editBtn);
+
+    const input = screen.getByPlaceholderText("가구 이름");
+    expect(input).toBeInTheDocument();
+    expect((input as HTMLInputElement).value).toBe("우리 집");
+
+    // Inside editing mode, there should be save and cancel buttons
+    const buttons = screen.getAllByRole("button");
+    expect(buttons.length).toBe(2); // save and cancel buttons
+  });
+
+  it("non-owner view: does not show edit button and displays help message", () => {
+    const mockRouter = { refresh: vi.fn() };
+    vi.mocked(useRouter).mockReturnValue(mockRouter as any);
+
+    vi.mocked(useUpdateHouseholdName).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as any);
+
+    render(
+      <HouseholdSettings
+        householdId="household-1"
+        householdName="우리 집"
+        isOwner={false}
+      />,
+    );
+
+    // No edit button
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+
+    // Shows non-owner text
+    expect(
+      screen.getByText("가구 이름은 관리자만 변경할 수 있습니다."),
+    ).toBeInTheDocument();
+  });
+});

--- a/components/household/HouseholdSettings.tsx
+++ b/components/household/HouseholdSettings.tsx
@@ -1,10 +1,14 @@
 "use client";
 
-import { Check, Pencil, Settings, X } from "lucide-react";
+import { Check, Pencil, X } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
+import { GroupedList } from "@/components/layout/screen/GroupedList";
+import {
+  ScreenSection,
+  SectionHeader,
+} from "@/components/layout/screen/ScreenSection";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { useUpdateHouseholdName } from "@/hooks/use-household";
 
@@ -47,66 +51,65 @@ export function HouseholdSettings({
   };
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <Settings className="size-5" />
-          가구 설정
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        <div className="space-y-2">
-          <p className="text-sm text-gray-500">가구 이름</p>
-          {isEditing ? (
-            <div className="flex items-center gap-2">
-              <Input
-                id="household-name"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                placeholder="가구 이름"
-                className="flex-1"
-                maxLength={50}
-                disabled={isPending}
-              />
-              <Button
-                size="icon"
-                variant="ghost"
-                onClick={handleSave}
-                disabled={isPending || !name.trim()}
-              >
-                <Check className="size-4 text-green-600" />
-              </Button>
-              <Button
-                size="icon"
-                variant="ghost"
-                onClick={handleCancel}
-                disabled={isPending}
-              >
-                <X className="size-4 text-gray-500" />
-              </Button>
-            </div>
-          ) : (
-            <div className="flex items-center justify-between p-3 bg-gray-50 rounded-xl">
-              <span className="font-medium text-gray-900">{householdName}</span>
-              {isOwner && (
+    <ScreenSection>
+      <SectionHeader title="가구 설정" />
+      <GroupedList data-testid="grouped-list">
+        <div className="p-4 space-y-4">
+          <div className="space-y-2">
+            <p className="text-sm text-gray-500">가구 이름</p>
+            {isEditing ? (
+              <div className="flex items-center gap-2">
+                <Input
+                  id="household-name"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="가구 이름"
+                  className="flex-1"
+                  maxLength={50}
+                  disabled={isPending}
+                />
                 <Button
                   size="icon"
                   variant="ghost"
-                  onClick={() => setIsEditing(true)}
+                  onClick={handleSave}
+                  disabled={isPending || !name.trim()}
                 >
-                  <Pencil className="size-4 text-gray-500" />
+                  <Check className="size-4 text-green-600" />
                 </Button>
-              )}
-            </div>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  onClick={handleCancel}
+                  disabled={isPending}
+                >
+                  <X className="size-4 text-gray-500" />
+                </Button>
+              </div>
+            ) : (
+              <div className="flex items-center justify-between p-3 bg-gray-50 rounded-xl">
+                <span className="font-medium text-gray-900">
+                  {householdName}
+                </span>
+                {isOwner && (
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    onClick={() => setIsEditing(true)}
+                  >
+                    <Pencil className="size-4 text-gray-500" />
+                  </Button>
+                )}
+              </div>
+            )}
+          </div>
+
+          {!isOwner && (
+            <p className="text-xs text-gray-400">
+              가구 이름은 관리자만 변경할 수 있습니다.
+            </p>
           )}
         </div>
-
-        {!isOwner && (
-          <p className="text-xs text-gray-400">
-            가구 이름은 관리자만 변경할 수 있습니다.
-          </p>
-        )}
-      </CardContent>
-    </Card>
+      </GroupedList>
+    </ScreenSection>
   );
 }

--- a/components/household/MembersTable.test.tsx
+++ b/components/household/MembersTable.test.tsx
@@ -37,11 +37,23 @@ describe("MembersTable", () => {
       />,
     );
 
+    // 1. No role="table"
     expect(screen.queryByRole("table")).not.toBeInTheDocument();
+
+    // 2. Members and pending invitations render
     expect(screen.getByText("진호")).toBeInTheDocument();
     expect(screen.getByText("jinho@example.com")).toBeInTheDocument();
     expect(screen.getByText("관리자")).toBeInTheDocument();
     expect(screen.getByText("대기 중 초대")).toBeInTheDocument();
     expect(screen.getByText("pending@example.com")).toBeInTheDocument();
+
+    // 3. Member and invitation sections both render as list/grouped row surfaces.
+    // We expect two GroupedLists (one for members, one for invitations).
+    const lists = screen.getAllByTestId("grouped-list");
+    expect(lists.length).toBe(2);
+
+    // 4. Owner cancel invitation button has accessible name "초대 취소"
+    const cancelBtn = screen.getByRole("button", { name: "초대 취소" });
+    expect(cancelBtn).toBeInTheDocument();
   });
 });

--- a/components/household/MembersTable.tsx
+++ b/components/household/MembersTable.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { Crown, Loader2, Mail, Trash2, User } from "lucide-react";
+import { GroupedList } from "@/components/layout/screen/GroupedList";
+import { ScreenState } from "@/components/layout/screen/ScreenState";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import type { HouseholdMemberInfo } from "@/lib/api/household";
@@ -27,11 +29,11 @@ export function MembersTable({
   return (
     <div className="space-y-4">
       {members.length > 0 && (
-        <div className="overflow-hidden rounded-2xl bg-white shadow-sm ring-1 ring-gray-100">
+        <GroupedList data-testid="grouped-list">
           {members.map((member) => (
             <article
               key={member.userId}
-              className="flex min-h-[76px] items-center gap-3 border-gray-100 border-t px-4 py-4 first:border-t-0"
+              className="flex min-h-[76px] items-center gap-3 px-4 py-4"
             >
               <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-gray-100">
                 {member.role === "owner" ? (
@@ -61,19 +63,19 @@ export function MembersTable({
               </div>
             </article>
           ))}
-        </div>
+        </GroupedList>
       )}
 
       {invitations.length > 0 && (
-        <div>
-          <h3 className="mb-2 px-1 font-medium text-gray-500 text-sm">
+        <div className="space-y-2">
+          <h3 className="px-1 font-medium text-gray-500 text-sm">
             대기 중 초대
           </h3>
-          <div className="overflow-hidden rounded-2xl bg-gray-50 shadow-sm ring-1 ring-gray-100">
+          <GroupedList data-testid="grouped-list">
             {invitations.map((invitation) => (
               <article
                 key={invitation.id}
-                className="flex min-h-[76px] items-center gap-3 border-gray-100 border-t px-4 py-4 first:border-t-0"
+                className="flex min-h-[76px] items-center gap-3 px-4 py-4"
               >
                 <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-white text-gray-400">
                   <Mail className="size-5" />
@@ -109,15 +111,16 @@ export function MembersTable({
                 )}
               </article>
             ))}
-          </div>
+          </GroupedList>
         </div>
       )}
 
       {members.length === 0 && invitations.length === 0 && (
-        <div className="rounded-2xl bg-white px-6 py-10 text-center shadow-sm ring-1 ring-gray-100">
-          <User className="mx-auto mb-3 size-8 text-gray-300" />
-          <p className="font-medium text-gray-700">구성원이 없습니다</p>
-        </div>
+        <ScreenState
+          type="empty"
+          title="구성원이 없습니다"
+          description="가구에 구성원을 초대해 보세요."
+        />
       )}
     </div>
   );

--- a/components/notifications/NotificationInboxClient.test.tsx
+++ b/components/notifications/NotificationInboxClient.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  useMarkAllNotificationsAsRead,
+  useMarkNotificationAsRead,
+  useNotifications,
+} from "@/hooks/use-notifications";
+import { NotificationInboxClient } from "./NotificationInboxClient";
+
+vi.mock("@/hooks/use-notifications", () => ({
+  useNotifications: vi.fn(),
+  useMarkNotificationAsRead: vi.fn(),
+  useMarkAllNotificationsAsRead: vi.fn(),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ href, children, onClick, ...props }: any) => (
+    <a href={href} onClick={onClick} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const mockNotificationsPage = {
+  pages: [
+    {
+      items: [
+        {
+          id: "noti-1",
+          title: "새 기록 요청",
+          body: "홍길동님이 수정을 요청했습니다.",
+          type: "ledger_record_change_request",
+          readAt: null,
+          createdAt: "2026-06-16T12:00:00Z",
+          linkKind: "record_change_request_detail",
+          linkParams: { requestId: "req-1" },
+        },
+        {
+          id: "noti-2",
+          title: "기록 변경 알림",
+          body: "기록이 변경되었습니다.",
+          type: "ledger_record_changed",
+          readAt: "2026-06-16T13:00:00Z",
+          createdAt: "2026-06-16T13:00:00Z",
+          linkKind: "ledger_record_detail",
+          linkParams: { entryId: "ledger-1" },
+        },
+      ],
+      nextCursor: null,
+    },
+  ],
+};
+
+describe("NotificationInboxClient", () => {
+  it("renders notifications as navigable list rows with unread affordances", () => {
+    vi.mocked(useNotifications).mockReturnValue({
+      data: mockNotificationsPage,
+      isLoading: false,
+      isFetchingNextPage: false,
+      hasNextPage: false,
+      fetchNextPage: vi.fn(),
+    } as any);
+
+    vi.mocked(useMarkNotificationAsRead).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as any);
+
+    vi.mocked(useMarkAllNotificationsAsRead).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as any);
+
+    render(<NotificationInboxClient />);
+
+    // 1. A notification link points to the href produced by buildNotificationHref.
+    const link = screen.getByRole("link", { name: /새 기록 요청/ });
+    expect(link).toBeInTheDocument();
+    expect(link.getAttribute("href")).toBe("/notifications/requests/req-1");
+
+    // 2. Unread notification has a visible "읽음" button.
+    const markReadButton = screen.getByRole("button", { name: "읽음" });
+    expect(markReadButton).toBeInTheDocument();
+
+    // 3. The "전체 읽음" button is enabled when at least one notification is unread.
+    const markAllReadButton = screen.getByRole("button", { name: /전체 읽음/ });
+    expect(markAllReadButton).toBeInTheDocument();
+    expect(markAllReadButton).not.toBeDisabled();
+
+    // 4. Notification body and type label are visible.
+    expect(
+      screen.getByText("홍길동님이 수정을 요청했습니다."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("가계부 수정/삭제 요청")).toBeInTheDocument();
+
+    // 5. GroupedList should be used for the list of notifications.
+    const groupedList = screen.getByTestId("grouped-list");
+    expect(groupedList).toBeInTheDocument();
+  });
+
+  it("keeps pagination action visible and disabled while fetching", () => {
+    vi.mocked(useNotifications).mockReturnValue({
+      data: mockNotificationsPage,
+      isLoading: false,
+      isFetchingNextPage: true,
+      hasNextPage: true,
+      fetchNextPage: vi.fn(),
+    } as any);
+
+    vi.mocked(useMarkNotificationAsRead).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as any);
+
+    vi.mocked(useMarkAllNotificationsAsRead).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as any);
+
+    render(<NotificationInboxClient />);
+
+    const moreButton = screen.getByRole("button", { name: /더 보기/ });
+    expect(moreButton).toBeInTheDocument();
+    expect(moreButton).toBeDisabled();
+  });
+});

--- a/components/notifications/NotificationInboxClient.tsx
+++ b/components/notifications/NotificationInboxClient.tsx
@@ -2,6 +2,8 @@
 
 import { Check, ChevronRight, Loader2 } from "lucide-react";
 import Link from "next/link";
+import { GroupedList } from "@/components/layout/screen/GroupedList";
+import { ScreenState } from "@/components/layout/screen/ScreenState";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
@@ -66,21 +68,20 @@ export function NotificationInboxClient() {
       </div>
 
       {notifications.length === 0 ? (
-        <div className="rounded-2xl bg-white p-8 text-center shadow-sm">
-          <p className="font-medium text-gray-900">아직 알림이 없습니다</p>
-          <p className="mt-2 text-sm text-gray-500">
-            협업 요청이나 공유 기록 변경이 생기면 여기에 표시됩니다.
-          </p>
-        </div>
+        <ScreenState
+          type="empty"
+          title="아직 알림이 없습니다"
+          description="협업 요청이나 공유 기록 변경이 생기면 여기에 표시됩니다."
+        />
       ) : (
-        <div className="space-y-3">
+        <GroupedList data-testid="grouped-list">
           {notifications.map((notification) => (
-            <NotificationItemCard
+            <NotificationItemRow
               key={notification.id}
               notification={notification}
             />
           ))}
-        </div>
+        </GroupedList>
       )}
 
       {hasNextPage && (
@@ -98,7 +99,7 @@ export function NotificationInboxClient() {
   );
 }
 
-function NotificationItemCard({
+function NotificationItemRow({
   notification,
 }: {
   notification: NotificationItem;
@@ -126,15 +127,15 @@ function NotificationItemCard({
   return (
     <div
       className={cn(
-        "relative rounded-2xl bg-white p-4 shadow-sm transition-colors",
-        isUnread && "ring-1 ring-primary/15",
+        "relative transition-colors hover:bg-gray-50",
+        isUnread && "bg-primary/[0.02] hover:bg-primary/[0.04]",
       )}
     >
-      <Link href={href} onClick={handleClick} className="block pr-8">
+      <Link href={href} onClick={handleClick} className="block p-4 pr-12">
         <div className="flex items-start gap-3">
           <span
             className={cn(
-              "mt-1 size-2.5 rounded-full",
+              "mt-1.5 size-2 shrink-0 rounded-full",
               isUnread ? "bg-primary" : "bg-gray-200",
             )}
           />

--- a/components/notifications/NotificationSettingsClient.test.tsx
+++ b/components/notifications/NotificationSettingsClient.test.tsx
@@ -1,0 +1,165 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  useNotificationPreferences,
+  useUpdateNotificationPreference,
+  useUpdateNotificationPreferencesBatch,
+} from "@/hooks/use-notification-preferences";
+import { usePushSubscription } from "@/hooks/use-push-subscription";
+import { NotificationSettingsClient } from "./NotificationSettingsClient";
+
+vi.mock("@/hooks/use-notification-preferences", () => ({
+  useNotificationPreferences: vi.fn(),
+  useUpdateNotificationPreference: vi.fn(),
+  useUpdateNotificationPreferencesBatch: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-push-subscription", () => ({
+  usePushSubscription: vi.fn(),
+}));
+
+const mockPreferences = [
+  {
+    type: "ledger_record_change_request",
+    label: "가계부 수정/삭제 요청",
+    description: "공용 가계부 기록에 대한 수정 또는 삭제 요청",
+    group: "requests",
+    inAppEnabled: true,
+    pushEnabled: true,
+  },
+  {
+    type: "ledger_record_changed",
+    label: "가계부 기록 수정/삭제",
+    description: "함께 보는 가계부 기록이 수정되거나 삭제됨",
+    group: "changes",
+    inAppEnabled: false,
+    pushEnabled: false,
+  },
+  {
+    type: "invitation_accepted",
+    label: "초대 수락",
+    description: "초대받은 사용자가 가구에 합류함",
+    group: "household",
+    inAppEnabled: true,
+    pushEnabled: false,
+  },
+];
+
+describe("NotificationSettingsClient", () => {
+  it("renders Push device state and grouped preference switches without card-only structure", () => {
+    vi.mocked(useNotificationPreferences).mockReturnValue({
+      data: mockPreferences,
+      isLoading: false,
+    } as any);
+
+    vi.mocked(usePushSubscription).mockReturnValue({
+      deviceState: "subscribed",
+      isSubscribed: true,
+      isPending: false,
+      subscribe: vi.fn(),
+      unsubscribe: vi.fn(),
+    } as any);
+
+    vi.mocked(useUpdateNotificationPreference).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as any);
+
+    vi.mocked(useUpdateNotificationPreferencesBatch).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    } as any);
+
+    render(<NotificationSettingsClient />);
+
+    // 1. Push state title is visible for subscribed.
+    expect(
+      screen.getByText("이 기기에서 Push를 받을 수 있어요"),
+    ).toBeInTheDocument();
+
+    // 2. Preference labels from at least two groups are visible.
+    expect(screen.getByText("가계부 수정/삭제 요청")).toBeInTheDocument();
+    expect(screen.getByText("초대 수락")).toBeInTheDocument();
+
+    // 3. Switch buttons named 앱 and Push are rendered with role="switch".
+    const switches = screen.getAllByRole("switch");
+    expect(switches.length).toBeGreaterThan(0);
+    expect(screen.getAllByText("앱").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Push").length).toBeGreaterThan(0);
+
+    // 4. Assert grouped list semantics or custom data-testid
+    // We expect GroupedList to be used. Let's look for components using data-testid="grouped-list" which will fail now.
+    const groupedLists = screen.getAllByTestId("grouped-list");
+    expect(groupedLists.length).toBeGreaterThan(0);
+  });
+
+  it("shows disabled Push reason when in-app is off or device is not subscribed", () => {
+    vi.mocked(useNotificationPreferences).mockReturnValue({
+      data: mockPreferences,
+      isLoading: false,
+    } as any);
+
+    vi.mocked(usePushSubscription).mockReturnValue({
+      deviceState: "unsupported",
+      isSubscribed: false,
+      isPending: false,
+      subscribe: vi.fn(),
+      unsubscribe: vi.fn(),
+    } as any);
+
+    vi.mocked(useUpdateNotificationPreference).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as any);
+
+    vi.mocked(useUpdateNotificationPreferencesBatch).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    } as any);
+
+    render(<NotificationSettingsClient />);
+
+    // In-app disabled row ("기록 변경 완료" has inAppEnabled: false) shows:
+    expect(
+      screen.getByText("앱 알림을 켜야 Push를 받을 수 있어요."),
+    ).toBeInTheDocument();
+
+    // Unsubscribed device ("기록 변경 요청" has inAppEnabled: true, but device is unsubscribed):
+    expect(
+      screen.getAllByText("상단에서 이 기기 Push를 먼저 켜세요.").length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("shows blocked message when device state is blocked", () => {
+    vi.mocked(useNotificationPreferences).mockReturnValue({
+      data: mockPreferences,
+      isLoading: false,
+    } as any);
+
+    vi.mocked(usePushSubscription).mockReturnValue({
+      deviceState: "blocked",
+      isSubscribed: false,
+      isPending: false,
+      subscribe: vi.fn(),
+      unsubscribe: vi.fn(),
+    } as any);
+
+    vi.mocked(useUpdateNotificationPreference).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as any);
+
+    vi.mocked(useUpdateNotificationPreferencesBatch).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    } as any);
+
+    render(<NotificationSettingsClient />);
+
+    expect(
+      screen.queryByText(
+        "브라우저 또는 OS 설정에서 oat 알림을 허용한 뒤 다시 시도하세요.",
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/components/notifications/NotificationSettingsClient.test.tsx
+++ b/components/notifications/NotificationSettingsClient.test.tsx
@@ -50,7 +50,7 @@ describe("NotificationSettingsClient", () => {
     vi.mocked(useNotificationPreferences).mockReturnValue({
       data: mockPreferences,
       isLoading: false,
-    } as any);
+    } as unknown as ReturnType<typeof useNotificationPreferences>);
 
     vi.mocked(usePushSubscription).mockReturnValue({
       deviceState: "subscribed",
@@ -58,17 +58,17 @@ describe("NotificationSettingsClient", () => {
       isPending: false,
       subscribe: vi.fn(),
       unsubscribe: vi.fn(),
-    } as any);
+    } as unknown as ReturnType<typeof usePushSubscription>);
 
     vi.mocked(useUpdateNotificationPreference).mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
-    } as any);
+    } as unknown as ReturnType<typeof useUpdateNotificationPreference>);
 
     vi.mocked(useUpdateNotificationPreferencesBatch).mockReturnValue({
       mutateAsync: vi.fn(),
       isPending: false,
-    } as any);
+    } as unknown as ReturnType<typeof useUpdateNotificationPreferencesBatch>);
 
     render(<NotificationSettingsClient />);
 
@@ -100,7 +100,7 @@ describe("NotificationSettingsClient", () => {
     vi.mocked(useNotificationPreferences).mockReturnValue({
       data: mockPreferences,
       isLoading: false,
-    } as any);
+    } as unknown as ReturnType<typeof useNotificationPreferences>);
 
     vi.mocked(usePushSubscription).mockReturnValue({
       deviceState: "unsupported",
@@ -108,17 +108,17 @@ describe("NotificationSettingsClient", () => {
       isPending: false,
       subscribe: vi.fn(),
       unsubscribe: vi.fn(),
-    } as any);
+    } as unknown as ReturnType<typeof usePushSubscription>);
 
     vi.mocked(useUpdateNotificationPreference).mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
-    } as any);
+    } as unknown as ReturnType<typeof useUpdateNotificationPreference>);
 
     vi.mocked(useUpdateNotificationPreferencesBatch).mockReturnValue({
       mutateAsync: vi.fn(),
       isPending: false,
-    } as any);
+    } as unknown as ReturnType<typeof useUpdateNotificationPreferencesBatch>);
 
     render(<NotificationSettingsClient />);
 
@@ -137,7 +137,7 @@ describe("NotificationSettingsClient", () => {
     vi.mocked(useNotificationPreferences).mockReturnValue({
       data: mockPreferences,
       isLoading: false,
-    } as any);
+    } as unknown as ReturnType<typeof useNotificationPreferences>);
 
     vi.mocked(usePushSubscription).mockReturnValue({
       deviceState: "blocked",
@@ -145,17 +145,17 @@ describe("NotificationSettingsClient", () => {
       isPending: false,
       subscribe: vi.fn(),
       unsubscribe: vi.fn(),
-    } as any);
+    } as unknown as ReturnType<typeof usePushSubscription>);
 
     vi.mocked(useUpdateNotificationPreference).mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
-    } as any);
+    } as unknown as ReturnType<typeof useUpdateNotificationPreference>);
 
     vi.mocked(useUpdateNotificationPreferencesBatch).mockReturnValue({
       mutateAsync: vi.fn(),
       isPending: false,
-    } as any);
+    } as unknown as ReturnType<typeof useUpdateNotificationPreferencesBatch>);
 
     render(<NotificationSettingsClient />);
 
@@ -164,5 +164,39 @@ describe("NotificationSettingsClient", () => {
         "브라우저 또는 OS 설정에서 oat 알림을 허용한 뒤 다시 시도하세요.",
       ),
     ).toBeInTheDocument();
+  });
+
+  it("keeps toggle buttons clean of inline loader spinners even when mutation is pending", () => {
+    vi.mocked(useNotificationPreferences).mockReturnValue({
+      data: mockPreferences,
+      isLoading: false,
+    } as unknown as ReturnType<typeof useNotificationPreferences>);
+
+    vi.mocked(usePushSubscription).mockReturnValue({
+      deviceState: "subscribed",
+      isSubscribed: true,
+      isPending: false,
+      subscribe: vi.fn(),
+      unsubscribe: vi.fn(),
+    } as unknown as ReturnType<typeof usePushSubscription>);
+
+    vi.mocked(useUpdateNotificationPreference).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: true,
+    } as unknown as ReturnType<typeof useUpdateNotificationPreference>);
+
+    vi.mocked(useUpdateNotificationPreferencesBatch).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useUpdateNotificationPreferencesBatch>);
+
+    render(<NotificationSettingsClient />);
+
+    const switches = screen.getAllByRole("switch");
+    expect(switches.length).toBeGreaterThan(0);
+    for (const toggle of switches) {
+      expect(toggle).toBeDisabled();
+      expect(toggle.querySelector("svg")).not.toBeInTheDocument();
+    }
   });
 });

--- a/components/notifications/NotificationSettingsClient.test.tsx
+++ b/components/notifications/NotificationSettingsClient.test.tsx
@@ -76,6 +76,9 @@ describe("NotificationSettingsClient", () => {
     expect(
       screen.getByText("이 기기에서 Push를 받을 수 있어요"),
     ).toBeInTheDocument();
+    expect(
+      screen.getByText("알림 종류별 앱 내 알림과 Push 수신 여부를 설정합니다."),
+    ).toBeInTheDocument();
 
     // 2. Preference labels from at least two groups are visible.
     expect(screen.getByText("가계부 수정/삭제 요청")).toBeInTheDocument();

--- a/components/notifications/NotificationSettingsClient.tsx
+++ b/components/notifications/NotificationSettingsClient.tsx
@@ -1,6 +1,11 @@
 "use client";
 
 import { Bell, BellOff, Loader2, Smartphone } from "lucide-react";
+import { GroupedList } from "@/components/layout/screen/GroupedList";
+import {
+  ScreenSection,
+  SectionHeader,
+} from "@/components/layout/screen/ScreenSection";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
@@ -54,7 +59,7 @@ export function NotificationSettingsClient() {
       <div>
         <h1 className="text-xl font-semibold text-gray-900">알림 설정</h1>
         <p className="mt-1 text-sm text-gray-500">
-          알림 종류별 앱 내 알림과 Push 수신 여부를 설정합니다.
+          알림 종류별 앱 내 알림 and Push 수신 여부를 설정합니다.
         </p>
       </div>
 
@@ -74,21 +79,18 @@ export function NotificationSettingsClient() {
           }
 
           return (
-            <section key={group} className="space-y-2">
-              <h2 className="px-1 text-sm font-semibold text-gray-700">
-                {label}
-              </h2>
-              <div className="overflow-hidden rounded-2xl bg-white shadow-sm">
-                {items.map((preference, index) => (
+            <ScreenSection key={group}>
+              <SectionHeader title={label} />
+              <GroupedList data-testid="grouped-list">
+                {items.map((preference) => (
                   <PreferenceRow
                     key={preference.type}
                     preference={preference}
                     isPushSubscribed={pushSubscription.isSubscribed}
-                    showBorder={index > 0}
                   />
                 ))}
-              </div>
-            </section>
+              </GroupedList>
+            </ScreenSection>
           );
         },
       )}
@@ -129,8 +131,8 @@ function PushDeviceCard({
   const content = getPushDeviceCardContent(pushSubscription.deviceState);
 
   return (
-    <section className="rounded-2xl bg-white p-4 shadow-sm">
-      <div className="flex items-start gap-3">
+    <GroupedList data-testid="grouped-list">
+      <div className="flex items-start gap-3 p-4">
         <div
           className={cn(
             "flex size-10 shrink-0 items-center justify-center rounded-full",
@@ -213,7 +215,7 @@ function PushDeviceCard({
           )}
         </div>
       </div>
-    </section>
+    </GroupedList>
   );
 }
 
@@ -291,11 +293,9 @@ function getPushDeviceCardContent(
 function PreferenceRow({
   preference,
   isPushSubscribed,
-  showBorder,
 }: {
   preference: NotificationPreferenceView;
   isPushSubscribed: boolean;
-  showBorder: boolean;
 }) {
   const updatePreference = useUpdateNotificationPreference();
 
@@ -327,12 +327,7 @@ function PreferenceRow({
       : null;
 
   return (
-    <div
-      className={cn(
-        "flex items-start justify-between gap-4 p-4",
-        showBorder && "border-gray-100 border-t",
-      )}
-    >
+    <div className="flex items-start justify-between gap-4 p-4">
       <div className="min-w-0 flex-1">
         <p className="font-medium text-gray-900">{preference.label}</p>
         <p className="mt-1 text-sm text-gray-500">{preference.description}</p>

--- a/components/notifications/NotificationSettingsClient.tsx
+++ b/components/notifications/NotificationSettingsClient.tsx
@@ -59,7 +59,7 @@ export function NotificationSettingsClient() {
       <div>
         <h1 className="text-xl font-semibold text-gray-900">알림 설정</h1>
         <p className="mt-1 text-sm text-gray-500">
-          알림 종류별 앱 내 알림 and Push 수신 여부를 설정합니다.
+          알림 종류별 앱 내 알림과 Push 수신 여부를 설정합니다.
         </p>
       </div>
 

--- a/components/notifications/NotificationSettingsClient.tsx
+++ b/components/notifications/NotificationSettingsClient.tsx
@@ -340,14 +340,12 @@ function PreferenceRow({
           label="앱"
           enabled={preference.inAppEnabled}
           disabled={updatePreference.isPending}
-          pending={updatePreference.isPending}
           onClick={() => handleToggle("inAppEnabled")}
         />
         <ToggleButton
           label="Push"
           enabled={preference.pushEnabled}
           disabled={pushDisabled}
-          pending={updatePreference.isPending}
           onClick={() => handleToggle("pushEnabled")}
         />
       </div>
@@ -359,13 +357,11 @@ function ToggleButton({
   label,
   enabled,
   disabled,
-  pending,
   onClick,
 }: {
   label: string;
   enabled: boolean;
   disabled: boolean;
-  pending: boolean;
   onClick: () => void;
 }) {
   return (
@@ -380,7 +376,6 @@ function ToggleButton({
         enabled ? "bg-primary text-white" : "bg-gray-100 text-gray-500",
       )}
     >
-      {pending && <Loader2 className="size-3 animate-spin" />}
       {label}
     </button>
   );

--- a/components/settings/McpTokenManager.test.tsx
+++ b/components/settings/McpTokenManager.test.tsx
@@ -1,0 +1,179 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { toast } from "sonner";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { McpTokenManager } from "./McpTokenManager";
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const mockTokens = [
+  {
+    id: "token-1",
+    name: "My Claude",
+    tokenPrefix: "oat_mcp_test",
+    tokenLast4: "abcd",
+    scopes: ["read"],
+    expiresAt: "2026-09-17T00:00:00.000Z",
+    lastUsedAt: "2026-06-17T12:00:00.000Z",
+    revokedAt: null,
+    createdAt: "2026-06-17T00:00:00.000Z",
+  },
+];
+
+describe("McpTokenManager", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+
+    // Mock clipboard
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+  });
+
+  it("loads and renders token management sections", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: mockTokens }),
+    } as any);
+
+    render(<McpTokenManager />);
+
+    // 1. GET /api/mcp-tokens is called on mount
+    expect(fetchSpy).toHaveBeenCalledWith("/api/mcp-tokens");
+
+    // Wait for tokens to load
+    await waitFor(() => {
+      expect(screen.queryByText("불러오는 중")).not.toBeInTheDocument();
+    });
+
+    // 2. Headings are visible
+    expect(screen.getByText("새 MCP 토큰")).toBeInTheDocument();
+    expect(screen.getByText("클라이언트 연결")).toBeInTheDocument();
+    expect(screen.getByText("토큰 목록")).toBeInTheDocument();
+
+    // 3. Existing token name, prefix/last4, status badge, expiration are visible
+    expect(screen.getByText("My Claude")).toBeInTheDocument();
+    expect(screen.getByText("oat_mcp_test...abcd")).toBeInTheDocument();
+    expect(screen.getByText("읽기 전용")).toBeInTheDocument();
+
+    // 4. Check that GroupedList is used for layout (TDD fail check)
+    const groupedLists = screen.getAllByTestId("grouped-list");
+    expect(groupedLists.length).toBeGreaterThan(0);
+  });
+
+  it("creates a token and exposes one-time copy action", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch");
+    // Initial fetch empty list
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: [] }),
+    } as any);
+
+    render(<McpTokenManager />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("불러오는 중")).not.toBeInTheDocument();
+    });
+
+    // Setup mock response for create POST
+    const newToken = {
+      id: "token-2",
+      name: "New Token",
+      tokenPrefix: "oat_mcp_new",
+      tokenLast4: "wxyz",
+      scopes: ["read"],
+      expiresAt: "2026-09-17T00:00:00.000Z",
+      lastUsedAt: null,
+      revokedAt: null,
+      createdAt: "2026-06-17T00:00:00.000Z",
+    };
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: {
+          token: "oat_mcp_new_token_secret_1234567890",
+          item: newToken,
+        },
+      }),
+    } as any);
+
+    // Enter name and click create
+    const input = screen.getByPlaceholderText("토큰 이름");
+    fireEvent.change(input, { target: { value: "New Token" } });
+
+    const createBtn = screen.getByRole("button", { name: "생성" });
+    fireEvent.click(createBtn);
+
+    // Verify POST was made
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/mcp-tokens",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ name: "New Token" }),
+        }),
+      );
+    });
+
+    // Created token is visible
+    await waitFor(() => {
+      expect(
+        screen.getByText("oat_mcp_new_token_secret_1234567890"),
+      ).toBeInTheDocument();
+    });
+
+    // Copy action writes to clipboard
+    const copyBtn = screen.getByLabelText("MCP 토큰 복사");
+    fireEvent.click(copyBtn);
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        "oat_mcp_new_token_secret_1234567890",
+      );
+      expect(toast.success).toHaveBeenCalledWith("토큰을 복사했습니다.");
+    });
+  });
+
+  it("copies connection snippets and revokes active tokens", async () => {
+    vi.spyOn(global, "fetch")
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: mockTokens }),
+      } as any) // for mount
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({}),
+      } as any); // for delete
+
+    render(<McpTokenManager />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("불러오는 중")).not.toBeInTheDocument();
+    });
+
+    // 1. Copy Codex connection guide
+    const copyCodexBtn = screen.getByLabelText("Codex MCP 설정 복사");
+    fireEvent.click(copyCodexBtn);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      expect.stringContaining("@oat-app/mcp-bridge"),
+    );
+
+    // 2. Revoke token
+    const revokeBtn = screen.getByRole("button", { name: "회수" });
+    fireEvent.click(revokeBtn);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/mcp-tokens/token-1",
+        expect.objectContaining({
+          method: "DELETE",
+        }),
+      );
+    });
+  });
+});

--- a/components/settings/McpTokenManager.tsx
+++ b/components/settings/McpTokenManager.tsx
@@ -1,25 +1,16 @@
 "use client";
 
-import {
-  Check,
-  Copy,
-  KeyRound,
-  Loader2,
-  Plus,
-  RotateCcw,
-  Terminal,
-} from "lucide-react";
+import { Check, Copy, Loader2, Plus, RotateCcw } from "lucide-react";
 import { useEffect, useState, useTransition } from "react";
 import { toast } from "sonner";
+import { GroupedList } from "@/components/layout/screen/GroupedList";
+import {
+  ScreenSection,
+  SectionHeader,
+} from "@/components/layout/screen/ScreenSection";
+import { ScreenState } from "@/components/layout/screen/ScreenState";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 
 interface McpTokenListItem {
@@ -191,77 +182,70 @@ env = { OAT_MCP_TOKEN = "${tokenForGuide}" }`;
   };
 
   return (
-    <div className="space-y-4">
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-base">
-            <KeyRound className="h-4 w-4" />새 MCP 토큰
-          </CardTitle>
-          <CardDescription>
-            읽기 전용 토큰이 생성되며 90일 뒤 만료됩니다.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-3">
-          <div className="flex gap-2">
-            <Input
-              value={name}
-              onChange={(event) => setName(event.target.value)}
-              maxLength={80}
-              placeholder="토큰 이름"
-            />
-            <Button
-              type="button"
-              onClick={handleCreate}
-              disabled={isPending || name.trim().length === 0}
-            >
-              {isPending ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <Plus className="h-4 w-4" />
-              )}
-              생성
-            </Button>
-          </div>
-
-          {createdToken && (
-            <div className="rounded-lg border bg-gray-50 p-3">
-              <div className="flex items-start justify-between gap-3">
-                <code className="break-all text-sm text-gray-900">
-                  {createdToken}
-                </code>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="icon-sm"
-                  onClick={handleCopy}
-                  aria-label="MCP 토큰 복사"
-                >
-                  {copied ? (
-                    <Check className="h-4 w-4" />
-                  ) : (
-                    <Copy className="h-4 w-4" />
-                  )}
-                </Button>
-              </div>
-              <p className="mt-2 text-xs text-gray-500">
-                이 값은 다시 표시되지 않습니다.
-              </p>
+    <div className="space-y-6">
+      <ScreenSection>
+        <SectionHeader
+          title="새 MCP 토큰"
+          description="읽기 전용 토큰이 생성되며 90일 뒤 만료됩니다."
+        />
+        <GroupedList data-testid="grouped-list">
+          <div className="p-4 space-y-3">
+            <div className="flex gap-2">
+              <Input
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                maxLength={80}
+                placeholder="토큰 이름"
+              />
+              <Button
+                type="button"
+                onClick={handleCreate}
+                disabled={isPending || name.trim().length === 0}
+              >
+                {isPending ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Plus className="h-4 w-4" />
+                )}
+                생성
+              </Button>
             </div>
-          )}
-        </CardContent>
-      </Card>
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-base">
-            <Terminal className="h-4 w-4" />
-            클라이언트 연결
-          </CardTitle>
-          <CardDescription>
-            @oat-app/mcp-bridge는 기본적으로 oat 상용 MCP endpoint에 연결합니다.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
+            {createdToken && (
+              <div className="rounded-lg border bg-gray-50 p-3">
+                <div className="flex items-start justify-between gap-3">
+                  <code className="break-all text-sm text-gray-900">
+                    {createdToken}
+                  </code>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon-sm"
+                    onClick={handleCopy}
+                    aria-label="MCP 토큰 복사"
+                  >
+                    {copied ? (
+                      <Check className="h-4 w-4" />
+                    ) : (
+                      <Copy className="h-4 w-4" />
+                    )}
+                  </Button>
+                </div>
+                <p className="mt-2 text-xs text-gray-500">
+                  이 값은 다시 표시되지 않습니다.
+                </p>
+              </div>
+            )}
+          </div>
+        </GroupedList>
+      </ScreenSection>
+
+      <ScreenSection>
+        <SectionHeader
+          title="클라이언트 연결"
+          description="@oat-app/mcp-bridge는 기본적으로 oat 상용 MCP endpoint에 연결합니다."
+        />
+        <div className="space-y-4">
           <ConnectionSnippet
             title="Claude Code"
             value={claudeCodeCommand}
@@ -282,7 +266,7 @@ env = { OAT_MCP_TOKEN = "${tokenForGuide}" }`;
               handleCopyGuide("claude-desktop", claudeDesktopConfig)
             }
           />
-          <div className="rounded-lg border border-dashed p-3">
+          <div className="rounded-lg border border-dashed bg-white p-3">
             <div className="mb-2 flex items-center justify-between gap-3">
               <p className="text-sm font-medium text-gray-900">
                 Preview endpoint
@@ -305,70 +289,67 @@ env = { OAT_MCP_TOKEN = "${tokenForGuide}" }`;
               {previewOverride}
             </code>
           </div>
-        </CardContent>
-      </Card>
+        </div>
+      </ScreenSection>
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">토큰 목록</CardTitle>
-          <CardDescription>
-            AI 도구에서 사용하는 oat MCP 연결을 관리합니다.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          {isLoading ? (
-            <div className="flex items-center justify-center py-8 text-gray-500">
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              불러오는 중
-            </div>
-          ) : tokens.length === 0 ? (
-            <div className="rounded-lg bg-gray-50 px-4 py-8 text-center text-sm text-gray-500">
-              생성된 MCP 토큰이 없습니다.
-            </div>
-          ) : (
-            <div className="divide-y">
-              {tokens.map((token) => {
-                const isRevoked = Boolean(token.revokedAt);
-                return (
-                  <div
-                    key={token.id}
-                    className="flex flex-col gap-3 py-4 first:pt-0 last:pb-0 sm:flex-row sm:items-center sm:justify-between"
-                  >
-                    <div className="min-w-0 space-y-1">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <p className="font-medium text-gray-900">
-                          {token.name}
-                        </p>
-                        <Badge variant={isRevoked ? "secondary" : "outline"}>
-                          {isRevoked ? "회수됨" : "읽기 전용"}
-                        </Badge>
-                      </div>
-                      <p className="text-sm text-gray-500">
-                        {token.tokenPrefix}...{token.tokenLast4}
-                      </p>
-                      <p className="text-xs text-gray-400">
-                        만료 {formatDate(token.expiresAt)} · 마지막 사용{" "}
-                        {formatDate(token.lastUsedAt)}
-                      </p>
+      <ScreenSection>
+        <SectionHeader
+          title="토큰 목록"
+          description="AI 도구에서 사용하는 oat MCP 연결을 관리합니다."
+        />
+        {isLoading ? (
+          <ScreenState
+            type="loading"
+            title="불러오는 중"
+            description="MCP 토큰 목록을 가져오고 있습니다."
+          />
+        ) : tokens.length === 0 ? (
+          <ScreenState
+            type="empty"
+            title="생성된 MCP 토큰이 없습니다"
+            description="새로운 MCP 토큰을 생성해 보세요."
+          />
+        ) : (
+          <GroupedList data-testid="grouped-list">
+            {tokens.map((token) => {
+              const isRevoked = Boolean(token.revokedAt);
+              return (
+                <div
+                  key={token.id}
+                  className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div className="min-w-0 space-y-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <p className="font-medium text-gray-900">{token.name}</p>
+                      <Badge variant={isRevoked ? "secondary" : "outline"}>
+                        {isRevoked ? "회수됨" : "읽기 전용"}
+                      </Badge>
                     </div>
-
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      onClick={() => handleRevoke(token.id)}
-                      disabled={isPending || isRevoked}
-                    >
-                      <RotateCcw className="h-4 w-4" />
-                      회수
-                    </Button>
+                    <p className="text-sm text-gray-500">
+                      {token.tokenPrefix}...{token.tokenLast4}
+                    </p>
+                    <p className="text-xs text-gray-400">
+                      만료 {formatDate(token.expiresAt)} · 마지막 사용{" "}
+                      {formatDate(token.lastUsedAt)}
+                    </p>
                   </div>
-                );
-              })}
-            </div>
-          )}
-        </CardContent>
-      </Card>
+
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => handleRevoke(token.id)}
+                    disabled={isPending || isRevoked}
+                  >
+                    <RotateCcw className="h-4 w-4" />
+                    회수
+                  </Button>
+                </div>
+              );
+            })}
+          </GroupedList>
+        )}
+      </ScreenSection>
     </div>
   );
 }
@@ -387,7 +368,7 @@ function ConnectionSnippet({
   onCopy,
 }: ConnectionSnippetProps) {
   return (
-    <div className="rounded-lg border p-3">
+    <div className="rounded-lg border bg-white p-3">
       <div className="mb-2 flex items-center justify-between gap-3">
         <p className="text-sm font-medium text-gray-900">{title}</p>
         <Button


### PR DESCRIPTION
### Summary
Recompose settings, notifications, household, and MCP token manager views using shared screen primitives.

### Key Changes
- **Notification Settings**: Converted to ScreenSection and GroupedList layout. Fixed description copy regression and removed inline spinners from toggle buttons for cleaner optimistic updates.
- **Notification Inbox**: Grouped notification cards into a single GroupedList row layout. Handled empty state using ScreenState.
- **Household Settings**: Removed shadcn Cards from profile edit and members wrapper. Used GroupedLists for active members and pending invitations.
- **MCP Token Manager**: Removed Card components and redesigned views around ScreenSection and GroupedList list layout. Used ScreenState for loading/empty states.
- **Tests & Quality**: Added test cases for loader-free optimistic preference switches, details navigation paths, household invite controls, and MCP token copies. All 14 tests pass cleanly. Biome check and type check succeed.