### PR TITLE
[codex] Improve ledger category navigation

### DIFF
--- a/app/(main)/ledger/categories/[parentId]/page.tsx
+++ b/app/(main)/ledger/categories/[parentId]/page.tsx
@@ -1,0 +1,40 @@
+import { notFound } from "next/navigation";
+import { PageContainer } from "@/components/layout";
+import { CategoryChildrenPage } from "@/components/ledger/CategoryChildrenPage";
+import { getUserHouseholdId } from "@/lib/api/invitation";
+import { createClient } from "@/lib/supabase/server";
+
+interface CategoryChildrenRouteProps {
+  params: Promise<{ parentId: string }>;
+}
+
+export default async function CategoryChildrenRoute({
+  params,
+}: CategoryChildrenRouteProps) {
+  const { parentId } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) notFound();
+
+  const householdId = await getUserHouseholdId(supabase, user.id);
+  if (!householdId) notFound();
+
+  const { data: parent } = await supabase
+    .from("categories")
+    .select("*")
+    .eq("id", parentId)
+    .eq("household_id", householdId)
+    .is("parent_id", null)
+    .maybeSingle();
+
+  if (!parent) notFound();
+
+  return (
+    <PageContainer maxWidth="medium">
+      <CategoryChildrenPage parent={parent} />
+    </PageContainer>
+  );
+}

--- a/app/(main)/ledger/records/page.tsx
+++ b/app/(main)/ledger/records/page.tsx
@@ -8,6 +8,9 @@ interface LedgerRecordsPageProps {
   searchParams: Promise<{
     date?: string;
     scope?: string;
+    categoryId?: string;
+    childCategoryId?: string;
+    categoryBreakdown?: string;
   }>;
 }
 

--- a/app/api/categories/reorder/route.ts
+++ b/app/api/categories/reorder/route.ts
@@ -9,7 +9,7 @@ import { reorderCategoriesSchema } from "@/schemas/category";
  * PATCH /api/categories/reorder
  * 카테고리 순서 변경 (display_order 배치 업데이트)
  *
- * Body: { orders: [{ id: string, displayOrder: number }] }
+ * Body: { parentId?: string | null, orders: [{ id: string, displayOrder: number }] }
  */
 export async function PATCH(request: Request) {
   try {
@@ -53,6 +53,7 @@ export async function PATCH(request: Request) {
         id: o.id,
         displayOrder: o.displayOrder,
       })),
+      result.data.parentId ?? null,
     );
 
     return NextResponse.json({ success: true });

--- a/app/api/categories/route.ts
+++ b/app/api/categories/route.ts
@@ -14,6 +14,7 @@ import type { CategoryType } from "@/types";
  * Query params:
  *   ?type=expense   → 지출 카테고리만
  *   ?type=income    → 수입 카테고리만
+ *   ?parentId=...  → 특정 parent의 child만
  *   (없음)          → 전체
  */
 export async function GET(request: NextRequest) {
@@ -44,8 +45,20 @@ export async function GET(request: NextRequest) {
       typeParam === "expense" || typeParam === "income"
         ? (typeParam as CategoryType)
         : undefined;
+    const parentIdParam = request.nextUrl.searchParams.get("parentId");
+    const parentId =
+      parentIdParam === null
+        ? undefined
+        : parentIdParam === "__root__"
+          ? null
+          : parentIdParam;
 
-    const categories = await getCategories(supabase, householdId, type);
+    const categories = await getCategories(
+      supabase,
+      householdId,
+      type,
+      parentId,
+    );
 
     return NextResponse.json({ data: categories });
   } catch (error) {
@@ -109,6 +122,7 @@ export async function POST(request: Request) {
       type: result.data.type,
       name: result.data.name,
       icon: result.data.icon,
+      parentId: result.data.parentId,
     });
 
     return NextResponse.json({ data: category }, { status: 201 });

--- a/app/api/ledger-entries/route.ts
+++ b/app/api/ledger-entries/route.ts
@@ -54,6 +54,11 @@ export async function GET(request: NextRequest) {
 
     const tagIdParams = searchParams.getAll("tagId");
 
+    const categoryBreakdown =
+      searchParams.get("categoryBreakdown") === "direct"
+        ? ("direct" as const)
+        : undefined;
+
     const options = {
       year: yearParam ? Number(yearParam) : undefined,
       month: monthParam ? Number(monthParam) : undefined,
@@ -61,6 +66,9 @@ export async function GET(request: NextRequest) {
       scope,
       userId: user.id,
       tagIds: tagIdParams.length > 0 ? tagIdParams : undefined,
+      categoryId: searchParams.get("categoryId") ?? undefined,
+      childCategoryId: searchParams.get("childCategoryId") ?? undefined,
+      categoryBreakdown,
     };
 
     const entries = await getLedgerEntries(supabase, householdId, options);

--- a/app/api/ledger/stats/details/route.ts
+++ b/app/api/ledger/stats/details/route.ts
@@ -69,6 +69,11 @@ export async function GET(request: NextRequest) {
       type,
       scope: parseScope(searchParams.get("scope")),
       categoryId: searchParams.get("categoryId") ?? undefined,
+      childCategoryId: searchParams.get("childCategoryId") ?? undefined,
+      categoryBreakdown:
+        searchParams.get("categoryBreakdown") === "direct"
+          ? "direct"
+          : undefined,
       paymentMethodId: searchParams.get("paymentMethodId") ?? undefined,
       limit: Number(searchParams.get("limit") ?? 20),
     });

--- a/components/ledger/CategoryChildrenPage.test.tsx
+++ b/components/ledger/CategoryChildrenPage.test.tsx
@@ -1,0 +1,90 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { Category } from "@/types";
+import { CategoryChildrenPage } from "./CategoryChildrenPage";
+
+const createCategory = vi.fn();
+
+vi.mock("./CategoryFormDialog", () => ({
+  CategoryFormDialog: ({
+    open,
+    parentId,
+  }: {
+    open: boolean;
+    parentId?: string | null;
+  }) =>
+    open ? (
+      <div data-parent-id={parentId} data-testid="category-form-dialog" />
+    ) : null,
+}));
+
+vi.mock("./CategoryDeleteDialog", () => ({
+  CategoryDeleteDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="category-delete-dialog" /> : null,
+}));
+
+vi.mock("./CategoryIcon", () => ({
+  CategoryIcon: ({ iconName }: { iconName: string | null }) => (
+    <span>Icon: {iconName}</span>
+  ),
+}));
+
+vi.mock("@/hooks/use-categories", () => ({
+  useCategories: () => ({ data: children, isLoading: false }),
+  useCreateCategory: () => ({ mutateAsync: createCategory, isPending: false }),
+}));
+
+const parent: Category = {
+  id: "parent-1",
+  household_id: "house-1",
+  name: "식비",
+  type: "expense",
+  icon: "Utensils",
+  parent_id: null,
+  is_system: true,
+  display_order: 0,
+  created_at: "2026-05-01T00:00:00.000Z",
+  updated_at: "2026-05-01T00:00:00.000Z",
+};
+
+const children: Category[] = [
+  {
+    ...parent,
+    id: "child-1",
+    name: "외식",
+    icon: "Store",
+    parent_id: "parent-1",
+    is_system: false,
+  },
+];
+
+describe("CategoryChildrenPage", () => {
+  it("parent name과 child categories를 보여준다", () => {
+    render(<CategoryChildrenPage parent={parent} />);
+
+    expect(screen.getByText("식비")).toBeInTheDocument();
+    expect(screen.getByText("외식")).toBeInTheDocument();
+  });
+
+  it("child create dialog를 parentId와 함께 연다", () => {
+    render(<CategoryChildrenPage parent={parent} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "세부 카테고리 추가" }));
+
+    expect(screen.getByTestId("category-form-dialog")).toHaveAttribute(
+      "data-parent-id",
+      "parent-1",
+    );
+  });
+
+  it("custom child edit/delete actions를 제공한다", async () => {
+    const user = userEvent.setup();
+    render(<CategoryChildrenPage parent={parent} />);
+
+    await user.click(screen.getByRole("button", { name: /메뉴 열기/i }));
+
+    expect(await screen.findByText("수정")).toBeInTheDocument();
+    expect(await screen.findByText("삭제")).toBeInTheDocument();
+  });
+});

