### PR TITLE
feat(auth): Auth/Public Shell Cleanup

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,19 +1,10 @@
+import { AuthShell } from "@/components/auth/AuthShell";
 import { SignInForm } from "@/components/auth/SignInForm";
 
 export default function LoginPage() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
-      <div className="w-full max-w-md space-y-8">
-        <div className="text-center">
-          <h1 className="text-3xl font-bold text-gray-900">oat</h1>
-          <p className="mt-2 text-gray-500">가족 자산 통합 관리</p>
-        </div>
-
-        <div className="bg-white rounded-2xl shadow-lg p-8">
-          <h2 className="text-xl font-semibold text-gray-900 mb-6">로그인</h2>
-          <SignInForm />
-        </div>
-      </div>
-    </div>
+    <AuthShell title="로그인">
+      <SignInForm />
+    </AuthShell>
   );
 }

--- a/app/(auth)/reset-password/page.tsx
+++ b/app/(auth)/reset-password/page.tsx
@@ -1,25 +1,13 @@
+import { AuthShell } from "@/components/auth/AuthShell";
 import { ResetPasswordRequestForm } from "@/components/auth/ResetPasswordRequestForm";
 
 export default function ResetPasswordPage() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
-      <div className="w-full max-w-md space-y-8">
-        <div className="text-center">
-          <h1 className="text-3xl font-bold text-gray-900">oat</h1>
-          <p className="mt-2 text-gray-500">가족 자산 통합 관리</p>
-        </div>
-
-        <div className="bg-white rounded-2xl shadow-lg p-8">
-          <h2 className="text-xl font-semibold text-gray-900 mb-2">
-            비밀번호 재설정
-          </h2>
-          <p className="text-sm text-gray-500 mb-6">
-            가입 시 사용한 이메일을 입력해주세요. 비밀번호 재설정 링크를
-            보내드립니다.
-          </p>
-          <ResetPasswordRequestForm />
-        </div>
-      </div>
-    </div>
+    <AuthShell
+      title="비밀번호 재설정"
+      description="가입 시 사용한 이메일을 입력해주세요. 비밀번호 재설정 링크를 보내드립니다."
+    >
+      <ResetPasswordRequestForm />
+    </AuthShell>
   );
 }

--- a/app/(auth)/reset-password/verify/page.tsx
+++ b/app/(auth)/reset-password/verify/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from "next/navigation";
+import { AuthShell } from "@/components/auth/AuthShell";
 import { ResetPasswordVerify } from "@/components/auth/ResetPasswordVerify";
 
 interface VerifyPageProps {
@@ -13,8 +14,8 @@ export default async function VerifyPage({ searchParams }: VerifyPageProps) {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+    <AuthShell title="비밀번호 재설정" contentClassName="mt-0">
       <ResetPasswordVerify email={email} />
-    </div>
+    </AuthShell>
   );
 }

--- a/app/(auth)/set-password/page.tsx
+++ b/app/(auth)/set-password/page.tsx
@@ -1,24 +1,13 @@
+import { AuthShell } from "@/components/auth/AuthShell";
 import { SetPasswordForm } from "@/components/auth/SetPasswordForm";
 
 export default function SetPasswordPage() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
-      <div className="w-full max-w-md space-y-8">
-        <div className="text-center">
-          <h1 className="text-3xl font-bold text-gray-900">oat</h1>
-          <p className="mt-2 text-gray-500">가족 자산 통합 관리</p>
-        </div>
-
-        <div className="bg-white rounded-2xl shadow-lg p-8">
-          <h2 className="text-xl font-semibold text-gray-900 mb-2">
-            비밀번호 설정
-          </h2>
-          <p className="text-sm text-gray-500 mb-6">
-            초대를 수락했습니다. 로그인에 사용할 비밀번호를 설정해주세요.
-          </p>
-          <SetPasswordForm />
-        </div>
-      </div>
-    </div>
+    <AuthShell
+      title="비밀번호 설정"
+      description="초대를 수락했습니다. 로그인에 사용할 비밀번호를 설정해주세요."
+    >
+      <SetPasswordForm />
+    </AuthShell>
   );
 }

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -1,19 +1,10 @@
+import { AuthShell } from "@/components/auth/AuthShell";
 import { SignUpForm } from "@/components/auth/SignUpForm";
 
 export default function SignUpPage() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