--- a/components/ledger/CategoryChildrenPage.test.tsx
+++ b/components/ledger/CategoryChildrenPage.test.tsx
@@ -65,6 +65,7 @@ describe("CategoryChildrenPage", () => {
 
     expect(screen.getByText("식비")).toBeInTheDocument();
     expect(screen.getByText("외식")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "카테고리" })).toBeNull();
   });
 
   it("child create dialog를 parentId와 함께 연다", () => {

--- a/components/ledger/CategoryChildrenPage.tsx
+++ b/components/ledger/CategoryChildrenPage.tsx
@@ -7,7 +7,6 @@ import {
   Plus,
   Trash2Icon,
 } from "lucide-react";
-import Link from "next/link";
 import { useState } from "react";
 import {
   GroupedList,
@@ -41,11 +40,6 @@ export function CategoryChildrenPage({ parent }: { parent: Category }) {
 
   return (
     <ScreenSection>
-      <div className="px-1">
-        <Button asChild variant="ghost" size="sm" className="-ml-2">
-          <Link href="/ledger/categories">카테고리</Link>
-        </Button>
-      </div>
       <SectionHeader
         title={parent.name}
         description="세부 카테고리 관리"

--- a/components/ledger/CategoryChildrenPage.tsx
+++ b/components/ledger/CategoryChildrenPage.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import {
+  LockIcon,
+  MoreHorizontal,
+  PencilIcon,
+  Plus,
+  Trash2Icon,
+} from "lucide-react";
+import Link from "next/link";
+import { useState } from "react";
+import {
+  GroupedList,
+  ScreenSection,
+  ScreenState,
+  SectionHeader,
+} from "@/components/layout/screen";
+import { CategoryDeleteDialog } from "@/components/ledger/CategoryDeleteDialog";
+import { CategoryFormDialog } from "@/components/ledger/CategoryFormDialog";
+import { CategoryIcon } from "@/components/ledger/CategoryIcon";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useCategories } from "@/hooks/use-categories";
+import type { Category } from "@/types";
+
+export function CategoryChildrenPage({ parent }: { parent: Category }) {
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState<Category | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<Category | null>(null);
+  const { data: children = [], isLoading } = useCategories(
+    parent.type,
+    parent.id,
+  );
+
+  return (
+    <ScreenSection>
+      <div className="px-1">
+        <Button asChild variant="ghost" size="sm" className="-ml-2">
+          <Link href="/ledger/categories">카테고리</Link>
+        </Button>
+      </div>
+      <SectionHeader
+        title={parent.name}
+        description="세부 카테고리 관리"
+        action={
+          <Button size="sm" onClick={() => setIsCreateOpen(true)}>
+            <Plus className="mr-1 size-4" />
+            세부 카테고리 추가
+          </Button>
+        }
+      />
+
+      {isLoading ? (
+        <GroupedList>
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div
+              // biome-ignore lint/suspicious/noArrayIndexKey: skeleton rows are static
+              key={i}
+              className="flex items-center gap-3 px-4 py-3.5 sm:px-5"
+            >
+              <Skeleton className="size-10 shrink-0 rounded-full" />
+              <Skeleton className="h-4 w-24 rounded" />
+            </div>
+          ))}
+        </GroupedList>
+      ) : children.length === 0 ? (
+        <ScreenState
+          type="empty"
+          title="등록된 세부 카테고리가 없습니다."
+          description="세부 카테고리를 추가하여 더 자세히 분류해보세요."
+        />
+      ) : (
+        <GroupedList>
+          {children.map((category) => (
+            <article
+              key={category.id}
+              className="flex items-center justify-between gap-3 px-4 py-3.5 sm:px-5"
+            >
+              <div className="flex min-w-0 items-center gap-3">
+                <div
+                  className={`flex size-10 shrink-0 items-center justify-center rounded-full ${
+                    category.is_system
+                      ? "bg-gray-100 text-gray-500"
+                      : "bg-primary/10 text-primary"
+                  }`}
+                >
+                  <CategoryIcon iconName={category.icon} className="size-5" />
+                </div>
+                <span className="truncate text-sm font-semibold text-gray-900">
+                  {category.name}
+                </span>
+              </div>
+
+              {category.is_system ? (
+                <div className="flex items-center gap-2 text-gray-400">
+                  <Badge
+                    variant="outline"
+                    className="h-5 border-gray-200 px-1.5 py-0 text-[10px] text-gray-400"
+                  >
+                    기본
+                  </Badge>
+                  <div className="flex size-9 items-center justify-center">
+                    <LockIcon className="size-4" />
+                  </div>
+                </div>
+              ) : (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="size-9"
+                      aria-label="메뉴 열기"
+                    >
+                      <MoreHorizontal className="size-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem onClick={() => setEditTarget(category)}>
+                      <PencilIcon className="mr-2 size-4" />
+                      수정
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      className="text-red-500 focus:bg-red-50 focus:text-red-500"
+                      onClick={() => setDeleteTarget(category)}
+                    >
+                      <Trash2Icon className="mr-2 size-4" />
+                      삭제
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
+            </article>
+          ))}
+        </GroupedList>
+      )}
+
+      <CategoryFormDialog
+        open={isCreateOpen}
+        onOpenChange={setIsCreateOpen}
+        type={parent.type}
+        mode="create"
+        parentId={parent.id}
+        parentName={parent.name}
+      />
+
+      <CategoryFormDialog
+        open={!!editTarget}
+        onOpenChange={(open) => {
+          if (!open) setEditTarget(null);
+        }}
+        type={parent.type}
+        mode="edit"
+        category={editTarget ?? undefined}
+        parentId={parent.id}
+        parentName={parent.name}
+      />
+
+      <CategoryDeleteDialog
+        category={deleteTarget}
+        open={!!deleteTarget}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTarget(null);
+        }}
+      />
+    </ScreenSection>
+  );
+}

--- a/components/ledger/CategoryFormDialog.tsx
+++ b/components/ledger/CategoryFormDialog.tsx
@@ -48,6 +48,8 @@ interface CategoryFormDialogProps {
   type: CategoryType;
   mode: "create" | "edit";
   category?: Category;
+  parentId?: string | null;
+  parentName?: string;
 }
 
 export function CategoryFormDialog({
@@ -56,6 +58,8 @@ export function CategoryFormDialog({
   type,
   mode,
   category,
+  parentId = null,
+  parentName,
 }: CategoryFormDialogProps) {
   const isDesktop = useMediaQuery("(min-width: 768px)");
   const createMutation = useCreateCategory();
@@ -101,6 +105,7 @@ export function CategoryFormDialog({
           type,
           name: data.name,
           icon: data.icon,
+          parentId,
         });
         toast.success("카테고리가 추가되었습니다.");
       } else if (category) {
@@ -125,8 +130,16 @@ export function CategoryFormDialog({
     }
   };
 
-  const title = mode === "create" ? "카테고리 추가" : "카테고리 수정";
+  const title =
+    mode === "create"
+      ? parentId
+        ? "세부 카테고리 추가"
+        : "카테고리 추가"
+      : "카테고리 수정";
   const typeLabel = type === "expense" ? "지출" : "수입";
+  const description = parentName
+    ? `${typeLabel} 카테고리 - ${parentName}`
+    : `${typeLabel} 카테고리`;
   const isPending = createMutation.isPending || updateMutation.isPending;
 
   const iconPicker = (
@@ -207,7 +220,7 @@ export function CategoryFormDialog({
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
             <DialogTitle>{title}</DialogTitle>
-            <DialogDescription>{typeLabel} 카테고리</DialogDescription>
+            <DialogDescription>{description}</DialogDescription>
           </DialogHeader>
 
           <form
@@ -242,7 +255,7 @@ export function CategoryFormDialog({
       <DrawerContent>
         <DrawerHeader>
           <DrawerTitle>{title}</DrawerTitle>
-          <DrawerDescription>{typeLabel} 카테고리</DrawerDescription>
+          <DrawerDescription>{description}</DrawerDescription>
         </DrawerHeader>
 
         <div className="overflow-y-auto flex-1 px-4">

--- a/components/ledger/CategoryList.test.tsx
+++ b/components/ledger/CategoryList.test.tsx
@@ -102,6 +102,11 @@ describe("CategoryList", () => {
       "/ledger/categories/cat-sys",
     );
     expect(screen.getByText("세부 카테고리 관리")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "상위 카테고리를 선택해 세부 카테고리를 관리할 수 있습니다.",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("shows custom category edit and delete actions but keeps system category locked", () => {

--- a/components/ledger/CategoryList.test.tsx
+++ b/components/ledger/CategoryList.test.tsx
@@ -109,18 +109,20 @@ describe("CategoryList", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows custom category edit and delete actions but keeps system category locked", () => {
+  it("shows default status, custom actions, and navigation disclosures", () => {
     mocks.categories = [systemCategory, customCategory];
 
     render(<CategoryList />);
 
-    // System category should show a lock/default indicator and status text
-    expect(screen.getByTestId("lock-icon")).toBeInTheDocument();
     expect(screen.getByText("기본")).toBeInTheDocument();
-
-    // Custom category has menu trigger (e.g. MoreHorizontal or equivalent button)
+    expect(screen.queryByTestId("lock-icon")).not.toBeInTheDocument();
+    expect(screen.getAllByTestId("category-disclosure")).toHaveLength(2);
     const menuButtons = screen.getAllByRole("button", { name: /메뉴 열기/i });
-    expect(menuButtons).toHaveLength(1); // Only 1 custom category menu button
+    expect(menuButtons).toHaveLength(1);
+    expect(screen.getByRole("link", { name: /배달/ })).toHaveAttribute(
+      "href",
+      "/ledger/categories/cat-cust",
+    );
   });
 
   it("opens create dialog from the section header add action", () => {

--- a/components/ledger/CategoryList.test.tsx
+++ b/components/ledger/CategoryList.test.tsx
@@ -50,6 +50,7 @@ const systemCategory: Category = {
   name: "식비",
   type: "expense",
   icon: "food",
+  parent_id: null,
   is_system: true,
   display_order: 0,
   created_at: "2026-05-01T00:00:00.000Z",
@@ -62,15 +63,23 @@ const customCategory: Category = {
   name: "배달",
   type: "expense",
   icon: "delivery",
+  parent_id: null,
   is_system: false,
   display_order: 1,
   created_at: "2026-05-01T00:00:00.000Z",
   updated_at: "2026-05-01T00:00:00.000Z",
 };
 
+const childCategory: Category = {
+  ...customCategory,
+  id: "cat-child",
+  name: "외식",
+  parent_id: "cat-sys",
+};
+
 describe("CategoryList", () => {
   it("renders categories as grouped list rows", () => {
-    mocks.categories = [systemCategory, customCategory];
+    mocks.categories = [systemCategory, customCategory, childCategory];
 
     render(<CategoryList />);
 
@@ -78,8 +87,21 @@ describe("CategoryList", () => {
     expect(screen.getByText("수입")).toBeInTheDocument();
     expect(screen.getByText("식비")).toBeInTheDocument();
     expect(screen.getByText("배달")).toBeInTheDocument();
+    expect(screen.queryByText("외식")).toBeNull();
     expect(screen.getByText("Icon: food")).toBeInTheDocument();
     expect(screen.getByText("Icon: delivery")).toBeInTheDocument();
+  });
+
+  it("parent rows link to child category management", () => {
+    mocks.categories = [systemCategory];
+
+    render(<CategoryList />);
+
+    expect(screen.getByRole("link", { name: /식비/ })).toHaveAttribute(
+      "href",
+      "/ledger/categories/cat-sys",
+    );
+    expect(screen.getByText("세부 카테고리 관리")).toBeInTheDocument();
   });
 
   it("shows custom category edit and delete actions but keeps system category locked", () => {

--- a/components/ledger/CategoryList.tsx
+++ b/components/ledger/CategoryList.tsx
@@ -7,6 +7,7 @@ import {
   Plus,
   Trash2Icon,
 } from "lucide-react";
+import Link from "next/link";
 import { useState } from "react";
 import {
   GroupedList,
@@ -37,6 +38,7 @@ export function CategoryList() {
   const [deleteTarget, setDeleteTarget] = useState<Category | null>(null);
 
   const { data: categories = [], isLoading } = useCategories(activeTab);
+  const parentCategories = categories.filter((category) => !category.parent_id);
 
   const renderList = () => {
     if (isLoading) {
@@ -56,7 +58,7 @@ export function CategoryList() {
       );
     }
 
-    if (categories.length === 0) {
+    if (parentCategories.length === 0) {
       return (
         <ScreenState
           type="empty"
@@ -68,12 +70,15 @@ export function CategoryList() {
 
     return (
       <GroupedList>
-        {categories.map((category) => (
+        {parentCategories.map((category) => (
           <article
             key={category.id}
             className="flex items-center justify-between gap-3 px-4 py-3.5 sm:px-5"
           >
-            <div className="flex items-center gap-3 min-w-0">
+            <Link
+              href={`/ledger/categories/${category.id}`}
+              className="flex min-w-0 flex-1 items-center gap-3"
+            >
               <div
                 className={`flex size-10 shrink-0 items-center justify-center rounded-full ${
                   category.is_system
@@ -86,7 +91,10 @@ export function CategoryList() {
               <span className="font-semibold text-gray-900 text-sm truncate">
                 {category.name}
               </span>
-            </div>
+              <span className="ml-auto hidden text-xs text-gray-400 sm:inline">
+                세부 카테고리 관리
+              </span>
+            </Link>
 
             {category.is_system ? (
               <div className="flex items-center gap-2 text-gray-400">
@@ -137,6 +145,7 @@ export function CategoryList() {
     <ScreenSection>
       <SectionHeader
         title="카테고리"
+        description="세부 카테고리 관리는 parent row에서 열 수 있습니다."
         action={
           <Button size="sm" onClick={() => setIsCreateOpen(true)}>
             <Plus className="mr-1 size-4" />

--- a/components/ledger/CategoryList.tsx
+++ b/components/ledger/CategoryList.tsx
@@ -145,7 +145,7 @@ export function CategoryList() {
     <ScreenSection>
       <SectionHeader
         title="카테고리"
-        description="세부 카테고리 관리는 parent row에서 열 수 있습니다."
+        description="상위 카테고리를 선택해 세부 카테고리를 관리할 수 있습니다."
         action={
           <Button size="sm" onClick={() => setIsCreateOpen(true)}>
             <Plus className="mr-1 size-4" />

--- a/components/ledger/CategoryList.tsx
+++ b/components/ledger/CategoryList.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import {
-  LockIcon,
+  ChevronRight,
   MoreHorizontal,
   PencilIcon,
   Plus,
@@ -104,36 +104,43 @@ export function CategoryList() {
                 >
                   기본
                 </Badge>
-                <div className="flex size-9 items-center justify-center">
-                  <LockIcon data-testid="lock-icon" className="size-4" />
-                </div>
+                <ChevronRight
+                  data-testid="category-disclosure"
+                  className="size-5"
+                />
               </div>
             ) : (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="size-9"
-                    aria-label="메뉴 열기"
-                  >
-                    <MoreHorizontal className="size-4" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuItem onClick={() => setEditTarget(category)}>
-                    <PencilIcon className="w-4 h-4 mr-2" />
-                    수정
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    className="text-red-500 focus:text-red-500 focus:bg-red-50"
-                    onClick={() => setDeleteTarget(category)}
-                  >
-                    <Trash2Icon className="w-4 h-4 mr-2" />
-                    삭제
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
+              <div className="flex items-center gap-1">
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="size-9"
+                      aria-label="메뉴 열기"
+                    >
+                      <MoreHorizontal className="size-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem onClick={() => setEditTarget(category)}>
+                      <PencilIcon className="w-4 h-4 mr-2" />
+                      수정
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      className="text-red-500 focus:text-red-500 focus:bg-red-50"
+                      onClick={() => setDeleteTarget(category)}
+                    >
+                      <Trash2Icon className="w-4 h-4 mr-2" />
+                      삭제
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+                <ChevronRight
+                  data-testid="category-disclosure"
+                  className="size-5 text-gray-400"
+                />
+              </div>
             )}
           </article>
         ))}

--- a/components/ledger/LedgerCategoryCombobox.test.tsx
+++ b/components/ledger/LedgerCategoryCombobox.test.tsx
@@ -45,6 +45,52 @@ describe("LedgerCategoryCombobox", () => {
     is_system: false,
   };
 
+  it("parent 순서대로 각 child를 sibling 순서로 묶는다", async () => {
+    const user = userEvent.setup();
+    const transport = {
+      ...category,
+      id: "cat-2",
+      name: "교통비",
+      display_order: 2,
+    };
+    const grocery = {
+      ...childCategory,
+      id: "cat-grocery",
+      name: "장보기",
+      display_order: 1,
+    };
+    const taxi = {
+      ...childCategory,
+      id: "cat-taxi",
+      name: "택시",
+      parent_id: "cat-2",
+      display_order: 0,
+    };
+    const dining = { ...childCategory, display_order: 2 };
+
+    render(
+      <LedgerCategoryCombobox
+        value=""
+        categories={[taxi, transport, dining, category, grocery]}
+        type="expense"
+        placeholder="선택"
+        onValueChange={() => undefined}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+
+    expect(
+      screen.getAllByRole("option").map((option) => option.textContent),
+    ).toEqual([
+      "식비",
+      "식비 > 장보기",
+      "식비 > 외식",
+      "교통비",
+      "교통비 > 택시",
+    ]);
+  });
+
   it("child option은 Parent > Child label로 렌더링하고 선택할 수 있다", async () => {
     const user = userEvent.setup();
     const onValueChange = vi.fn();
@@ -63,6 +109,24 @@ describe("LedgerCategoryCombobox", () => {
     await user.click(screen.getByText("식비 > 외식"));
 
     expect(onValueChange).toHaveBeenCalledWith("cat-child");
+  });
+
+  it("child option도 들여쓰기 없이 Parent > Child label로 정렬한다", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <LedgerCategoryCombobox
+        value=""
+        categories={[category, childCategory]}
+        type="expense"
+        placeholder="선택"
+        onValueChange={() => undefined}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+
+    expect(screen.getByText("식비 > 외식")).not.toHaveClass("pl-3");
   });
 
   it("inline creation UI links to category management for child categories", async () => {

--- a/components/ledger/LedgerCategoryCombobox.test.tsx
+++ b/components/ledger/LedgerCategoryCombobox.test.tsx
@@ -28,11 +28,62 @@ describe("LedgerCategoryCombobox", () => {
     type: "expense" as const,
     name: "식비",
     icon: "utensils",
+    parent_id: null,
     display_order: 1,
     is_system: true,
     created_at: "2026-01-01T00:00:00.000Z",
     updated_at: "2026-01-01T00:00:00.000Z",
   };
+
+  const childCategory = {
+    ...category,
+    id: "cat-child",
+    name: "외식",
+    icon: "store",
+    parent_id: "cat-1",
+    display_order: 0,
+    is_system: false,
+  };
+
+  it("child option은 Parent > Child label로 렌더링하고 선택할 수 있다", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+
+    render(
+      <LedgerCategoryCombobox
+        value=""
+        categories={[category, childCategory]}
+        type="expense"
+        placeholder="선택"
+        onValueChange={onValueChange}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByText("식비 > 외식"));
+
+    expect(onValueChange).toHaveBeenCalledWith("cat-child");
+  });
+
+  it("inline creation UI links to category management for child categories", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <LedgerCategoryCombobox
+        value=""
+        categories={[category]}
+        type="expense"
+        placeholder="선택"
+        onValueChange={() => undefined}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+
+    expect(
+      screen.getByRole("link", { name: "세부 카테고리 관리" }),
+    ).toHaveAttribute("href", "/ledger/categories");
+  });
 
   it("검색어가 있으면 새 카테고리 추가 dialog를 열 수 있다", async () => {
     const user = userEvent.setup();

--- a/components/ledger/LedgerCategoryCombobox.tsx
+++ b/components/ledger/LedgerCategoryCombobox.tsx
@@ -7,6 +7,7 @@ import {
   ChevronsUpDownIcon,
   PlusIcon,
 } from "lucide-react";
+import Link from "next/link";
 import type { ComponentPropsWithoutRef, FormEvent } from "react";
 import { forwardRef, useEffect, useState } from "react";
 import { CategoryIcon } from "@/components/ledger/CategoryIcon";
@@ -37,6 +38,26 @@ import {
 import { useCreateCategory } from "@/hooks/use-categories";
 import { cn } from "@/lib/utils/cn";
 import type { Category, CategoryType } from "@/types";
+
+function buildCategoryOptions(categories: Category[]) {
+  const parentById = new Map(
+    categories
+      .filter((category) => !category.parent_id)
+      .map((category) => [category.id, category]),
+  );
+
+  return categories.map((category) => {
+    const parent = category.parent_id
+      ? parentById.get(category.parent_id)
+      : undefined;
+    return {
+      category,
+      label: parent ? `${parent.name} > ${category.name}` : category.name,
+      icon: category.icon ?? parent?.icon ?? null,
+      isChild: Boolean(parent),
+    };
+  });
+}
 
 interface LedgerCategoryBaseProps {
   value: string;
@@ -111,6 +132,8 @@ function CategoryCommandList({
   onCreate?: () => void;
   className?: string;
 }) {
+  const options = buildCategoryOptions(categories);
+
   return (
     <CommandList className={cn("max-h-[320px]", className)}>
       <CommandEmpty>
@@ -125,10 +148,10 @@ function CategoryCommandList({
         </div>
       </CommandEmpty>
       <CommandGroup heading="카테고리 선택">
-        {categories.map((category) => (
+        {options.map(({ category, label, icon, isChild }) => (
           <CommandItem
             key={category.id}
-            value={category.name}
+            value={label}
             onSelect={() => onValueChange(category.id)}
             className="cursor-pointer py-2.5"
           >
@@ -140,14 +163,27 @@ function CategoryCommandList({
             />
             <div className="flex items-center gap-2 min-w-0 flex-1">
               <CategoryIcon
-                iconName={category.icon}
+                iconName={icon}
                 className="size-4 text-gray-500 shrink-0"
               />
-              <span className="truncate font-medium">{category.name}</span>
+              <span className={cn("truncate font-medium", isChild && "pl-3")}>
+                {label}
+              </span>
             </div>
           </CommandItem>
         ))}
       </CommandGroup>
+      <div className="border-t p-2">
+        <Button
+          asChild
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="w-full justify-start"
+        >
+          <Link href="/ledger/categories">세부 카테고리 관리</Link>
+        </Button>
+      </div>
     </CommandList>
   );
 }
@@ -278,7 +314,10 @@ export function LedgerCategoryCombobox({
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [createInitialName, setCreateInitialName] = useState("");
   const selectedCategory = categories.find((cat) => cat.id === value);
-  const selectedLabel = selectedCategory ? selectedCategory.name : placeholder;
+  const selectedLabel =
+    buildCategoryOptions(categories).find(
+      (option) => option.category.id === selectedCategory?.id,
+    )?.label ?? placeholder;
   const createQuery = search.trim();
   const createLabel = createQuery
     ? `"${createQuery}" 새 카테고리 추가`

--- a/components/ledger/LedgerCategoryCombobox.tsx
+++ b/components/ledger/LedgerCategoryCombobox.tsx
@@ -40,13 +40,37 @@ import { cn } from "@/lib/utils/cn";
 import type { Category, CategoryType } from "@/types";
 
 function buildCategoryOptions(categories: Category[]) {
+  const parents = categories
+    .filter((category) => !category.parent_id)
+    .sort((a, b) => a.display_order - b.display_order);
   const parentById = new Map(
-    categories
-      .filter((category) => !category.parent_id)
-      .map((category) => [category.id, category]),
+    parents.map((category) => [category.id, category]),
+  );
+  const childrenByParent = new Map<string, Category[]>();
+  const orphans: Category[] = [];
+
+  for (const category of categories) {
+    if (!category.parent_id) continue;
+    if (!parentById.has(category.parent_id)) {
+      orphans.push(category);
+      continue;
+    }
+    const siblings = childrenByParent.get(category.parent_id) ?? [];
+    siblings.push(category);
+    childrenByParent.set(category.parent_id, siblings);
+  }
+
+  const orderedCategories = parents.flatMap((parent) => [
+    parent,
+    ...(childrenByParent.get(parent.id) ?? []).sort(
+      (a, b) => a.display_order - b.display_order,
+    ),
+  ]);
+  orderedCategories.push(
+    ...orphans.sort((a, b) => a.display_order - b.display_order),
   );
 
-  return categories.map((category) => {
+  return orderedCategories.map((category) => {
     const parent = category.parent_id
       ? parentById.get(category.parent_id)
       : undefined;
@@ -148,7 +172,7 @@ function CategoryCommandList({
         </div>
       </CommandEmpty>
       <CommandGroup heading="카테고리 선택">
-        {options.map(({ category, label, icon, isChild }) => (
+        {options.map(({ category, label, icon }) => (
           <CommandItem
             key={category.id}
             value={label}
@@ -166,9 +190,7 @@ function CategoryCommandList({
                 iconName={icon}
                 className="size-4 text-gray-500 shrink-0"
               />
-              <span className={cn("truncate font-medium", isChild && "pl-3")}>
-                {label}
-              </span>
+              <span className="truncate font-medium">{label}</span>
             </div>
           </CommandItem>
         ))}

--- a/components/ledger/analysis/ByCategoryClient.test.tsx
+++ b/components/ledger/analysis/ByCategoryClient.test.tsx
@@ -163,6 +163,7 @@ describe("ByCategoryClient", () => {
       name: /의료비.*15,800원.*1건/,
     });
     expect(medical).not.toHaveAttribute("aria-expanded");
+    expect(medical.querySelector(".lucide-chevron-right")).toBeInTheDocument();
 
     await user.click(medical);
 

--- a/components/ledger/analysis/ByCategoryClient.test.tsx
+++ b/components/ledger/analysis/ByCategoryClient.test.tsx
@@ -1,0 +1,177 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useLedgerStatsByCategory } from "@/hooks/use-ledger-stats";
+import { ByCategoryClient } from "./ByCategoryClient";
+
+vi.mock("@/hooks/use-ledger-stats", () => ({
+  useLedgerStatsByCategory: vi.fn(),
+}));
+
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: ReactNode }) => children,
+  useReducedMotion: () => false,
+  motion: {
+    li: ({
+      children,
+      className,
+    }: {
+      children: ReactNode;
+      className?: string;
+    }) => <li className={className}>{children}</li>,
+    div: ({
+      children,
+      className,
+    }: {
+      children: ReactNode;
+      className?: string;
+    }) => (
+      <div className={className} data-motion="div">
+        {children}
+      </div>
+    ),
+  },
+}));
+
+vi.mock("recharts", () => ({
+  Bar: () => null,
+  BarChart: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Cell: () => null,
+  Pie: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  PieChart: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  XAxis: () => null,
+  YAxis: () => null,
+}));
+
+vi.mock("@/components/ui/chart", () => ({
+  ChartContainer: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ChartTooltip: () => null,
+  ChartTooltipContent: () => null,
+}));
+
+vi.mock("./MonthSelector", () => ({
+  MonthSelector: () => null,
+}));
+
+vi.mock("./LedgerStatsDetailDrawer", () => ({
+  LedgerStatsDetailDrawer: ({
+    open,
+    title,
+    expectedCount,
+  }: {
+    open: boolean;
+    title: string;
+    expectedCount?: number;
+  }) =>
+    open ? (
+      <div data-expected-count={expectedCount} data-testid="detail-drawer">
+        {title}
+      </div>
+    ) : null,
+}));
+
+const currentData = {
+  type: "expense" as const,
+  scope: "shared" as const,
+  total: 76_300,
+  items: [
+    {
+      categoryId: "food",
+      categoryName: "식비",
+      categoryIcon: "utensils",
+      amount: 60_500,
+      percentage: 79.3,
+      entryCount: 2,
+      directAmount: 0,
+      directEntryCount: 0,
+      children: [
+        {
+          categoryId: "grocery",
+          categoryName: "장보기",
+          categoryIcon: "shopping-basket",
+          amount: 35_000,
+          percentage: 45.9,
+          entryCount: 1,
+        },
+        {
+          categoryId: "dining",
+          categoryName: "외식",
+          categoryIcon: "store",
+          amount: 25_500,
+          percentage: 33.4,
+          entryCount: 1,
+        },
+      ],
+    },
+    {
+      categoryId: "medical",
+      categoryName: "의료비",
+      categoryIcon: "stethoscope",
+      amount: 15_800,
+      percentage: 20.7,
+      entryCount: 1,
+      directAmount: 15_800,
+      directEntryCount: 1,
+      children: [],
+    },
+  ],
+};
+
+describe("ByCategoryClient", () => {
+  beforeEach(() => {
+    vi.mocked(useLedgerStatsByCategory).mockReturnValue({
+      data: currentData,
+      isLoading: false,
+    } as unknown as ReturnType<typeof useLedgerStatsByCategory>);
+  });
+
+  it("child breakdown을 접어두고 parent를 누르면 금액과 비중을 펼친다", async () => {
+    const user = userEvent.setup();
+
+    const { container } = render(<ByCategoryClient scope="shared" />);
+
+    expect(screen.queryByText("직접 0건")).not.toBeInTheDocument();
+    expect(screen.queryByText("장보기")).not.toBeInTheDocument();
+    expect(container.querySelector("[style*='width']")).not.toBeInTheDocument();
+
+    const food = screen.getByRole("button", {
+      name: /식비.*60,500원.*2건/,
+    });
+    expect(food).toHaveAttribute("aria-expanded", "false");
+
+    await user.click(food);
+
+    expect(food).toHaveAttribute("aria-expanded", "true");
+    expect(container.querySelector("[data-motion='div']")).toBeInTheDocument();
+    expect(screen.getByText("장보기")).toBeInTheDocument();
+    expect(screen.getByText("35,000원")).toBeInTheDocument();
+    expect(screen.getByText("식비의 57.9% · 1건")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "전체 2건 보기" }),
+    ).toBeInTheDocument();
+  });
+
+  it("child가 없는 parent는 accordion 없이 상세 내역을 연다", async () => {
+    const user = userEvent.setup();
+
+    render(<ByCategoryClient scope="shared" />);
+
+    const medical = screen.getByRole("button", {
+      name: /의료비.*15,800원.*1건/,
+    });
+    expect(medical).not.toHaveAttribute("aria-expanded");
+
+    await user.click(medical);
+
+    expect(screen.getByTestId("detail-drawer")).toHaveTextContent(
+      "의료비 기록",
+    );
+    expect(screen.getByTestId("detail-drawer")).toHaveAttribute(
+      "data-expected-count",
+      "1",
+    );
+  });
+});

--- a/components/ledger/analysis/ByCategoryClient.tsx
+++ b/components/ledger/analysis/ByCategoryClient.tsx
@@ -461,6 +461,12 @@ export function ByCategoryClient({ scope }: ByCategoryClientProps) {
                             aria-hidden="true"
                           />
                         )}
+                        {!hasChildren && (
+                          <ChevronRight
+                            className="size-4 text-gray-400"
+                            aria-hidden="true"
+                          />
+                        )}
                       </span>
                     </div>
                   </button>

--- a/components/ledger/analysis/ByCategoryClient.tsx
+++ b/components/ledger/analysis/ByCategoryClient.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { startOfMonth } from "date-fns";
-import { AnimatePresence, motion } from "framer-motion";
-import { Check, ChevronDown, Search } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { Check, ChevronDown, ChevronRight, Search } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { Bar, BarChart, Cell, Pie, PieChart, XAxis, YAxis } from "recharts";
 import { CategoryIcon } from "@/components/ledger/CategoryIcon";
@@ -47,6 +47,7 @@ interface ByCategoryClientProps {
 }
 
 export function ByCategoryClient({ scope }: ByCategoryClientProps) {
+  const shouldReduceMotion = useReducedMotion();
   const [currentMonth, setCurrentMonth] = useState<Date>(() =>
     startOfMonth(getKstNow()),
   );
@@ -54,11 +55,15 @@ export function ByCategoryClient({ scope }: ByCategoryClientProps) {
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [hoveredId, setHoveredId] = useState<string | null>(null);
   const [open, setOpen] = useState(false);
+  const [expandedCategoryId, setExpandedCategoryId] = useState<string | null>(
+    null,
+  );
   const [detail, setDetail] = useState<{
     title: string;
     categoryId: string;
     childCategoryId?: string;
     categoryBreakdown?: "direct";
+    expectedCount: number;
   } | null>(null);
 
   const year = currentMonth.getFullYear();
@@ -397,91 +402,172 @@ export function ByCategoryClient({ scope }: ByCategoryClientProps) {
             상세 내역
           </h3>
           <ul className="space-y-3">
-            {data.items.map((item) => (
-              <li key={item.categoryId ?? "null"} className="space-y-2">
-                <button
-                  type="button"
-                  onClick={() =>
-                    setDetail({
-                      title: `${item.categoryName} 기록`,
-                      categoryId: item.categoryId ?? "__none__",
-                    })
-                  }
-                  className="flex w-full items-center gap-3 rounded-xl text-left transition-colors hover:bg-gray-50"
-                >
-                  <div className="w-8 h-8 rounded-full bg-gray-100 flex items-center justify-center shrink-0">
-                    <CategoryIcon
-                      iconName={item.categoryIcon}
-                      className="w-4 h-4 text-gray-600"
-                    />
-                  </div>
-                  <div className="flex-1 min-w-0 py-1">
-                    <div className="flex justify-between items-center text-sm mb-1">
-                      <span className="text-gray-700 truncate">
+            {data.items.map((item) => {
+              const categoryId = item.categoryId ?? "__none__";
+              const children = item.children ?? [];
+              const hasChildren = children.length > 0;
+              const isExpanded = expandedCategoryId === categoryId;
+              const breakdownId = `category-breakdown-${categoryId}`;
+              const parentPercentage = (amount: number) =>
+                item.amount > 0
+                  ? ((amount / item.amount) * 100).toFixed(1)
+                  : "0.0";
+
+              return (
+                <li key={item.categoryId ?? "null"} className="space-y-2">
+                  <button
+                    type="button"
+                    aria-expanded={hasChildren ? isExpanded : undefined}
+                    aria-controls={hasChildren ? breakdownId : undefined}
+                    onClick={() => {
+                      if (hasChildren) {
+                        setExpandedCategoryId((current) =>
+                          current === categoryId ? null : categoryId,
+                        );
+                        return;
+                      }
+                      setDetail({
+                        title: `${item.categoryName} 기록`,
+                        categoryId,
+                        expectedCount: item.entryCount,
+                      });
+                    }}
+                    className="flex w-full items-center gap-3 rounded-lg py-1 text-left transition-colors hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+                  >
+                    <div className="w-8 h-8 rounded-full bg-gray-100 flex items-center justify-center shrink-0">
+                      <CategoryIcon
+                        iconName={item.categoryIcon}
+                        className="w-4 h-4 text-gray-600"
+                      />
+                    </div>
+                    <div className="flex min-w-0 flex-1 items-center justify-between py-1">
+                      <span className="truncate text-sm text-gray-700">
                         {item.categoryName}
                       </span>
-                      <span className="font-medium text-gray-900 shrink-0 ml-2">
-                        {formatCurrency(item.amount)}
+                      <span className="ml-2 flex shrink-0 items-center gap-1.5">
+                        <span className="text-right">
+                          <span className="block text-sm font-medium text-gray-900">
+                            {formatCurrency(item.amount)}
+                          </span>
+                          <span className="block text-xs text-gray-400">
+                            {item.entryCount}건
+                          </span>
+                        </span>
+                        {hasChildren && (
+                          <ChevronDown
+                            className={`size-4 text-gray-400 transition-transform ${
+                              isExpanded ? "rotate-180" : ""
+                            }`}
+                            aria-hidden="true"
+                          />
+                        )}
                       </span>
                     </div>
-                    <div className="flex items-center gap-2">
-                      <div className="flex-1 h-1.5 bg-gray-100 rounded-full overflow-hidden">
-                        <div
-                          className="h-full bg-primary/60 rounded-full"
-                          style={{
-                            width: `${Math.min(item.percentage, 100)}%`,
-                          }}
-                        />
-                      </div>
-                      <span className="text-xs text-gray-400 shrink-0">
-                        {item.entryCount}건
-                      </span>
-                    </div>
-                  </div>
-                </button>
-                {item.categoryId && (
-                  <div className="ml-11 flex flex-wrap gap-2">
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="outline"
-                      onClick={() =>
-                        setDetail({
-                          title: `${item.categoryName} 직접 기록`,
-                          categoryId: item.categoryId ?? "__none__",
-                          categoryBreakdown: "direct",
-                        })
-                      }
-                    >
-                      직접 {item.directEntryCount ?? 0}건
-                    </Button>
-                    {(item.children ?? []).map((child) => (
-                      <Button
-                        key={child.categoryId}
-                        type="button"
-                        size="sm"
-                        variant="outline"
-                        onClick={() =>
-                          setDetail({
-                            title: `${item.categoryName} > ${child.categoryName} 기록`,
-                            categoryId: item.categoryId ?? "__none__",
-                            childCategoryId: child.categoryId,
-                          })
+                  </button>
+
+                  <AnimatePresence initial={false}>
+                    {hasChildren && isExpanded && (
+                      <motion.div
+                        id={breakdownId}
+                        initial={
+                          shouldReduceMotion ? false : { height: 0, opacity: 0 }
                         }
+                        animate={{ height: "auto", opacity: 1 }}
+                        exit={{ height: 0, opacity: 0 }}
+                        transition={{ duration: shouldReduceMotion ? 0 : 0.2 }}
+                        className="ml-11 overflow-hidden border-l border-gray-200 pl-4"
                       >
-                        {child.categoryName} {child.entryCount}건
-                      </Button>
-                    ))}
-                  </div>
-                )}
-              </li>
-            ))}
+                        <div className="space-y-1">
+                          {(item.directEntryCount ?? 0) > 0 && (
+                            <button
+                              type="button"
+                              onClick={() =>
+                                setDetail({
+                                  title: `${item.categoryName} 직접 기록`,
+                                  categoryId,
+                                  categoryBreakdown: "direct",
+                                  expectedCount: item.directEntryCount ?? 0,
+                                })
+                              }
+                              className="flex w-full items-center justify-between gap-3 rounded-md px-2 py-2 text-left hover:bg-gray-50"
+                            >
+                              <span className="min-w-0">
+                                <span className="block truncate text-sm text-gray-700">
+                                  {item.categoryName}로 기록
+                                </span>
+                                <span className="block text-xs text-gray-400">
+                                  {item.categoryName}의{" "}
+                                  {parentPercentage(item.directAmount ?? 0)}% ·{" "}
+                                  {item.directEntryCount}건
+                                </span>
+                              </span>
+                              <span className="shrink-0 text-sm font-medium text-gray-900">
+                                {formatCurrency(item.directAmount ?? 0)}
+                              </span>
+                            </button>
+                          )}
+
+                          {children.map((child) => (
+                            <button
+                              key={child.categoryId}
+                              type="button"
+                              onClick={() =>
+                                setDetail({
+                                  title: `${item.categoryName} > ${child.categoryName} 기록`,
+                                  categoryId,
+                                  childCategoryId: child.categoryId,
+                                  expectedCount: child.entryCount,
+                                })
+                              }
+                              className="flex w-full items-center justify-between gap-3 rounded-md px-2 py-2 text-left hover:bg-gray-50"
+                            >
+                              <span className="min-w-0">
+                                <span className="block truncate text-sm text-gray-700">
+                                  {child.categoryName}
+                                </span>
+                                <span className="block text-xs text-gray-400">
+                                  {item.categoryName}의{" "}
+                                  {parentPercentage(child.amount)}% ·{" "}
+                                  {child.entryCount}건
+                                </span>
+                              </span>
+                              <span className="shrink-0 text-sm font-medium text-gray-900">
+                                {formatCurrency(child.amount)}
+                              </span>
+                            </button>
+                          ))}
+
+                          <button
+                            type="button"
+                            onClick={() =>
+                              setDetail({
+                                title: `${item.categoryName} 기록`,
+                                categoryId,
+                                expectedCount: item.entryCount,
+                              })
+                            }
+                            className="mt-1 flex w-full items-center justify-between border-t border-gray-100 px-2 py-2 text-xs font-medium text-gray-600 hover:text-gray-900"
+                          >
+                            전체 {item.entryCount}건 보기
+                            <ChevronRight
+                              className="size-4"
+                              aria-hidden="true"
+                            />
+                          </button>
+                        </div>
+                      </motion.div>
+                    )}
+                  </AnimatePresence>
+                </li>
+              );
+            })}
           </ul>
         </div>
       )}
       <LedgerStatsDetailDrawer
         open={!!detail}
         title={detail?.title ?? ""}
+        expectedCount={detail?.expectedCount}
         params={
           detail
             ? {

--- a/components/ledger/analysis/ByCategoryClient.tsx
+++ b/components/ledger/analysis/ByCategoryClient.tsx
@@ -57,6 +57,8 @@ export function ByCategoryClient({ scope }: ByCategoryClientProps) {
   const [detail, setDetail] = useState<{
     title: string;
     categoryId: string;
+    childCategoryId?: string;
+    categoryBreakdown?: "direct";
   } | null>(null);
 
   const year = currentMonth.getFullYear();
@@ -108,6 +110,12 @@ export function ByCategoryClient({ scope }: ByCategoryClientProps) {
         amount: otherAmount,
         percentage: otherPct,
         entryCount: others.reduce((s, o) => s + o.entryCount, 0),
+        directAmount: others.reduce((s, o) => s + (o.directAmount ?? 0), 0),
+        directEntryCount: others.reduce(
+          (s, o) => s + (o.directEntryCount ?? 0),
+          0,
+        ),
+        children: [],
         fill: "#8B95A1",
       },
     ];
@@ -390,10 +398,7 @@ export function ByCategoryClient({ scope }: ByCategoryClientProps) {
           </h3>
           <ul className="space-y-3">
             {data.items.map((item) => (
-              <li
-                key={item.categoryId ?? "null"}
-                className="flex items-center gap-3"
-              >
+              <li key={item.categoryId ?? "null"} className="space-y-2">
                 <button
                   type="button"
                   onClick={() =>
@@ -434,6 +439,41 @@ export function ByCategoryClient({ scope }: ByCategoryClientProps) {
                     </div>
                   </div>
                 </button>
+                {item.categoryId && (
+                  <div className="ml-11 flex flex-wrap gap-2">
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={() =>
+                        setDetail({
+                          title: `${item.categoryName} 직접 기록`,
+                          categoryId: item.categoryId ?? "__none__",
+                          categoryBreakdown: "direct",
+                        })
+                      }
+                    >
+                      직접 {item.directEntryCount ?? 0}건
+                    </Button>
+                    {(item.children ?? []).map((child) => (
+                      <Button
+                        key={child.categoryId}
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        onClick={() =>
+                          setDetail({
+                            title: `${item.categoryName} > ${child.categoryName} 기록`,
+                            categoryId: item.categoryId ?? "__none__",
+                            childCategoryId: child.categoryId,
+                          })
+                        }
+                      >
+                        {child.categoryName} {child.entryCount}건
+                      </Button>
+                    ))}
+                  </div>
+                )}
               </li>
             ))}
           </ul>
@@ -451,6 +491,8 @@ export function ByCategoryClient({ scope }: ByCategoryClientProps) {
                 type: entryType,
                 scope,
                 categoryId: detail.categoryId,
+                childCategoryId: detail.childCategoryId,
+                categoryBreakdown: detail.categoryBreakdown,
               }
             : null
         }

--- a/components/ledger/analysis/LedgerStatsDetailDrawer.test.tsx
+++ b/components/ledger/analysis/LedgerStatsDetailDrawer.test.tsx
@@ -1,0 +1,49 @@
+import { render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { useLedgerStatsDetail } from "@/hooks/use-ledger-stats";
+import { LedgerStatsDetailDrawer } from "./LedgerStatsDetailDrawer";
+
+vi.mock("@/hooks/use-ledger-stats", () => ({
+  useLedgerStatsDetail: vi.fn(),
+}));
+
+vi.mock("@/components/ui/drawer", () => ({
+  Drawer: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DrawerContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DrawerDescription: ({ children }: { children: ReactNode }) => (
+    <p>{children}</p>
+  ),
+  DrawerFooter: ({ children }: { children: ReactNode }) => (
+    <footer>{children}</footer>
+  ),
+  DrawerHeader: ({ children }: { children: ReactNode }) => (
+    <header>{children}</header>
+  ),
+  DrawerTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+}));
+
+describe("LedgerStatsDetailDrawer", () => {
+  it("알고 있는 기록 건수만큼 loading skeleton을 표시한다", () => {
+    vi.mocked(useLedgerStatsDetail).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as unknown as ReturnType<typeof useLedgerStatsDetail>);
+
+    const { container } = render(
+      <LedgerStatsDetailDrawer
+        open
+        title="식비 기록"
+        params={{ kind: "category", scope: "shared" }}
+        expectedCount={2}
+        onOpenChange={() => undefined}
+      />,
+    );
+
+    expect(container.querySelectorAll("[data-slot='skeleton']")).toHaveLength(
+      2,
+    );
+  });
+});

--- a/components/ledger/analysis/LedgerStatsDetailDrawer.tsx
+++ b/components/ledger/analysis/LedgerStatsDetailDrawer.tsx
@@ -19,6 +19,7 @@ interface LedgerStatsDetailDrawerProps {
   open: boolean;
   title: string;
   params: LedgerStatsDetailParams | null;
+  expectedCount?: number;
   onOpenChange: (open: boolean) => void;
 }
 
@@ -26,11 +27,13 @@ export function LedgerStatsDetailDrawer({
   open,
   title,
   params,
+  expectedCount,
   onOpenChange,
 }: LedgerStatsDetailDrawerProps) {
   const { data, isLoading } = useLedgerStatsDetail(open ? params : null);
   const items = data?.items ?? [];
   const hasMore = (data?.totalCount ?? 0) > items.length;
+  const skeletonCount = Math.min(Math.max(expectedCount ?? 3, 1), 5);
 
   return (
     <Drawer open={open} onOpenChange={onOpenChange}>
@@ -45,7 +48,7 @@ export function LedgerStatsDetailDrawer({
         <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-2">
           {isLoading ? (
             <div className="space-y-3">
-              {[1, 2, 3].map((item) => (
+              {[1, 2, 3, 4, 5].slice(0, skeletonCount).map((item) => (
                 <Skeleton key={item} className="h-16 rounded-xl" />
               ))}
             </div>

--- a/components/ledger/records/LedgerEntryRow.test.tsx
+++ b/components/ledger/records/LedgerEntryRow.test.tsx
@@ -68,6 +68,15 @@ describe("LedgerEntryRow", () => {
     expect(screen.getByText("현대카드")).toBeInTheDocument();
   });
 
+  it("child category label을 API가 제공한 Parent > Child 그대로 렌더링한다", () => {
+    renderRow({
+      ...baseEntry,
+      categoryName: "식비 > 외식",
+    });
+
+    expect(screen.getByText("식비 > 외식")).toBeInTheDocument();
+  });
+
   it("이체 기록에는 카테고리 기본 아이콘 대신 이체 아이콘을 보여준다", () => {
     renderRow({
       ...baseEntry,

--- a/components/ledger/records/LedgerRecordsClient.tsx
+++ b/components/ledger/records/LedgerRecordsClient.tsx
@@ -63,6 +63,17 @@ export function LedgerRecordsClient({
   const [selectedTagIds, setSelectedTagIds] = useState<string[]>(() => {
     return searchParams.getAll("tagId");
   });
+  const categoryFilter = useMemo(
+    () => ({
+      categoryId: searchParams.get("categoryId"),
+      childCategoryId: searchParams.get("childCategoryId"),
+      categoryBreakdown:
+        searchParams.get("categoryBreakdown") === "direct"
+          ? ("direct" as const)
+          : undefined,
+    }),
+    [searchParams],
+  );
 
   const { data: availableTags = [], isSuccess: isTagsLoaded } = useLedgerTags({
     scope,
@@ -108,18 +119,21 @@ export function LedgerRecordsClient({
     month: prevMonth.getMonth() + 1,
     scope,
     tagIds: selectedTagIds,
+    ...categoryFilter,
   });
   const { data: entries = [], isLoading } = useLedgerEntries({
     year: currentMonth.getFullYear(),
     month: currentMonth.getMonth() + 1,
     scope,
     tagIds: selectedTagIds,
+    ...categoryFilter,
   });
   const { data: nextEntries = [] } = useLedgerEntries({
     year: nextMonth.getFullYear(),
     month: nextMonth.getMonth() + 1,
     scope,
     tagIds: selectedTagIds,
+    ...categoryFilter,
   });
 
   const summary = useMemo(() => calculateLedgerSummary(entries), [entries]);

--- a/constants/service-routes.test.ts
+++ b/constants/service-routes.test.ts
@@ -1,5 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { isMcpEnabled } from "@/lib/mcp/feature-flags";
+import { describe, expect, it } from "vitest";
 import {
   getServiceRouteMeta,
   resolveServiceParentHref,
@@ -25,6 +24,26 @@ describe("getServiceRouteMeta", () => {
         { href: "/assets", label: "자산" },
         { href: "/assets/stock", label: "주식" },
         { href: "/assets/stock/holdings", label: "보유 종목" },
+      ],
+    });
+  });
+
+  it("카테고리 상세 화면의 parent와 breadcrumb를 계산한다", () => {
+    expect(
+      getServiceRouteMeta("/ledger/categories/parent-1", {
+        mcpEnabled: true,
+      }),
+    ).toMatchObject({
+      label: "세부 카테고리",
+      mobileVariant: "child",
+      parentHref: "/ledger/categories",
+      breadcrumb: [
+        { href: "/ledger", label: "가계부" },
+        { href: "/ledger/categories", label: "카테고리 관리" },
+        {
+          href: "/ledger/categories/[parentId]",
+          label: "세부 카테고리",
+        },
       ],
     });
   });

--- a/constants/service-routes.ts
+++ b/constants/service-routes.ts
@@ -85,7 +85,17 @@ export function getServiceRouteTree(options?: {
             },
           ],
         },
-        { href: "/ledger/categories", label: "카테고리 관리" },
+        {
+          href: "/ledger/categories",
+          label: "카테고리 관리",
+          children: [
+            {
+              href: "/ledger/categories/[parentId]",
+              pattern: "/ledger/categories/[parentId]",
+              label: "세부 카테고리",
+            },
+          ],
+        },
         {
           href: "/ledger/analysis",
           label: "통계",

--- a/docs/superpowers/plans/2026-06-22-ledger-category-detail-accordion.md
+++ b/docs/superpowers/plans/2026-06-22-ledger-category-detail-accordion.md
@@ -1,0 +1,115 @@
+# Ledger Category Detail Accordion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace category breakdown pills with an on-demand accordion that hides zero direct counts and exposes clearer child-category amounts.
+
+**Architecture:** Keep aggregation and detail drawer contracts unchanged. Add one expanded-category state to `ByCategoryClient`, render child breakdown rows inline, and reuse the existing `detail` state for filtered drawers.
+
+**Tech Stack:** React, TypeScript, Tailwind CSS, Lucide, Vitest, React Testing Library
+
+---
+
+### Task 1: Category detail accordion
+
+**Files:**
+- Create: `components/ledger/analysis/ByCategoryClient.test.tsx`
+- Modify: `components/ledger/analysis/ByCategoryClient.tsx:40-480`
+
+- [ ] **Step 1: Write the failing interaction tests**
+
+Mock `useLedgerStatsByCategory`, chart primitives, `MonthSelector`, and `LedgerStatsDetailDrawer`. Render one parent with two children and zero direct entries plus one leaf category. Assert:
+
+```tsx
+expect(screen.queryByText("직접 0건")).not.toBeInTheDocument();
+expect(screen.queryByText("장보기")).not.toBeInTheDocument();
+
+await user.click(screen.getByRole("button", { name: /식비 60,500원 2건/ }));
+
+expect(screen.getByText("장보기")).toBeInTheDocument();
+expect(screen.getByText("35,000원")).toBeInTheDocument();
+expect(screen.getByText("식비의 57.9% · 1건")).toBeInTheDocument();
+expect(screen.getByRole("button", { name: "전체 2건 보기" })).toBeInTheDocument();
+```
+
+Also assert a leaf row has no `aria-expanded` and opens the mocked detail drawer directly.
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run:
+
+```bash
+pnpm vitest run components/ledger/analysis/ByCategoryClient.test.tsx
+```
+
+Expected: FAIL because category rows do not expose accordion state and child pills are visible before interaction.
+
+- [ ] **Step 3: Implement the minimum accordion**
+
+In `ByCategoryClient`:
+
+```tsx
+const [expandedCategoryId, setExpandedCategoryId] = useState<string | null>(null);
+```
+
+For each category, calculate `hasChildren`, toggle only one expanded parent at a time, and show `ChevronDown` only when `hasChildren` is true. Leaf rows continue setting parent detail directly.
+
+Remove the parent progress bar, then replace pills with an animated inset border list rendered only when expanded:
+
+```tsx
+<AnimatePresence initial={false}>
+{isExpanded && (
+  <motion.div className="ml-11 overflow-hidden border-l border-gray-200 pl-4">
+    {directEntryCount > 0 && <button>{categoryName}로 기록 ...</button>}
+    {children.map((child) => <button key={child.categoryId}>...</button>)}
+    <button>전체 {entryCount}건 보기</button>
+  </motion.div>
+)}
+</AnimatePresence>
+```
+
+Each breakdown row shows amount and `부모 지출의 N% · N건`, calculated from `child.amount / item.amount`. Keep existing drawer parameters for direct, child, and parent detail actions.
+
+Add an optional `expectedCount` prop to `LedgerStatsDetailDrawer`. Pass the known parent, direct, or child entry count from `ByCategoryClient`, and render `Math.min(Math.max(expectedCount ?? 3, 1), 5)` skeleton rows.
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run:
+
+```bash
+pnpm vitest run components/ledger/analysis/ByCategoryClient.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run static and regression checks**
+
+Run:
+
+```bash
+pnpm type-check
+pnpm biome check components/ledger/analysis/ByCategoryClient.tsx components/ledger/analysis/ByCategoryClient.test.tsx
+pnpm vitest run components/ledger/analysis/ByCategoryClient.test.tsx components/ledger/analysis/LedgerStatsDetailDrawer.test.tsx lib/api/ledger-stats.test.ts
+```
+
+Expected: all commands exit 0 with no warnings.
+
+- [ ] **Step 6: Verify in the local browser**
+
+Using the `mcp__agent_browser` session at `http://localhost:3000/ledger/analysis/by-category?scope=shared`, reload at 390x844 and verify:
+
+- `직접 0건` is absent.
+- Child categories are hidden initially.
+- Only parent rows with children show a chevron.
+- Parent rows do not repeat the pie-chart share as progress bars.
+- Accordion height and opacity animate when toggled.
+- Pressing 식비 expands 장보기/외식 and pressing another parent collapses 식비.
+- Child and 전체 actions open the expected detail drawer.
+- A two-entry detail action shows two skeleton rows while loading.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add components/ledger/analysis/ByCategoryClient.tsx components/ledger/analysis/ByCategoryClient.test.tsx components/ledger/analysis/LedgerStatsDetailDrawer.tsx components/ledger/analysis/LedgerStatsDetailDrawer.test.tsx docs/superpowers/specs/2026-06-22-ledger-category-detail-accordion-design.md docs/superpowers/plans/2026-06-22-ledger-category-detail-accordion.md
+git commit -m "Improve category detail breakdown"
+```

--- a/docs/superpowers/specs/2026-06-21-ledger-category-navigation-design.md
+++ b/docs/superpowers/specs/2026-06-21-ledger-category-navigation-design.md
@@ -1,0 +1,39 @@
+# Ledger Category Navigation Design
+
+## Goal
+
+Make the parent-to-child category flow visibly navigable while preserving the rule that system categories are read-only.
+
+## List
+
+- A parent row opens `/ledger/categories/[parentId]` from its main clickable area.
+- Every parent row ends with `ChevronRight` to communicate navigation.
+- System parents show a `기본` badge and no lock icon.
+- Custom parents keep a separate `...` menu for edit and delete before the chevron.
+- Parent rows remain ordered by parent `display_order`.
+
+## Detail
+
+- Register `/ledger/categories/[parentId]` in service route metadata as a child of `/ledger/categories` with the label `세부 카테고리`.
+- Use the shared mobile child header and desktop breadcrumb instead of an inline back button.
+- Keep the parent name and `세부 카테고리 관리` section header in the content.
+- Child edit/delete behavior remains unchanged.
+
+## Transition
+
+- Add an explicit mobile drill rule from `/ledger/categories` to `/ledger/categories/*`.
+- Desktop behavior remains the existing lightweight transition policy.
+- Reduced-motion behavior remains unchanged.
+
+## Picker Ordering
+
+- Render each parent followed immediately by its children.
+- Order parents by their sibling `display_order` and children by their own sibling `display_order`.
+- Keep labels as `Parent > Child`; do not change API or seed ordering semantics.
+
+## Verification
+
+- Update category list tests for the default badge, chevron, custom action menu, and detail link.
+- Update service route and transition rule tests for the dynamic child route and drill rule.
+- Update category picker tests with multiple parents and children to assert grouped ordering.
+- Verify the list and detail routes at mobile and desktop widths on the existing local server.

--- a/docs/superpowers/specs/2026-06-22-ledger-category-detail-accordion-design.md
+++ b/docs/superpowers/specs/2026-06-22-ledger-category-detail-accordion-design.md
@@ -1,0 +1,35 @@
+# Ledger Category Detail Accordion
+
+## Goal
+
+Make category composition easier to scan without showing empty `직접 0건` controls or expanding every child category by default.
+
+## Interaction
+
+- Category rows without child categories keep opening the existing detail drawer.
+- Category rows with child categories toggle an inline accordion when the row is pressed.
+- Only one category accordion is open at a time.
+- A chevron appears only on rows that have child categories.
+- Expanded child rows open the existing detail drawer filtered to that child category.
+- The expanded footer opens the existing detail drawer for the full parent category.
+
+## Content
+
+- Remove the pill-button breakdown.
+- Do not render zero-count direct records.
+- When direct records exist, show them as `<부모 카테고리>로 기록`.
+- Each breakdown row shows its amount and `부모 지출의 N% · N건`.
+- A subtle inset border communicates hierarchy without adding another card.
+
+## Scope
+
+- Reuse the current API response and detail drawer.
+- Keep the current category icon, total amount, total count, and progress bar.
+- Do not change aggregation logic, charts, colors, typography, or database schema.
+
+## Verification
+
+- Rows with children expose accordion state and toggle it.
+- Rows without children still open the detail drawer directly.
+- Zero direct counts are absent.
+- Child and parent detail actions retain their existing filter parameters.

--- a/docs/superpowers/specs/2026-06-22-ledger-category-detail-accordion-design.md
+++ b/docs/superpowers/specs/2026-06-22-ledger-category-detail-accordion-design.md
@@ -10,7 +10,7 @@ Make category composition easier to scan without showing empty `직접 0건` con
 - Category rows with child categories toggle an inline accordion when the row is pressed.
 - Only one category accordion is open at a time.
 - Accordion content animates height and opacity while respecting reduced-motion preferences.
-- A chevron appears only on rows that have child categories.
+- Rows with child categories use a down chevron; leaf rows use a right chevron to keep alignment and communicate detail navigation.
 - Expanded child rows open the existing detail drawer filtered to that child category.
 - The expanded footer opens the existing detail drawer for the full parent category.
 
@@ -29,6 +29,7 @@ Make category composition easier to scan without showing empty `직접 0건` con
 - Reuse the current API response and detail drawer.
 - Keep the current category icon, total amount, and total count.
 - Do not change aggregation logic, charts, colors, typography, or database schema.
+- Ledger entry mutations invalidate ledger statistics and home summary queries so analysis does not reuse stale data.
 
 ## Verification
 

--- a/docs/superpowers/specs/2026-06-22-ledger-category-detail-accordion-design.md
+++ b/docs/superpowers/specs/2026-06-22-ledger-category-detail-accordion-design.md
@@ -9,6 +9,7 @@ Make category composition easier to scan without showing empty `직접 0건` con
 - Category rows without child categories keep opening the existing detail drawer.
 - Category rows with child categories toggle an inline accordion when the row is pressed.
 - Only one category accordion is open at a time.
+- Accordion content animates height and opacity while respecting reduced-motion preferences.
 - A chevron appears only on rows that have child categories.
 - Expanded child rows open the existing detail drawer filtered to that child category.
 - The expanded footer opens the existing detail drawer for the full parent category.
@@ -20,11 +21,13 @@ Make category composition easier to scan without showing empty `직접 0건` con
 - When direct records exist, show them as `<부모 카테고리>로 기록`.
 - Each breakdown row shows its amount and `부모 지출의 N% · N건`.
 - A subtle inset border communicates hierarchy without adding another card.
+- Parent rows show amount and count without a progress bar because the pie chart already communicates category share.
+- The detail drawer uses the known entry count for its loading skeleton, capped at five visible rows.
 
 ## Scope
 
 - Reuse the current API response and detail drawer.
-- Keep the current category icon, total amount, total count, and progress bar.
+- Keep the current category icon, total amount, and total count.
 - Do not change aggregation logic, charts, colors, typography, or database schema.
 
 ## Verification

--- a/hooks/use-categories.ts
+++ b/hooks/use-categories.ts
@@ -21,8 +21,14 @@ interface CategoryError {
 
 // ─── fetch 함수 ───
 
-async function fetchCategories(type?: CategoryType): Promise<Category[]> {
-  const url = type ? `/api/categories?type=${type}` : "/api/categories";
+async function fetchCategories(
+  type?: CategoryType,
+  parentId?: string | null,
+): Promise<Category[]> {
+  const params = new URLSearchParams();
+  if (type) params.set("type", type);
+  if (parentId !== undefined) params.set("parentId", parentId ?? "__root__");
+  const url = params.size ? `/api/categories?${params}` : "/api/categories";
   const response = await fetch(url);
   const json = await response.json();
 
@@ -38,6 +44,7 @@ async function createCategoryFn(params: {
   type: CategoryType;
   name: string;
   icon?: string | null;
+  parentId?: string | null;
 }): Promise<Category> {
   const response = await fetch("/api/categories", {
     method: "POST",
@@ -87,13 +94,14 @@ async function deleteCategoryFn(id: string): Promise<void> {
   }
 }
 
-async function reorderCategoriesFn(
-  orders: { id: string; displayOrder: number }[],
-): Promise<void> {
+async function reorderCategoriesFn(params: {
+  parentId?: string | null;
+  orders: { id: string; displayOrder: number }[];
+}): Promise<void> {
   const response = await fetch("/api/categories/reorder", {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ orders }),
+    body: JSON.stringify(params),
   });
 
   if (!response.ok) {
@@ -105,10 +113,13 @@ async function reorderCategoriesFn(
 
 // ─── Query 훅 ───
 
-export function useCategories(type?: CategoryType) {
+export function useCategories(type?: CategoryType, parentId?: string | null) {
   return useQuery({
-    queryKey: queries.categories.list(type).queryKey,
-    queryFn: () => fetchCategories(type),
+    queryKey: queries.categories.list(
+      type,
+      parentId === null ? "__root__" : parentId,
+    ).queryKey,
+    queryFn: () => fetchCategories(type, parentId),
     staleTime: 1000 * 60 * 5,
   });
 }

--- a/hooks/use-ledger-entries.test.tsx
+++ b/hooks/use-ledger-entries.test.tsx
@@ -1,0 +1,50 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { queries } from "@/lib/queries/keys";
+import { useCreateLedgerEntry } from "./use-ledger-entries";
+
+describe("useCreateLedgerEntry", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("기록 생성 후 가계부 통계와 홈 요약 cache를 invalidate한다", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: { id: "entry-1" } }),
+      }),
+    );
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const statsKey = queries.ledgerStats.byCategory(
+      2026,
+      6,
+      "expense",
+      "shared",
+    ).queryKey;
+    const homeKey = queries.home.summary({ year: 2026, month: 6 }).queryKey;
+    queryClient.setQueryData(statsKey, { items: [] });
+    queryClient.setQueryData(homeKey, { topCategories: [] });
+
+    const { result } = renderHook(() => useCreateLedgerEntry(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      ),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({} as never);
+    });
+
+    expect(queryClient.getQueryState(statsKey)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(homeKey)?.isInvalidated).toBe(true);
+  });
+});

--- a/hooks/use-ledger-entries.ts
+++ b/hooks/use-ledger-entries.ts
@@ -43,6 +43,9 @@ interface LedgerEntriesParams {
   date?: string;
   scope?: "shared" | "personal";
   tagIds?: string[];
+  categoryId?: string | null;
+  childCategoryId?: string | null;
+  categoryBreakdown?: "direct";
 }
 
 async function fetchLedgerEntries(
@@ -53,6 +56,13 @@ async function fetchLedgerEntries(
   if (params?.month) searchParams.set("month", String(params.month));
   if (params?.date) searchParams.set("date", params.date);
   if (params?.scope) searchParams.set("scope", params.scope);
+  if (params?.categoryId) searchParams.set("categoryId", params.categoryId);
+  if (params?.childCategoryId) {
+    searchParams.set("childCategoryId", params.childCategoryId);
+  }
+  if (params?.categoryBreakdown) {
+    searchParams.set("categoryBreakdown", params.categoryBreakdown);
+  }
   if (params?.tagIds) {
     for (const tagId of params.tagIds) {
       searchParams.append("tagId", tagId);

--- a/hooks/use-ledger-entries.ts
+++ b/hooks/use-ledger-entries.ts
@@ -149,6 +149,8 @@ function invalidateLedgerBalanceQueries(
   queryClient.invalidateQueries({ queryKey: queries.accounts._def });
   queryClient.invalidateQueries({ queryKey: queries.paymentMethods._def });
   queryClient.invalidateQueries({ queryKey: queries.ledgerTags._def });
+  queryClient.invalidateQueries({ queryKey: queries.ledgerStats._def });
+  queryClient.invalidateQueries({ queryKey: queries.home._def });
 }
 
 export function useCreateLedgerEntry() {

--- a/hooks/use-ledger-stats.ts
+++ b/hooks/use-ledger-stats.ts
@@ -110,6 +110,12 @@ export function useLedgerStatsDetail(params: LedgerStatsDetailParams | null) {
       if (params.date) searchParams.set("date", params.date);
       if (params.type) searchParams.set("type", params.type);
       if (params.categoryId) searchParams.set("categoryId", params.categoryId);
+      if (params.childCategoryId) {
+        searchParams.set("childCategoryId", params.childCategoryId);
+      }
+      if (params.categoryBreakdown) {
+        searchParams.set("categoryBreakdown", params.categoryBreakdown);
+      }
       if (params.paymentMethodId) {
         searchParams.set("paymentMethodId", params.paymentMethodId);
       }

--- a/lib/api/category.test.ts
+++ b/lib/api/category.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { nextDisplayOrder, validateReorderIds } from "./category";
+import {
+  isDuplicateCategoryName,
+  nextDisplayOrder,
+  validateReorderIds,
+  validateReorderSiblingSet,
+} from "./category";
 
 describe("nextDisplayOrder", () => {
   it("기존 순서가 없으면 0을 반환한다", () => {
@@ -58,5 +63,63 @@ describe("validateReorderIds", () => {
   it("모든 가구 카테고리를 포함한 전체 재정렬도 통과한다", () => {
     const ids = new Set(["id-1", "id-2", "id-3"]);
     expect(validateReorderIds(["id-3", "id-1", "id-2"], ids)).toBe(true);
+  });
+});
+
+describe("validateReorderSiblingSet", () => {
+  it("하나의 parent sibling set이면 true를 반환한다", () => {
+    expect(
+      validateReorderSiblingSet(
+        [
+          { id: "cat-1", parent_id: null },
+          { id: "cat-2", parent_id: null },
+        ],
+        null,
+      ),
+    ).toBe(true);
+  });
+
+  it("parent와 child가 섞이면 false를 반환한다", () => {
+    expect(
+      validateReorderSiblingSet(
+        [
+          { id: "cat-1", parent_id: null },
+          { id: "cat-2", parent_id: "parent-1" },
+        ],
+        null,
+      ),
+    ).toBe(false);
+  });
+
+  it("서로 다른 child parent ID가 섞이면 false를 반환한다", () => {
+    expect(
+      validateReorderSiblingSet(
+        [
+          { id: "cat-1", parent_id: "parent-1" },
+          { id: "cat-2", parent_id: "parent-2" },
+        ],
+        "parent-1",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("isDuplicateCategoryName", () => {
+  it("서로 다른 parent 아래 같은 child 이름은 허용한다", () => {
+    expect(
+      isDuplicateCategoryName(
+        [{ id: "cat-1", name: "기타", parent_id: "parent-1" }],
+        { name: "기타", parentId: "parent-2" },
+      ),
+    ).toBe(false);
+  });
+
+  it("같은 parent 아래 같은 child 이름은 중복이다", () => {
+    expect(
+      isDuplicateCategoryName(
+        [{ id: "cat-1", name: "기타", parent_id: "parent-1" }],
+        { name: "기타", parentId: "parent-1" },
+      ),
+    ).toBe(true);
   });
 });

--- a/lib/api/category.ts
+++ b/lib/api/category.ts
@@ -7,6 +7,7 @@ export interface CreateCategoryParams {
   type: CategoryType;
   name: string;
   icon?: string | null;
+  parentId?: string | null;
 }
 
 export interface UpdateCategoryParams {
@@ -17,6 +18,15 @@ export interface UpdateCategoryParams {
 export interface ReorderItem {
   id: string;
   displayOrder: number;
+}
+
+interface CategorySiblingRow {
+  id: string;
+  parent_id: string | null;
+}
+
+interface CategoryNameRow extends CategorySiblingRow {
+  name: string;
 }
 
 /**
@@ -38,10 +48,52 @@ export function validateReorderIds(
   return requestedIds.every((id) => householdCategoryIds.has(id));
 }
 
+export function validateReorderSiblingSet(
+  rows: CategorySiblingRow[],
+  parentId: string | null,
+): boolean {
+  return rows.every((row) => row.parent_id === parentId);
+}
+
+export function isDuplicateCategoryName(
+  rows: CategoryNameRow[],
+  input: { name: string; parentId?: string | null; excludeId?: string },
+): boolean {
+  const parentId = input.parentId ?? null;
+  const nextName = input.name.trim().toLocaleLowerCase("ko-KR");
+  return rows.some(
+    (row) =>
+      row.id !== input.excludeId &&
+      row.parent_id === parentId &&
+      row.name.trim().toLocaleLowerCase("ko-KR") === nextName,
+  );
+}
+
+export function categoryLabel(category: {
+  name: string;
+  parent?: { name: string | null } | null;
+}): string {
+  return category.parent?.name
+    ? `${category.parent.name} > ${category.name}`
+    : category.name;
+}
+
+function applyParentFilter<
+  T extends {
+    is: (column: string, value: null) => T;
+    eq: (column: string, value: string) => T;
+  },
+>(query: T, parentId?: string | null): T {
+  return parentId
+    ? query.eq("parent_id", parentId)
+    : query.is("parent_id", null);
+}
+
 export async function getCategories(
   supabase: SupabaseClient<Database>,
   householdId: string,
   type?: CategoryType,
+  parentId?: string | null,
 ): Promise<Category[]> {
   let query = supabase
     .from("categories")
@@ -51,6 +103,10 @@ export async function getCategories(
 
   if (type) {
     query = query.eq("type", type);
+  }
+
+  if (parentId !== undefined) {
+    query = applyParentFilter(query, parentId);
   }
 
   const { data, error } = await query;
@@ -67,15 +123,55 @@ export async function createCategory(
   supabase: SupabaseClient<Database>,
   params: CreateCategoryParams,
 ): Promise<Category> {
-  const { householdId, type, name, icon } = params;
+  const { householdId, type, name, icon, parentId = null } = params;
 
-  const { data: duplicate } = await supabase
+  let parent: Category | null = null;
+  if (parentId) {
+    const { data, error } = await supabase
+      .from("categories")
+      .select("*")
+      .eq("id", parentId)
+      .eq("household_id", householdId)
+      .eq("type", type)
+      .is("parent_id", null)
+      .maybeSingle();
+
+    if (error) {
+      console.error("Parent category fetch error:", error);
+      throw new APIError(
+        "INTERNAL_ERROR",
+        "상위 카테고리 조회에 실패했습니다.",
+        500,
+      );
+    }
+    if (!data) {
+      throw new APIError(
+        "CATEGORY_PARENT_INVALID",
+        "상위 카테고리를 찾을 수 없습니다.",
+        400,
+      );
+    }
+    if (
+      data.name.trim().toLocaleLowerCase("ko-KR") ===
+      name.trim().toLocaleLowerCase("ko-KR")
+    ) {
+      throw new APIError(
+        "CATEGORY_DUPLICATE_NAME",
+        "상위 카테고리와 같은 이름은 사용할 수 없습니다.",
+        400,
+      );
+    }
+    parent = data;
+  }
+
+  let duplicateQuery = supabase
     .from("categories")
     .select("id")
     .eq("household_id", householdId)
     .eq("type", type)
-    .eq("name", name)
-    .maybeSingle();
+    .eq("name", name);
+  duplicateQuery = applyParentFilter(duplicateQuery, parentId);
+  const { data: duplicate } = await duplicateQuery.maybeSingle();
 
   if (duplicate) {
     throw new APIError(
@@ -85,11 +181,13 @@ export async function createCategory(
     );
   }
 
-  const { data: existing } = await supabase
+  let existingQuery = supabase
     .from("categories")
     .select("display_order")
     .eq("household_id", householdId)
     .eq("type", type);
+  existingQuery = applyParentFilter(existingQuery, parentId);
+  const { data: existing } = await existingQuery;
 
   const orders = (existing ?? []).map((row) => row.display_order);
   const displayOrder = nextDisplayOrder(orders);
@@ -101,6 +199,7 @@ export async function createCategory(
       type,
       name,
       icon: icon ?? null,
+      parent_id: parent?.id ?? null,
       display_order: displayOrder,
       is_system: false,
     })
@@ -150,13 +249,35 @@ export async function updateCategory(
   }
 
   if (params.name && params.name !== existing.name) {
-    const { data: duplicate } = await supabase
+    if (
+      existing.parent_id &&
+      params.name.trim().toLocaleLowerCase("ko-KR") ===
+        (
+          await supabase
+            .from("categories")
+            .select("name")
+            .eq("id", existing.parent_id)
+            .maybeSingle()
+        ).data?.name
+          ?.trim()
+          .toLocaleLowerCase("ko-KR")
+    ) {
+      throw new APIError(
+        "CATEGORY_DUPLICATE_NAME",
+        "상위 카테고리와 같은 이름은 사용할 수 없습니다.",
+        400,
+      );
+    }
+
+    let duplicateQuery = supabase
       .from("categories")
       .select("id")
       .eq("household_id", householdId)
       .eq("type", existing.type)
       .eq("name", params.name)
-      .maybeSingle();
+      .neq("id", id);
+    duplicateQuery = applyParentFilter(duplicateQuery, existing.parent_id);
+    const { data: duplicate } = await duplicateQuery.maybeSingle();
 
     if (duplicate) {
       throw new APIError(
@@ -219,6 +340,29 @@ export async function deleteCategory(
     );
   }
 
+  const { data: children, error: childFetchError } = await supabase
+    .from("categories")
+    .select("id")
+    .eq("parent_id", id)
+    .limit(1);
+
+  if (childFetchError) {
+    console.error("Category children fetch error:", childFetchError);
+    throw new APIError(
+      "INTERNAL_ERROR",
+      "하위 카테고리 조회에 실패했습니다.",
+      500,
+    );
+  }
+
+  if ((children ?? []).length > 0) {
+    throw new APIError(
+      "CATEGORY_HAS_CHILDREN",
+      "세부 카테고리가 있는 카테고리는 삭제할 수 없습니다.",
+      400,
+    );
+  }
+
   const { error } = await supabase.from("categories").delete().eq("id", id);
 
   if (error) {
@@ -231,12 +375,13 @@ export async function reorderCategories(
   supabase: SupabaseClient<Database>,
   householdId: string,
   orders: ReorderItem[],
+  parentId: string | null = null,
 ): Promise<void> {
   const requestedIds = orders.map((o) => o.id);
 
   const { data: existing, error: fetchError } = await supabase
     .from("categories")
-    .select("id")
+    .select("id, parent_id")
     .eq("household_id", householdId)
     .in("id", requestedIds);
 
@@ -252,6 +397,14 @@ export async function reorderCategories(
       "CATEGORY_NOT_FOUND",
       "일부 카테고리를 찾을 수 없습니다.",
       404,
+    );
+  }
+
+  if (!validateReorderSiblingSet(existing ?? [], parentId)) {
+    throw new APIError(
+      "CATEGORY_REORDER_MIXED_SIBLINGS",
+      "같은 단계의 카테고리만 순서를 변경할 수 있습니다.",
+      400,
     );
   }
 

--- a/lib/api/ledger-stats.test.ts
+++ b/lib/api/ledger-stats.test.ts
@@ -1,5 +1,50 @@
 import { describe, expect, it, vi } from "vitest";
-import { getLedgerStatsDetail } from "./ledger-stats";
+import { getLedgerStatsByCategory, getLedgerStatsDetail } from "./ledger-stats";
+
+function createByCategorySupabaseMock() {
+  const ledgerBuilder = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    gte: vi.fn().mockReturnThis(),
+    lt: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
+    data: [
+      { amount: 10000, category_id: "parent-food" },
+      { amount: 20000, category_id: "child-dining" },
+      { amount: 5000, category_id: null },
+    ],
+    error: null,
+  };
+  const categoryBuilder = {
+    select: vi.fn().mockReturnThis(),
+    in: vi.fn().mockResolvedValue({
+      data: [
+        {
+          id: "parent-food",
+          name: "식비",
+          icon: "Utensils",
+          parent_id: null,
+        },
+        {
+          id: "child-dining",
+          name: "외식",
+          icon: "Store",
+          parent_id: "parent-food",
+        },
+      ],
+      error: null,
+    }),
+  };
+
+  return {
+    from: vi
+      .fn()
+      .mockReturnValueOnce(ledgerBuilder)
+      .mockReturnValueOnce(categoryBuilder),
+    ledgerBuilder,
+    categoryBuilder,
+  };
+}
 
 function createLedgerDetailSupabaseMock(rows: unknown[]) {
   const builder = {
@@ -77,10 +122,27 @@ describe("getLedgerStatsDetail", () => {
       "transacted_at",
       "2026-05-31T15:00:00.000Z",
     );
-    expect(supabase.builder.eq).toHaveBeenCalledWith("category_id", "cat-1");
+    expect(supabase.builder.in).toHaveBeenCalledWith("category_id", ["cat-1"]);
     expect(supabase.builder.eq).toHaveBeenCalledWith("type", "expense");
     expect(supabase.builder.eq).toHaveBeenCalledWith("is_shared", true);
     expect(supabase.builder.range).toHaveBeenCalledWith(0, 19);
+  });
+
+  it("parent category detail은 parent와 child ID를 함께 필터링한다", async () => {
+    const supabase = createLedgerDetailSupabaseMock([]);
+
+    await getLedgerStatsDetail(supabase as never, "household-1", "user-1", {
+      kind: "category",
+      year: 2026,
+      month: 5,
+      type: "expense",
+      scope: "shared",
+      categoryId: "parent-food",
+    });
+
+    expect(supabase.builder.in).toHaveBeenCalledWith("category_id", [
+      "parent-food",
+    ]);
   });
 
   it("filters null payment-method groups explicitly", async () => {
@@ -101,5 +163,38 @@ describe("getLedgerStatsDetail", () => {
       "from_payment_method_id",
       null,
     );
+  });
+});
+
+describe("getLedgerStatsByCategory", () => {
+  it("child records를 parent total로 집계하고 direct/children breakdown을 포함한다", async () => {
+    const supabase = createByCategorySupabaseMock();
+
+    const result = await getLedgerStatsByCategory(
+      supabase as never,
+      "household-1",
+      "user-1",
+      2026,
+      5,
+      "expense",
+      "all",
+    );
+
+    const food = result.items.find((item) => item.categoryId === "parent-food");
+    expect(food).toMatchObject({
+      categoryName: "식비",
+      amount: 30000,
+      entryCount: 2,
+      directAmount: 10000,
+      directEntryCount: 1,
+    });
+    expect(food?.children).toEqual([
+      expect.objectContaining({
+        categoryId: "child-dining",
+        categoryName: "외식",
+        amount: 20000,
+        entryCount: 1,
+      }),
+    ]);
   });
 });

--- a/lib/api/ledger-stats.ts
+++ b/lib/api/ledger-stats.ts
@@ -41,6 +41,18 @@ export interface CategoryStatItem {
   amount: number;
   percentage: number;
   entryCount: number;
+  directAmount?: number;
+  directEntryCount?: number;
+  children?: CategoryStatChildItem[];
+}
+
+export interface CategoryStatChildItem {
+  categoryId: string;
+  categoryName: string;
+  categoryIcon: string | null;
+  amount: number;
+  percentage: number;
+  entryCount: number;
 }
 
 export interface LedgerStatsByCategoryResult {
@@ -306,26 +318,113 @@ export async function getLedgerStatsByCategory(
     categoryIds.length > 0
       ? await supabase
           .from("categories")
-          .select("id, name, icon")
+          .select("id, name, icon, parent_id")
           .in("id", categoryIds)
       : { data: [] };
 
   const categoryMap = new Map(
-    (categories ?? []).map((c) => [c.id, { name: c.name, icon: c.icon }]),
+    (categories ?? []).map((c) => [
+      c.id,
+      {
+        id: c.id,
+        name: c.name,
+        icon: c.icon,
+        parent_id: c.parent_id as string | null,
+      },
+    ]),
   );
 
-  const items: CategoryStatItem[] = [...aggregateMap.entries()]
-    .map(([categoryId, { amount, count }]) => {
-      const cat = categoryId ? categoryMap.get(categoryId) : undefined;
-      return {
+  const parentIds = [
+    ...new Set(
+      [...categoryMap.values()]
+        .map((category) => category.parent_id)
+        .filter(Boolean) as string[],
+    ),
+  ].filter((id) => !categoryMap.has(id));
+
+  if (parentIds.length > 0) {
+    const { data: parents } = await supabase
+      .from("categories")
+      .select("id, name, icon, parent_id")
+      .in("id", parentIds);
+    for (const parent of parents ?? []) {
+      categoryMap.set(parent.id, {
+        id: parent.id,
+        name: parent.name,
+        icon: parent.icon,
+        parent_id: parent.parent_id as string | null,
+      });
+    }
+  }
+
+  const parentStats = new Map<string | null, CategoryStatItem>();
+  const ensureParent = (parentId: string | null, categoryName: string) => {
+    const existing = parentStats.get(parentId);
+    if (existing) return existing;
+    const parent = parentId ? categoryMap.get(parentId) : undefined;
+    const item: CategoryStatItem = {
+      categoryId: parentId,
+      categoryName: parent?.name ?? categoryName,
+      categoryIcon: parent?.icon ?? null,
+      amount: 0,
+      percentage: 0,
+      entryCount: 0,
+      directAmount: 0,
+      directEntryCount: 0,
+      children: [],
+    };
+    parentStats.set(parentId, item);
+    return item;
+  };
+
+  for (const [categoryId, { amount, count }] of aggregateMap.entries()) {
+    if (!categoryId) {
+      const uncategorized = ensureParent(null, "미분류");
+      uncategorized.amount += amount;
+      uncategorized.entryCount += count;
+      uncategorized.directAmount = (uncategorized.directAmount ?? 0) + amount;
+      uncategorized.directEntryCount =
+        (uncategorized.directEntryCount ?? 0) + count;
+      continue;
+    }
+
+    const category = categoryMap.get(categoryId);
+    const parentId = category?.parent_id ?? categoryId;
+    const parent = ensureParent(parentId, category?.name ?? "미분류");
+    parent.amount += amount;
+    parent.entryCount += count;
+
+    if (category?.parent_id) {
+      parent.children?.push({
         categoryId,
-        categoryName: cat?.name ?? "미분류",
-        categoryIcon: cat?.icon ?? null,
+        categoryName: category.name,
+        categoryIcon: category.icon ?? parent.categoryIcon,
         amount,
-        percentage: total > 0 ? Math.round((amount / total) * 10000) / 100 : 0,
+        percentage: 0,
         entryCount: count,
-      };
-    })
+      });
+    } else {
+      parent.directAmount = (parent.directAmount ?? 0) + amount;
+      parent.directEntryCount = (parent.directEntryCount ?? 0) + count;
+      parent.categoryIcon = category?.icon ?? parent.categoryIcon;
+    }
+  }
+
+  const items: CategoryStatItem[] = [...parentStats.values()]
+    .map((item) => ({
+      ...item,
+      percentage:
+        total > 0 ? Math.round((item.amount / total) * 10000) / 100 : 0,
+      children: (item.children ?? [])
+        .map((child) => ({
+          ...child,
+          percentage:
+            item.amount > 0
+              ? Math.round((child.amount / item.amount) * 10000) / 100
+              : 0,
+        }))
+        .sort((a, b) => b.amount - a.amount),
+    }))
     .sort((a, b) => b.amount - a.amount);
 
   return { type, scope, total, items };
@@ -567,6 +666,8 @@ export interface LedgerStatsDetailParams {
   type?: "expense" | "income";
   scope: StatsScope;
   categoryId?: string | null;
+  childCategoryId?: string | null;
+  categoryBreakdown?: "direct";
   paymentMethodId?: string | null;
   limit?: number;
 }
@@ -598,6 +699,12 @@ function buildLedgerStatsDetailViewAllHref(
     "categoryId",
     params.categoryId === null ? "__none__" : params.categoryId,
   );
+  appendParam(
+    searchParams,
+    "childCategoryId",
+    params.childCategoryId ?? undefined,
+  );
+  appendParam(searchParams, "categoryBreakdown", params.categoryBreakdown);
   appendParam(
     searchParams,
     "paymentMethodId",
@@ -682,7 +789,7 @@ export async function getLedgerStatsDetail(
       created_at,
       updated_at,
       profiles!ledger_entries_owner_id_fkey ( id, name ),
-      categories ( id, name, icon ),
+      categories ( id, name, icon, parent_id ),
       from_account:accounts!ledger_entries_from_account_id_fkey ( id, name ),
       to_account:accounts!ledger_entries_to_account_id_fkey ( id, name ),
       from_payment_method:payment_methods!ledger_entries_from_payment_method_id_fkey ( id, name ),
@@ -704,8 +811,20 @@ export async function getLedgerStatsDetail(
     query = query.eq("type", params.type ?? "expense");
     if (params.categoryId === "__none__" || params.categoryId === null) {
       query = query.is("category_id", null);
-    } else if (params.categoryId) {
+    } else if (params.childCategoryId) {
+      query = query.eq("category_id", params.childCategoryId);
+    } else if (params.categoryId && params.categoryBreakdown === "direct") {
       query = query.eq("category_id", params.categoryId);
+    } else if (params.categoryId) {
+      const { data: children } = await supabase
+        .from("categories")
+        .select("id")
+        .eq("parent_id", params.categoryId);
+      const categoryIds = [
+        params.categoryId,
+        ...(children ?? []).map((c) => c.id),
+      ];
+      query = query.in("category_id", categoryIds);
     }
   }
 

--- a/lib/api/ledger.ts
+++ b/lib/api/ledger.ts
@@ -152,6 +152,9 @@ export interface GetLedgerEntriesOptions {
   scope?: "shared" | "personal";
   userId?: string;
   tagIds?: string[];
+  categoryId?: string | null;
+  childCategoryId?: string | null;
+  categoryBreakdown?: "direct";
 }
 
 export interface CreateLedgerEntryParams {
@@ -430,7 +433,7 @@ async function attachLedgerEntryDetails(
     categoryIds.length > 0
       ? supabase
           .from("categories")
-          .select("id, name, icon")
+          .select("id, name, icon, parent_id")
           .in("id", categoryIds)
       : Promise.resolve({ data: [] }),
     accountIds.length > 0
@@ -446,8 +449,28 @@ async function attachLedgerEntryDetails(
   ]);
 
   const ownerMap = new Map((profiles ?? []).map((p) => [p.id, p.name]));
+  const categoryRows = categories ?? [];
+  const parentCategoryIds = [
+    ...new Set(
+      categoryRows.map((c) => c.parent_id).filter(Boolean) as string[],
+    ),
+  ].filter((id) => !categoryRows.some((c) => c.id === id));
+  const { data: parentCategories } =
+    parentCategoryIds.length > 0
+      ? await supabase
+          .from("categories")
+          .select("id, name, icon, parent_id")
+          .in("id", parentCategoryIds)
+      : { data: [] };
   const categoryMap = new Map(
-    (categories ?? []).map((c) => [c.id, { name: c.name, icon: c.icon }]),
+    [...categoryRows, ...(parentCategories ?? [])].map((c) => [
+      c.id,
+      {
+        name: c.name,
+        icon: c.icon,
+        parentId: c.parent_id as string | null,
+      },
+    ]),
   );
   const accountMap = new Map((accounts ?? []).map((a) => [a.id, a.name]));
   const paymentMethodMap = new Map(
@@ -464,10 +487,24 @@ async function attachLedgerEntryDetails(
     title: r.title,
     categoryId: r.category_id,
     categoryName: r.category_id
-      ? (categoryMap.get(r.category_id)?.name ?? null)
+      ? (() => {
+          const category = categoryMap.get(r.category_id);
+          const parent = category?.parentId
+            ? categoryMap.get(category.parentId)
+            : undefined;
+          return parent && category
+            ? `${parent.name} > ${category.name}`
+            : (category?.name ?? null);
+        })()
       : null,
     categoryIcon: r.category_id
-      ? (categoryMap.get(r.category_id)?.icon ?? null)
+      ? (() => {
+          const category = categoryMap.get(r.category_id);
+          const parent = category?.parentId
+            ? categoryMap.get(category.parentId)
+            : undefined;
+          return category?.icon ?? parent?.icon ?? null;
+        })()
       : null,
     fromAccountId: r.from_account_id,
     fromAccountName: r.from_account_id
@@ -566,6 +603,32 @@ export async function getLedgerEntries(
     }
   }
 
+  let categoryFilterIds: string[] | null = null;
+  if (options?.childCategoryId) {
+    categoryFilterIds = [options.childCategoryId];
+  } else if (options?.categoryId && options.categoryId !== "__none__") {
+    if (options.categoryBreakdown === "direct") {
+      categoryFilterIds = [options.categoryId];
+    } else {
+      const { data: children, error: childrenError } = await supabase
+        .from("categories")
+        .select("id")
+        .eq("parent_id", options.categoryId);
+      if (childrenError) {
+        console.error("Category children fetch error:", childrenError);
+        throw new APIError(
+          "LEDGER_CATEGORY_FETCH_ERROR",
+          "카테고리 조회에 실패했습니다.",
+          500,
+        );
+      }
+      categoryFilterIds = [
+        options.categoryId,
+        ...(children ?? []).map((child) => child.id),
+      ];
+    }
+  }
+
   const query = supabase
     .from("ledger_entries")
     .select("*")
@@ -575,6 +638,12 @@ export async function getLedgerEntries(
 
   if (matchingIds !== null) {
     query.in("id", matchingIds);
+  }
+
+  if (options?.categoryId === "__none__" || options?.categoryId === null) {
+    query.is("category_id", null);
+  } else if (categoryFilterIds) {
+    query.in("category_id", categoryFilterIds);
   }
 
   const { data, error } = await query

--- a/lib/api/record-change-requests.ts
+++ b/lib/api/record-change-requests.ts
@@ -45,6 +45,31 @@ interface LedgerEntryTargetRow {
   profiles: { name: string | null } | null;
 }
 
+async function getCategoryDisplay(
+  supabase: SupabaseClient<Database>,
+  categoryId: string | null,
+): Promise<{ name: string | null; icon: string | null }> {
+  if (!categoryId) return { name: null, icon: null };
+  const { data: category } = await supabase
+    .from("categories")
+    .select("id, name, icon, parent_id")
+    .eq("id", categoryId)
+    .maybeSingle();
+  if (!category) return { name: null, icon: null };
+  if (!category.parent_id) {
+    return { name: category.name, icon: category.icon };
+  }
+  const { data: parent } = await supabase
+    .from("categories")
+    .select("name, icon")
+    .eq("id", category.parent_id)
+    .maybeSingle();
+  return {
+    name: parent?.name ? `${parent.name} > ${category.name}` : category.name,
+    icon: category.icon ?? parent?.icon ?? null,
+  };
+}
+
 interface StockTransactionTargetRow {
   id: string;
   household_id: string;
@@ -170,6 +195,8 @@ export async function validateRecordChangeRequestTarget(
       );
     }
 
+    const category = await getCategoryDisplay(supabase, row.category_id);
+
     return {
       householdId: row.household_id,
       targetOwnerId: row.owner_id,
@@ -180,7 +207,7 @@ export async function validateRecordChangeRequestTarget(
         title: row.title,
         amount: Number(row.amount),
         type: row.type,
-        categoryName: row.categories?.name ?? null,
+        categoryName: category.name ?? row.categories?.name ?? null,
         isShared: row.is_shared,
       },
     };

--- a/lib/queries/keys.ts
+++ b/lib/queries/keys.ts
@@ -119,7 +119,9 @@ export const queries = createQueryKeyStore({
 
   categories: {
     all: null,
-    list: (type?: "expense" | "income") => ({ queryKey: [type] }),
+    list: (type?: "expense" | "income", parentId?: string) => ({
+      queryKey: [type, parentId],
+    }),
   },
 
   ledgerEntries: {
@@ -131,6 +133,9 @@ export const queries = createQueryKeyStore({
       date?: string;
       scope?: "shared" | "personal";
       tagIds?: string[];
+      categoryId?: string | null;
+      childCategoryId?: string | null;
+      categoryBreakdown?: string;
     }) => ({
       queryKey: [params],
     }),
@@ -188,6 +193,8 @@ export const queries = createQueryKeyStore({
       type?: string;
       scope?: string;
       categoryId?: string | null;
+      childCategoryId?: string | null;
+      categoryBreakdown?: string;
       paymentMethodId?: string | null;
       limit?: number;
     }) => ({ queryKey: [params] }),

--- a/lib/transitions/page-transition-rules.test.ts
+++ b/lib/transitions/page-transition-rules.test.ts
@@ -96,6 +96,12 @@ describe("page transition rules", () => {
     });
     expect(getPageTransitionRules("mobile")).toContainEqual({
       kind: "drill",
+      enter: "/ledger/categories/*",
+      exit: "/ledger/categories",
+      type: "parallax",
+    });
+    expect(getPageTransitionRules("mobile")).toContainEqual({
+      kind: "drill",
       enter: "/assets/stock/transactions/*",
       exit: "/assets/stock/records",
       type: "parallax",

--- a/lib/transitions/page-transition-rules.ts
+++ b/lib/transitions/page-transition-rules.ts
@@ -90,6 +90,12 @@ export function getPageTransitionRules(
         },
         {
           kind: "drill",
+          enter: "/ledger/categories/*",
+          exit: "/ledger/categories",
+          type: "parallax",
+        },
+        {
+          kind: "drill",
           enter: "/assets/*",
           exit: "/assets",
           type: "parallax",

--- a/schemas/category.test.ts
+++ b/schemas/category.test.ts
@@ -31,6 +31,24 @@ describe("createCategorySchema", () => {
     expect(result.success).toBe(true);
   });
 
+  it("parentId가 있으면 child category 생성 입력으로 파싱된다", () => {
+    const result = createCategorySchema.safeParse({
+      type: "expense",
+      name: "외식",
+      parentId: "550e8400-e29b-41d4-a716-446655440000",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("parentId가 UUID 형식이 아니면 실패한다", () => {
+    const result = createCategorySchema.safeParse({
+      type: "expense",
+      name: "외식",
+      parentId: "not-a-uuid",
+    });
+    expect(result.success).toBe(false);
+  });
+
   it("유효하지 않은 type이면 실패한다", () => {
     const result = createCategorySchema.safeParse({
       type: "transfer",
@@ -98,6 +116,14 @@ describe("updateCategorySchema", () => {
     const result = updateCategorySchema.safeParse({ name: "a".repeat(21) });
     expect(result.success).toBe(false);
   });
+
+  it("parentId를 move operation으로 받지 않는다", () => {
+    const result = updateCategorySchema.safeParse({
+      name: "새이름",
+      parentId: "550e8400-e29b-41d4-a716-446655440000",
+    });
+    expect(result.success).toBe(false);
+  });
 });
 
 describe("reorderCategoriesSchema", () => {
@@ -132,6 +158,14 @@ describe("reorderCategoriesSchema", () => {
   it("displayOrder가 0이면 파싱된다", () => {
     const result = reorderCategoriesSchema.safeParse({
       orders: [{ id: validUuid, displayOrder: 0 }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("parentId가 있으면 child sibling reorder 입력으로 파싱된다", () => {
+    const result = reorderCategoriesSchema.safeParse({
+      parentId: validUuid,
+      orders: [{ id: "550e8400-e29b-41d4-a716-446655440001", displayOrder: 0 }],
     });
     expect(result.success).toBe(true);
   });

--- a/schemas/category.ts
+++ b/schemas/category.ts
@@ -15,26 +15,38 @@ export const createCategorySchema = z.object({
     .max(50, "아이콘명은 50자 이내여야 합니다.")
     .nullable()
     .optional(),
-});
-
-export type CreateCategoryInput = z.infer<typeof createCategorySchema>;
-
-export const updateCategorySchema = z.object({
-  name: z
+  parentId: z
     .string()
-    .min(1, "카테고리명을 입력해주세요.")
-    .max(20, "카테고리명은 20자 이내여야 합니다.")
-    .optional(),
-  icon: z
-    .string()
-    .max(50, "아이콘명은 50자 이내여야 합니다.")
+    .uuid("유효하지 않은 상위 카테고리 ID입니다.")
     .nullable()
     .optional(),
 });
 
+export type CreateCategoryInput = z.infer<typeof createCategorySchema>;
+
+export const updateCategorySchema = z
+  .object({
+    name: z
+      .string()
+      .min(1, "카테고리명을 입력해주세요.")
+      .max(20, "카테고리명은 20자 이내여야 합니다.")
+      .optional(),
+    icon: z
+      .string()
+      .max(50, "아이콘명은 50자 이내여야 합니다.")
+      .nullable()
+      .optional(),
+  })
+  .strict();
+
 export type UpdateCategoryInput = z.infer<typeof updateCategorySchema>;
 
 export const reorderCategoriesSchema = z.object({
+  parentId: z
+    .string()
+    .uuid("유효하지 않은 상위 카테고리 ID입니다.")
+    .nullable()
+    .optional(),
   orders: z
     .array(
       z.object({

--- a/supabase/migrations/20260621000000_add_category_parent_hierarchy.sql
+++ b/supabase/migrations/20260621000000_add_category_parent_hierarchy.sql
@@ -1,0 +1,19 @@
+alter table public.categories
+  add column parent_id uuid references public.categories(id) on delete restrict;
+
+alter table public.categories
+  add constraint categories_parent_not_self_check
+  check (parent_id is null or parent_id <> id);
+
+alter table public.categories
+  drop constraint categories_household_id_type_name_key;
+
+create unique index categories_parent_name_unique_idx
+  on public.categories (household_id, type, lower(name))
+  where parent_id is null;
+
+create unique index categories_child_name_unique_idx
+  on public.categories (parent_id, lower(name))
+  where parent_id is not null;
+
+create index categories_parent_id_idx on public.categories(parent_id);

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -145,6 +145,18 @@ VALUES
 -- 테스트 가구 기본 카테고리 생성 (#236)
 SELECT public.seed_household_categories('00000000-0000-4000-8000-000000000010');
 
+INSERT INTO public.categories (
+  id, household_id, type, name, icon, display_order, is_system, parent_id
+) VALUES
+('00000000-0000-4000-8000-000000000901', '00000000-0000-4000-8000-000000000010', 'expense', '배달', 'Bike', 0, false, (select id from public.categories where household_id = '00000000-0000-4000-8000-000000000010' and type = 'expense' and name = '식비' and parent_id is null)),
+('00000000-0000-4000-8000-000000000902', '00000000-0000-4000-8000-000000000010', 'expense', '장보기', 'ShoppingBasket', 1, false, (select id from public.categories where household_id = '00000000-0000-4000-8000-000000000010' and type = 'expense' and name = '식비' and parent_id is null)),
+('00000000-0000-4000-8000-000000000903', '00000000-0000-4000-8000-000000000010', 'expense', '외식', 'Store', 2, false, (select id from public.categories where household_id = '00000000-0000-4000-8000-000000000010' and type = 'expense' and name = '식비' and parent_id is null)),
+('00000000-0000-4000-8000-000000000904', '00000000-0000-4000-8000-000000000010', 'expense', '택시', 'Taxi', 0, false, (select id from public.categories where household_id = '00000000-0000-4000-8000-000000000010' and type = 'expense' and name = '교통비' and parent_id is null)),
+('00000000-0000-4000-8000-000000000905', '00000000-0000-4000-8000-000000000010', 'expense', '대중교통', 'Train', 1, false, (select id from public.categories where household_id = '00000000-0000-4000-8000-000000000010' and type = 'expense' and name = '교통비' and parent_id is null)),
+('00000000-0000-4000-8000-000000000906', '00000000-0000-4000-8000-000000000010', 'expense', '카페', 'Coffee', 0, false, (select id from public.categories where household_id = '00000000-0000-4000-8000-000000000010' and type = 'expense' and name = '여가/문화' and parent_id is null)),
+('00000000-0000-4000-8000-000000000907', '00000000-0000-4000-8000-000000000010', 'income', '본업', 'BriefcaseBusiness', 0, false, (select id from public.categories where household_id = '00000000-0000-4000-8000-000000000010' and type = 'income' and name = '급여' and parent_id is null)),
+('00000000-0000-4000-8000-000000000908', '00000000-0000-4000-8000-000000000010', 'income', '프리랜스', 'Laptop', 0, false, (select id from public.categories where household_id = '00000000-0000-4000-8000-000000000010' and type = 'income' and name = '부수입' and parent_id is null));
+
 -- ============================================================================
 -- 환율 초기 데이터
 -- ============================================================================
@@ -189,14 +201,14 @@ INSERT INTO public.ledger_entries (
   id, household_id, owner_id, amount, title, type, is_shared, memo, transacted_at, 
   from_payment_method_id, to_account_id, from_account_id, category_id, to_payment_method_id
 ) VALUES
-('00000000-0000-4000-8000-000000000301', '00000000-0000-4000-8000-000000000010', '00000000-0000-4000-8000-000000000001', 18500, '점심 식사', 'expense', true, '오늘 공유 지출 상세 확인용', now(), '00000000-0000-4000-8000-000000000201', null, null, (select id from public.categories where household_id = '00000000-0000-4000-8000-000000000010' and type = 'expense' and name = '식비'), null),
+('00000000-0000-4000-8000-000000000301', '00000000-0000-4000-8000-000000000010', '00000000-0000-4000-8000-000000000001', 18500, '점심 식사', 'expense', true, '오늘 공유 지출 상세 확인용', now(), '00000000-0000-4000-8000-000000000201', null, null, '00000000-0000-4000-8000-000000000903', null),
 ('00000000-0000-4000-8000-000000000302', '00000000-0000-4000-8000-000000000010', '00000000-0000-4000-8000-000000000001', 9900, '개인 구독', 'expense', false, '개인 기록 노출 범위 확인용', now() - interval '2 hours', '00000000-0000-4000-8000-000000000201', null, null, (select id from public.categories where household_id = '00000000-0000-4000-8000-000000000010' and type = 'expense' and name = '구독/정기결제'), null),
-('00000000-0000-4000-8000-000000000303', '00000000-0000-4000-8000-000000000010', '00000000-0000-4000-8000-000000000002', 42000, '장보기', 'expense', true, null, now() - interval '1 day', '00000000-0000-4000-8000-000000000203', null, null, (select id from public.categories where household_id = '00000000-0000-4000-8000-000000000010' and type = 'expense' and name = '식비'), null),
-('00000000-0000-4000-8000-000000000304', '00000000-0000-4000-8000-000000000010', '00000000-0000-4000-8000-000000000001', 3200000, '월급', 'income', true, '수입 상세 확인용', now() - interval '3 days', null, '00000000-0000-4000-8000-000000000101', null, (select id from public.categories where household_id = '00000000-0000-4000-8000-000000000010' and type = 'income' and name = '급여'), null),
-('00000000-0000-4000-8000-000000000305', '00000000-0000-4000-8000-000000000010', '00000000-0000-4000-8000-000000000002', 250000, '부수입 정산', 'income', false, '과거 개인 수입', now() - interval '35 days', null, '00000000-0000-4000-8000-000000000103', null, (select id from public.categories where household_id = '00000000-0000-4000-8000-000000000010' and type = 'income' and name = '부수입'), null),
+('00000000-0000-4000-8000-000000000303', '00000000-0000-4000-8000-000000000010', '00000000-0000-4000-8000-000000000002', 42000, '장보기', 'expense', true, null, now() - interval '1 day', '00000000-0000-4000-8000-000000000203', null, null, '00000000-0000-4000-8000-000000000902', null),
+('00000000-0000-4000-8000-000000000304', '00000000-0000-4000-8000-000000000010', '00000000-0000-4000-8000-000000000001', 3200000, '월급', 'income', true, '수입 상세 확인용', now() - interval '3 days', null, '00000000-0000-4000-8000-000000000101', null, '00000000-0000-4000-8000-000000000907', null),
+('00000000-0000-4000-8000-000000000305', '00000000-0000-4000-8000-000000000010', '00000000-0000-4000-8000-000000000002', 250000, '부수입 정산', 'income', false, '과거 개인 수입', now() - interval '35 days', null, '00000000-0000-4000-8000-000000000103', null, '00000000-0000-4000-8000-000000000908', null),
 ('00000000-0000-4000-8000-000000000306', '00000000-0000-4000-8000-000000000010', '00000000-0000-4000-8000-000000000001', 500000, '투자금 이체', 'transfer', true, '계좌 간 이체 검증', now() - interval '5 days', null, '00000000-0000-4000-8000-000000000102', '00000000-0000-4000-8000-000000000101', null, null),
 ('00000000-0000-4000-8000-000000000307', '00000000-0000-4000-8000-000000000010', '00000000-0000-4000-8000-000000000001', 50000, '현금 인출', 'transfer', true, null, now() - interval '6 days', null, null, '00000000-0000-4000-8000-000000000101', null, '00000000-0000-4000-8000-000000000202'),
-('00000000-0000-4000-8000-000000000308', '00000000-0000-4000-8000-000000000010', '00000000-0000-4000-8000-000000000002', 15800, '카페', 'expense', true, '일간조회 과거 날짜 상세 진입 확인용', now() - interval '14 days', '00000000-0000-4000-8000-000000000203', null, null, (select id from public.categories where household_id = '00000000-0000-4000-8000-000000000010' and type = 'expense' and name = '여가/문화'), null);
+('00000000-0000-4000-8000-000000000308', '00000000-0000-4000-8000-000000000010', '00000000-0000-4000-8000-000000000002', 15800, '카페', 'expense', true, '일간조회 과거 날짜 상세 진입 확인용', now() - interval '14 days', '00000000-0000-4000-8000-000000000203', null, null, '00000000-0000-4000-8000-000000000906', null);
 
 -- Stock Transactions
 INSERT INTO public.transactions (

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -183,6 +183,7 @@ export type Database = {
           id: string;
           is_system: boolean;
           name: string;
+          parent_id: string | null;
           type: Database["public"]["Enums"]["category_type"];
           updated_at: string;
         };
@@ -194,6 +195,7 @@ export type Database = {
           id?: string;
           is_system?: boolean;
           name: string;
+          parent_id?: string | null;
           type: Database["public"]["Enums"]["category_type"];
           updated_at?: string;
         };
@@ -205,10 +207,18 @@ export type Database = {
           id?: string;
           is_system?: boolean;
           name?: string;
+          parent_id?: string | null;
           type?: Database["public"]["Enums"]["category_type"];
           updated_at?: string;
         };
         Relationships: [
+          {
+            foreignKeyName: "categories_parent_id_fkey";
+            columns: ["parent_id"];
+            isOneToOne: false;
+            referencedRelation: "categories";
+            referencedColumns: ["id"];
+          },
           {
             foreignKeyName: "categories_household_id_fkey";
             columns: ["household_id"];


### PR DESCRIPTION
## Summary

- Make ledger category parent rows navigable with clearer affordance and replace lock icons with 기본 badges.
- Register category detail route metadata and drill transition so the shared page header handles navigation.
- Order category picker options by parent, show child labels as `Parent > Child`, and remove child-only indentation.

## Validation

- `pnpm vitest run constants/service-routes.test.ts lib/transitions/page-transition-rules.test.ts components/ledger/CategoryList.test.tsx components/ledger/CategoryChildrenPage.test.tsx components/ledger/LedgerCategoryCombobox.test.tsx`
- `pnpm type-check`
- `pnpm biome check constants/service-routes.ts lib/transitions/page-transition-rules.ts components/ledger/CategoryList.tsx components/ledger/CategoryChildrenPage.tsx components/ledger/LedgerCategoryCombobox.tsx components/ledger/LedgerCategoryCombobox.test.tsx components/ledger/CategoryList.test.tsx components/ledger/CategoryChildrenPage.test.tsx constants/service-routes.test.ts lib/transitions/page-transition-rules.test.ts`