-      <div className="w-full max-w-md space-y-8">
-        <div className="text-center">
-          <h1 className="text-3xl font-bold text-gray-900">oat</h1>
-          <p className="mt-2 text-gray-500">가족 자산 통합 관리</p>
-        </div>
-
-        <div className="bg-white rounded-2xl shadow-lg p-8">
-          <h2 className="text-xl font-semibold text-gray-900 mb-6">회원가입</h2>
-          <SignUpForm />
-        </div>
-      </div>
-    </div>
+    <AuthShell title="회원가입">
+      <SignUpForm />
+    </AuthShell>
   );
 }

--- a/app/(auth)/signup/verify/page.tsx
+++ b/app/(auth)/signup/verify/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from "next/navigation";
+import { AuthShell } from "@/components/auth/AuthShell";
 import { EmailVerificationNotice } from "@/components/auth/EmailVerificationNotice";
 
 interface VerifyPageProps {
@@ -13,8 +14,8 @@ export default async function VerifyPage({ searchParams }: VerifyPageProps) {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+    <AuthShell title="이메일 인증" contentClassName="mt-0">
       <EmailVerificationNotice email={email} />
-    </div>
+    </AuthShell>
   );
 }

--- a/app/auth/invite/callback/page.tsx
+++ b/app/auth/invite/callback/page.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
-import { Spinner } from "@/components/ui/spinner";
+import { AuthNotice } from "@/components/auth/AuthNotice";
+import { AuthShell } from "@/components/auth/AuthShell";
+import { Button } from "@/components/ui/button";
 import { createClient } from "@/lib/supabase/client";
 
 export default function InviteCallbackPage() {
@@ -62,24 +65,28 @@ export default function InviteCallbackPage() {
 
   if (error) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50">
-        <div className="text-center space-y-4">
-          <p className="text-red-600">{error}</p>
-          <button
-            type="button"
-            onClick={() => router.replace("/login")}
-            className="text-blue-600 hover:underline"
-          >
-            로그인 페이지로 이동
-          </button>
-        </div>
-      </div>
+      <AuthShell title="초대 확인">
+        <AuthNotice
+          tone="error"
+          title="초대 링크를 처리하지 못했습니다"
+          description={error}
+          primaryAction={
+            <Button asChild className="w-full h-12 rounded-xl">
+              <Link href="/login">로그인 페이지로 이동</Link>
+            </Button>
+          }
+        />
+      </AuthShell>
     );
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50">
-      <Spinner className="size-6 sm:size-8 md:size-10 text-gray-400" />
-    </div>
+    <AuthShell title="초대 확인">
+      <AuthNotice
+        tone="loading"
+        title="초대 링크를 확인하고 있어요"
+        description="잠시만 기다려주세요."
+      />
+    </AuthShell>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -81,7 +81,7 @@ function FeatureCard({
   description: string;
 }) {
   return (
-    <div className="bg-white rounded-2xl p-6 shadow-sm">
+    <div className="bg-white rounded-xl p-6 border border-gray-100">
       <h3 className="font-semibold text-gray-900 mb-2">{title}</h3>
       <p className="text-sm text-gray-600 leading-relaxed">{description}</p>
     </div>

--- a/components/auth/AuthNotice.test.tsx
+++ b/components/auth/AuthNotice.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AuthNotice } from "./AuthNotice";
+
+describe("AuthNotice", () => {
+  it("renders info notice with primary and secondary actions", () => {
+    const { container } = render(
+      <AuthNotice
+        tone="info"
+        title="Info Title"
+        description="Info Description"
+        primaryAction={<button type="button">Primary Button</button>}
+        secondaryAction={<button type="button">Secondary Button</button>}
+      />,
+    );
+
+    expect(screen.getByText("Info Title")).toBeInTheDocument();
+    expect(screen.getByText("Info Description")).toBeInTheDocument();
+
+    const primary = screen.getByText("Primary Button");
+    const secondary = screen.getByText("Secondary Button");
+
+    expect(primary).toBeInTheDocument();
+    expect(secondary).toBeInTheDocument();
+
+    // Primary action should render before secondary action in document order
+    const primaryIndex = container.innerHTML.indexOf("Primary Button");
+    const secondaryIndex = container.innerHTML.indexOf("Secondary Button");
+    expect(primaryIndex).toBeLessThan(secondaryIndex);
+
+    // Root should not contain shadow-lg
+    expect(container.innerHTML).not.toContain("shadow-lg");
+  });
+
+  it("renders error notice with primary action", () => {
+    render(
+      <AuthNotice
+        tone="error"
+        title="Error Title"
+        description="Error Description"
+        primaryAction={<a href="/login">로그인 페이지로 이동</a>}
+      />,
+    );
+
+    expect(screen.getByText("Error Title")).toBeInTheDocument();
+    expect(screen.getByText("Error Description")).toBeInTheDocument();
+
+    const link = screen.getByRole("link", { name: "로그인 페이지로 이동" });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/login");
+  });
+
+  it("wraps long email text safely", () => {
+    const longEmail =
+      "very-long-email-address-that-exceeds-standard-card-width-for-overflow-testing@example.com";
+    render(
+      <AuthNotice
+        tone="info"
+        title="Verification"
+        description={
+          <span>
+            Email sent to{" "}
+            <span className="highlight font-semibold">{longEmail}</span>
+          </span>
+        }
+      />,
+    );
+
+    // Assert that the container or description element wraps safely
+    // Search for the element containing the email
+    const emailSpan = screen.getByText(longEmail);
+    expect(emailSpan).toBeInTheDocument();
+
+    // AuthNotice's description or long text element should wrap
+    const descElement = screen.getByText(/Verification/).nextElementSibling;
+    const className = descElement?.className || "";
+    const hasSafeWrap =
+      className.includes("[overflow-wrap:anywhere]") ||
+      className.includes("break-words");
+    expect(hasSafeWrap).toBe(true);
+  });
+});

--- a/components/auth/AuthNotice.tsx
+++ b/components/auth/AuthNotice.tsx
@@ -1,0 +1,80 @@
+import { AlertCircle, CheckCircle2, Loader2, Mail } from "lucide-react";
+import type * as React from "react";
+import { cn } from "@/lib/utils/cn";
+
+export interface AuthNoticeProps {
+  tone: "info" | "success" | "error" | "loading";
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  children?: React.ReactNode;
+  primaryAction?: React.ReactNode;
+  secondaryAction?: React.ReactNode;
+  className?: string;
+}
+
+export function AuthNotice({
+  tone,
+  title,
+  description,
+  children,
+  primaryAction,
+  secondaryAction,
+  className,
+}: AuthNoticeProps) {
+  let Icon = Mail;
+  let iconColorClass = "text-blue-600";
+  let iconBgClass = "bg-blue-50";
+
+  switch (tone) {
+    case "success":
+      Icon = CheckCircle2;
+      iconColorClass = "text-green-600";
+      iconBgClass = "bg-green-50";
+      break;
+    case "error":
+      Icon = AlertCircle;
+      iconColorClass = "text-red-600";
+      iconBgClass = "bg-red-50";
+      break;
+    case "loading":
+      Icon = Loader2;
+      iconColorClass = "text-gray-600 animate-spin";
+      iconBgClass = "bg-gray-50";
+      break;
+    case "info":
+    default:
+      Icon = Mail;
+      iconColorClass = "text-blue-600";
+      iconBgClass = "bg-blue-50";
+      break;
+  }
+
+  return (
+    <div className={cn("text-center", className)}>
+      <div
+        className={cn(
+          "mx-auto flex size-12 items-center justify-center rounded-full",
+          iconBgClass,
+        )}
+      >
+        <Icon className={cn("size-6", iconColorClass)} />
+      </div>
+
+      <h3 className="mt-4 text-xl font-semibold text-gray-900">{title}</h3>
+      {description && (
+        <p className="mt-2 text-sm leading-6 text-gray-500 [overflow-wrap:anywhere]">
+          {description}
+        </p>
+      )}
+
+      {children && <div className="mt-6">{children}</div>}
+
+      {(primaryAction || secondaryAction) && (
+        <div className="mt-6 space-y-3">
+          {primaryAction && <div>{primaryAction}</div>}
+          {secondaryAction && <div>{secondaryAction}</div>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/auth/AuthRouteShell.test.tsx
+++ b/components/auth/AuthRouteShell.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AuthNotice } from "./AuthNotice";
+import { AuthShell } from "./AuthShell";
+
+describe("AuthRouteShell", () => {
+  it("renders a representative form route inside the shared auth shell", () => {
+    const { container } = render(
+      <AuthShell title="Representative Form Heading">
+        <form>
+          <label htmlFor="test-input">Test Field</label>
+          <input id="test-input" type="text" />
+          <button type="submit">Submit Form</button>
+        </form>
+      </AuthShell>,
+    );
+
+    expect(screen.getByText("Representative Form Heading")).toBeInTheDocument();
+    expect(screen.getByLabelText("Test Field")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Submit Form" }),
+    ).toBeInTheDocument();
+
+    // Check that there is no heavy styling like shadow-lg or rounded-2xl
+    expect(container.innerHTML).not.toContain("shadow-lg");
+    expect(container.innerHTML).not.toContain("rounded-2xl");
+  });
+
+  it("renders a representative notice route inside the shared auth shell", () => {
+    const { container } = render(
+      <AuthShell title="Representative Notice Page" contentClassName="mt-0">
+        <AuthNotice
+          tone="success"
+          title="Operation Successful"
+          description="Everything went fine."
+          primaryAction={<a href="/login">로그인 페이지로 이동</a>}
+        />
+      </AuthShell>,
+    );
+
+    expect(screen.getByText("Representative Notice Page")).toBeInTheDocument();
+    expect(screen.getByText("Operation Successful")).toBeInTheDocument();
+    expect(screen.getByText("Everything went fine.")).toBeInTheDocument();
+
+    const actionLink = screen.getByRole("link", {
+      name: "로그인 페이지로 이동",
+    });
+    expect(actionLink).toBeInTheDocument();
+    expect(actionLink).toHaveAttribute("href", "/login");
+
+    // Check that there is no heavy styling
+    expect(container.innerHTML).not.toContain("shadow-lg");
+    expect(container.innerHTML).not.toContain("rounded-2xl");
+  });
+
+  it("keeps the shared route shell free of heavy card styling", () => {
+    render(
+      <AuthShell title="Simple Shell">
+        <div>Content</div>
+      </AuthShell>,
+    );
+
+    // Assert that the container has border, rounded-xl but no shadow-lg or rounded-2xl
+    const panel = screen.getByText("Simple Shell").closest(".border");
+    expect(panel).toBeInTheDocument();
+    expect(panel?.className).toContain("rounded-xl");
+    expect(panel?.className).not.toContain("rounded-2xl");
+    expect(panel?.className).not.toContain("shadow");
+  });
+});

--- a/components/auth/AuthShell.test.tsx
+++ b/components/auth/AuthShell.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AuthShell } from "./AuthShell";
+
+describe("AuthShell", () => {
+  it("renders brand, title, description, and children in a quiet centered panel", () => {
+    const { container } = render(
+      <AuthShell title="Test Title" description="Test Description">
+        <div>Child Content</div>
+      </AuthShell>,
+    );
+
+    // Assert visible elements
+    expect(screen.getByText("oat")).toBeInTheDocument();
+    expect(screen.getByText("Test Title")).toBeInTheDocument();
+    expect(screen.getByText("Test Description")).toBeInTheDocument();
+    expect(screen.getByText("Child Content")).toBeInTheDocument();
+
+    // Assert styling requirements on the panel/containers
+    // Finding the panel - the container around the title/description/children
+    // It should have 'border' but NOT 'shadow-lg' or 'rounded-2xl'
+    const panel = screen.getByText("Test Title").closest(".border");
+    expect(panel).toBeInTheDocument();
+
+    // Check classes in the container hierarchy
+    const htmlString = container.innerHTML;
+    expect(htmlString).not.toContain("shadow-lg");
+    expect(htmlString).not.toContain("rounded-2xl");
+  });
+
+  it("keeps long text layout-safe", () => {
+    const longDesc =
+      "long-email-address-or-long-description-without-spaces-that-could-overflow-the-width-of-the-card-on-mobile-devices";
+    render(
+      <AuthShell title="Test Title" description={longDesc}>
+        <div>Child Content</div>
+      </AuthShell>,
+    );
+
+    const descElement = screen.getByText(longDesc);
+    const className = descElement.className || "";
+    const hasSafeWrap =
+      className.includes("[overflow-wrap:anywhere]") ||
+      className.includes("break-words");
+    expect(hasSafeWrap).toBe(true);
+  });
+});

--- a/components/auth/AuthShell.tsx
+++ b/components/auth/AuthShell.tsx
@@ -1,0 +1,42 @@
+import type * as React from "react";
+import { cn } from "@/lib/utils/cn";
+
+export interface AuthShellProps {
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  children: React.ReactNode;
+  footer?: React.ReactNode;
+  className?: string;
+  contentClassName?: string;
+}
+
+export function AuthShell({
+  title,
+  description,
+  children,
+  footer,
+  className,
+  contentClassName,
+}: AuthShellProps) {
+  return (
+    <div className={cn("min-h-screen bg-white px-4 py-10 sm:px-6", className)}>
+      <div className="mx-auto flex min-h-[calc(100dvh-5rem)] w-full max-w-md flex-col justify-center">
+        <div className="text-center mb-8">
+          <h1 className="text-3xl font-bold text-gray-900">oat</h1>
+          <p className="mt-2 text-sm text-gray-500">가족 자산 통합 관리</p>
+        </div>
+
+        <div className="rounded-xl border border-gray-100 bg-white p-6 sm:p-8">
+          <h2 className="text-xl font-semibold text-gray-900">{title}</h2>
+          {description && (
+            <p className="mt-2 text-sm leading-6 text-gray-500 [overflow-wrap:anywhere]">
+              {description}
+            </p>
+          )}
+          <div className={cn("mt-6", contentClassName)}>{children}</div>
+          {footer && <div className="mt-6">{footer}</div>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/auth/EmailVerificationNotice.tsx
+++ b/components/auth/EmailVerificationNotice.tsx
@@ -3,14 +3,8 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
+import { AuthNotice } from "@/components/auth/AuthNotice";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import {
   InputOTP,
   InputOTPGroup,
@@ -94,32 +88,32 @@ export function EmailVerificationNotice({
   };
 
   return (
-    <Card className="w-full max-w-md border-0 shadow-lg">
-      <CardHeader className="text-center pb-2">
-        <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-primary/10">
-          <svg
-            className="h-8 w-8 text-primary"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            aria-hidden="true"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
-            />
-          </svg>
-        </div>
-        <CardTitle className="text-xl">이메일을 확인해주세요</CardTitle>
-        <CardDescription className="text-base mt-2">
+    <AuthNotice
+      tone="info"
+      title="이메일을 확인해주세요"
+      description={
+        <>
           <span className="font-medium text-gray-900">{email}</span>
           <br />
           으로 인증 코드를 보냈습니다
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-6">
+        </>
+      }
+      primaryAction={
+        <Button
+          onClick={handleVerify}
+          disabled={otp.length !== 6 || isVerifying}
+          className="w-full h-12 rounded-xl"
+        >
+          {isVerifying ? "확인 중..." : "인증하기"}
+        </Button>
+      }
+      secondaryAction={
+        <Button asChild variant="outline" className="w-full h-12 rounded-xl">
+          <Link href="/login">로그인 페이지로</Link>
+        </Button>
+      }
+    >
+      <div className="space-y-6">
         <div className="flex flex-col items-center gap-4">
           <InputOTP
             maxLength={6}
@@ -142,14 +136,6 @@ export function EmailVerificationNotice({
           )}
         </div>
 
-        <Button
-          onClick={handleVerify}
-          disabled={otp.length !== 6 || isVerifying}
-          className="w-full h-12 rounded-xl"
-        >
-          {isVerifying ? "확인 중..." : "인증하기"}
-        </Button>
-
         <div className="text-center space-y-2">
           <p className="text-sm text-gray-500">
             메일이 오지 않았다면 스팸함을 확인해주세요.
@@ -163,11 +149,7 @@ export function EmailVerificationNotice({
             {isResending ? "발송 중..." : "인증 메일 다시 받기"}
           </Button>
         </div>
-
-        <Button asChild variant="outline" className="w-full h-12 rounded-xl">
-          <Link href="/login">로그인 페이지로</Link>
-        </Button>
-      </CardContent>
-    </Card>
+      </div>
+    </AuthNotice>
   );
 }

--- a/components/auth/ResetPasswordVerify.tsx
+++ b/components/auth/ResetPasswordVerify.tsx
@@ -6,14 +6,8 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { resetPasswordAction } from "@/app/(auth)/reset-password/actions";
+import { AuthNotice } from "@/components/auth/AuthNotice";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import {
   InputOTP,
@@ -133,116 +127,98 @@ export function ResetPasswordVerify({ email }: ResetPasswordVerifyProps) {
 
   if (isVerified) {
     return (
-      <Card className="w-full max-w-md border-0 shadow-lg">
-        <CardHeader className="text-center pb-2">
-          <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-green-100">
-            <svg
-              className="h-8 w-8 text-green-600"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M5 13l4 4L19 7"
-              />
-            </svg>
-          </div>
-          <CardTitle className="text-xl">새 비밀번호 설정</CardTitle>
-          <CardDescription className="text-base mt-2">
-            새로운 비밀번호를 입력해주세요.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <form
-            onSubmit={handleSubmit(onSubmitNewPassword)}
-            className="space-y-6"
-          >
-            <div className="space-y-2">
-              <Label htmlFor="password" className="text-gray-700">
-                새 비밀번호
-              </Label>
-              <Input
-                id="password"
-                type="password"
-                placeholder="영문, 숫자 포함 8자 이상"
-                className="h-12 rounded-xl"
-                aria-invalid={!!errors.password}
-                {...register("password")}
-              />
-              {errors.password && (
-                <p className="text-sm text-destructive">
-                  {errors.password.message}
-                </p>
-              )}
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="confirmPassword" className="text-gray-700">
-                새 비밀번호 확인
-              </Label>
-              <Input
-                id="confirmPassword"
-                type="password"
-                placeholder="비밀번호를 다시 입력해주세요"
-                className="h-12 rounded-xl"
-                aria-invalid={!!errors.confirmPassword}
-                {...register("confirmPassword")}
-              />
-              {errors.confirmPassword && (
-                <p className="text-sm text-destructive">
-                  {errors.confirmPassword.message}
-                </p>
-              )}
-            </div>
-
-            {error && (
-              <p className="text-sm text-destructive text-center">{error}</p>
+      <AuthNotice
+        tone="success"
+        title="새 비밀번호 설정"
+        description="새로운 비밀번호를 입력해주세요."
+      >
+        <form
+          onSubmit={handleSubmit(onSubmitNewPassword)}
+          className="space-y-6 text-left"
+        >
+          <div className="space-y-2">
+            <Label htmlFor="password" className="text-gray-700">
+              새 비밀번호
+            </Label>
+            <Input
+              id="password"
+              type="password"
+              placeholder="영문, 숫자 포함 8자 이상"
+              className="h-12 rounded-xl"
+              aria-invalid={!!errors.password}
+              {...register("password")}
+            />
+            {errors.password && (
+              <p className="text-sm text-destructive font-medium">
+                {errors.password.message}
+              </p>
             )}
+          </div>
 
-            <Button
-              type="submit"
-              className="w-full h-12 rounded-xl text-base font-semibold"
-              disabled={isSubmitting}
-            >
-              {isSubmitting ? "변경 중..." : "비밀번호 변경"}
-            </Button>
-          </form>
-        </CardContent>
-      </Card>
+          <div className="space-y-2">
+            <Label htmlFor="confirmPassword" className="text-gray-700">
+              새 비밀번호 확인
+            </Label>
+            <Input
+              id="confirmPassword"
+              type="password"
+              placeholder="비밀번호를 다시 입력해주세요"
+              className="h-12 rounded-xl"
+              aria-invalid={!!errors.confirmPassword}
+              {...register("confirmPassword")}
+            />
+            {errors.confirmPassword && (
+              <p className="text-sm text-destructive font-medium">
+                {errors.confirmPassword.message}
+              </p>
+            )}
+          </div>
+
+          {error && (
+            <p className="text-sm text-destructive text-center font-medium">
+              {error}
+            </p>
+          )}
+
+          <Button
+            type="submit"
+            className="w-full h-12 rounded-xl text-base font-semibold"
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? "변경 중..." : "비밀번호 변경"}
+          </Button>
+        </form>
+      </AuthNotice>
     );
   }
 
   return (
-    <Card className="w-full max-w-md border-0 shadow-lg">
-      <CardHeader className="text-center pb-2">
-        <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-primary/10">
-          <svg
-            className="h-8 w-8 text-primary"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            aria-hidden="true"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
-            />
-          </svg>
-        </div>
-        <CardTitle className="text-xl">이메일을 확인해주세요</CardTitle>
-        <CardDescription className="text-base mt-2">
+    <AuthNotice
+      tone="info"
+      title="이메일을 확인해주세요"
+      description={
+        <>
           <span className="font-medium text-gray-900">{email}</span>
           <br />
           으로 인증 코드를 보냈습니다
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-6">
+        </>
+      }
+      primaryAction={
+        <Button
+          onClick={handleVerifyOtp}
+          disabled={otp.length !== 6 || isVerifying}
+          className="w-full h-12 rounded-xl"
+        >
+          {isVerifying ? "확인 중..." : "인증하기"}
+        </Button>
+      }
+      secondaryAction={
+        <Button asChild variant="outline" className="w-full h-12 rounded-xl">
+          <Link href="/login">로그인 페이지로</Link>
+        </Button>
+      }
+    >
+      <div className="space-y-6">
         <div className="flex flex-col items-center gap-4">
           <InputOTP
             maxLength={6}
@@ -261,17 +237,11 @@ export function ResetPasswordVerify({ email }: ResetPasswordVerifyProps) {
           </InputOTP>
 
           {error && (
-            <p className="text-sm text-destructive text-center">{error}</p>
+            <p className="text-sm text-destructive text-center font-medium">
+              {error}
+            </p>
           )}
         </div>
-
-        <Button
-          onClick={handleVerifyOtp}
-          disabled={otp.length !== 6 || isVerifying}
-          className="w-full h-12 rounded-xl"
-        >
-          {isVerifying ? "확인 중..." : "인증하기"}
-        </Button>
 
         <div className="text-center space-y-2">
           <p className="text-sm text-gray-500">
@@ -286,11 +256,7 @@ export function ResetPasswordVerify({ email }: ResetPasswordVerifyProps) {
             {isResending ? "발송 중..." : "인증 코드 다시 받기"}
           </Button>
         </div>
-
-        <Button asChild variant="outline" className="w-full h-12 rounded-xl">
-          <Link href="/login">로그인 페이지로</Link>
-        </Button>
-      </CardContent>
-    </Card>
+      </div>
+    </AuthNotice>
   );
 }


### PR DESCRIPTION
Resolves #394.

### Completed
- Created `AuthShell` component to support unified and quiet centered layout without heavy shadow-lg or rounded-2xl classes.
- Created `AuthNotice` component with tone support (info, success, error, loading) and appropriate Lucide icon styles.
- Migrated standard forms page to use `AuthShell`:
  - `/login`
  - `/signup`
  - `/reset-password`
  - `/set-password`
- Migrated verification flows and notice components to `AuthNotice` + `AuthShell`:
  - `/signup/verify`
  - `/reset-password/verify`
- Migrated `/auth/invite/callback` flow handling states to `AuthNotice` + `AuthShell` structure with primary action routing to `/login` for error states.
- Aligned `/` landing page to use rounded-xl and borders instead of shadows on `FeatureCard`.
