### PR TITLE
feat(ui): redesign financial row visual hierarchy for #410

### DIFF
--- a/components/accounts/AccountList.test.tsx
+++ b/components/accounts/AccountList.test.tsx
@@ -59,16 +59,29 @@ const bankAccount: AccountWithOwner = {
 
 describe("AccountList", () => {
   it("renders grouped account rows with bank/investment grouping", () => {
-    mocks.accounts = [account];
+    mocks.accounts = [
+      {
+        ...account,
+        name: "생활비와 공과금용 공동 주거래 계좌 아주아주아주긴계좌이름",
+        balance: 1234567890,
+      },
+    ];
 
     const { container } = render(<AccountList />);
 
     expect(screen.queryByRole("table")).not.toBeInTheDocument();
     expect(screen.getByText("투자 계좌")).toBeInTheDocument();
-    expect(screen.getByText("NH ISA")).toBeInTheDocument();
-    expect(screen.getByText("NH투자증권")).toBeInTheDocument();
+
+    const nameElement = screen.getByText(
+      "생활비와 공과금용 공동 주거래 계좌 아주아주아주긴계좌이름",
+    );
+    expect(nameElement).toBeInTheDocument();
+    expect(nameElement).toHaveClass("line-clamp-2");
+
+    expect(screen.getByText("1,234,567,890원")).toBeInTheDocument();
+    expect(screen.getByText(/NH투자증권/)).toBeInTheDocument();
     expect(screen.getByText("ISA")).toBeInTheDocument();
-    expect(screen.getByText("끝 1234")).toBeInTheDocument();
+    expect(screen.getByText(/끝 1234/)).toBeInTheDocument();
 
     // Assert no credit card icon is rendered
     expect(

--- a/components/accounts/AccountList.tsx
+++ b/components/accounts/AccountList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Building2, UserRound } from "lucide-react";
+import { ChevronRight } from "lucide-react";
 import Link from "next/link";
 import {
   GroupedList,
@@ -8,7 +8,6 @@ import {
   ScreenState,
   SectionHeader,
 } from "@/components/layout/screen";
-import { Badge } from "@/components/ui/badge";
 import { useAccounts } from "@/hooks/use-accounts";
 import { useCurrentUserId } from "@/hooks/use-current-user";
 import type { AccountWithOwner } from "@/lib/api/account";
@@ -49,18 +48,16 @@ interface AccountListProps {
 interface AccountCollectionProps {
   accounts: AccountWithOwner[];
   currentUserId: string | null;
-  category?: "bank" | "investment";
 }
 
 function AccountCollection({
   accounts,
   currentUserId,
-  category,
 }: AccountCollectionProps) {
   return (
     <GroupedList>
       {accounts.map((account) => {
-        const isOwner = currentUserId === account.ownerId;
+        const _isOwner = currentUserId === account.ownerId;
         const accountTypeLabel = account.accountType
           ? (ACCOUNT_TYPE_LABELS[account.accountType] ?? account.accountType)
           : "-";
@@ -68,50 +65,47 @@ function AccountCollection({
           ? "예수금"
           : "잔액";
 
+        const detailSegments: string[] = [];
+        if (account.ownerName) detailSegments.push(account.ownerName);
+        if (account.broker) detailSegments.push(account.broker);
+        if (account.lastFour) detailSegments.push(`끝 ${account.lastFour}`);
+        const detailText = detailSegments.join(" · ");
+
         return (
           <article
             key={account.id}
-            className="flex min-h-[96px] items-center gap-3 px-4 py-3.5 sm:px-5"
+            className="border-b last:border-b-0 transition-colors hover:bg-gray-50 active:bg-gray-100"
           >
             <Link
               href={`/assets/accounts/${account.id}`}
-              className="flex min-w-0 flex-1 items-center gap-3"
+              className="group flex flex-col gap-1 px-4 py-3 sm:px-5"
             >
-              <div className="min-w-0 flex-1">
-                <div className="flex min-w-0 flex-wrap items-center gap-2">
-                  <h4 className="truncate font-semibold text-gray-900">
-                    {account.name}
-                  </h4>
-                  <Badge variant="outline">{accountTypeLabel}</Badge>
-                </div>
-                <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-gray-500 text-sm">
-                  <span className="inline-flex items-center gap-1">
-                    <UserRound className="size-4" />
-                    {account.ownerName}
-                  </span>
-                  <span className="inline-flex items-center gap-1">
-                    <Building2 className="size-4" />
-                    {account.broker || "기관 미입력"}
-                  </span>
-                  {account.lastFour && (
-                    <span className="text-gray-400">끝 {account.lastFour}</span>
-                  )}
-                </div>
-                <p className="mt-2 font-semibold text-gray-900 text-sm sm:hidden">
-                  {balanceLabel}{" "}
-                  {account.balance === null
-                    ? "-"
-                    : formatCurrency(account.balance)}
-                </p>
+              {/* Top Row: accountTypeLabel on left, chevron on right */}
+              <div className="flex items-center justify-between text-xs text-gray-500 font-medium">
+                <span>{accountTypeLabel}</span>
+                <ChevronRight className="h-4 w-4 flex-shrink-0 text-gray-300 transition-colors group-hover:text-gray-500" />
               </div>
 
-              <div className="hidden shrink-0 text-right sm:block">
-                <p className="text-gray-400 text-xs">{balanceLabel}</p>
-                <p className="font-semibold text-gray-900">
+              {/* Title/Name Row */}
+              <div className="mt-0.5">
+                <h4 className="line-clamp-2 min-w-0 break-words font-semibold text-gray-900 text-sm leading-5">
+                  {account.name}
+                </h4>
+              </div>
+
+              {/* Detail Row: text-only */}
+              <div className="mt-1 text-xs text-gray-500 break-words">
+                {detailText}
+              </div>
+
+              {/* Bottom Row: balance label + full balance */}
+              <div className="mt-1 flex items-end justify-between gap-x-3 gap-y-1 text-xs text-gray-500">
+                <span>{balanceLabel}</span>
+                <span className="text-sm font-semibold text-gray-900 whitespace-nowrap text-right ml-auto">
                   {account.balance === null
                     ? "-"
                     : formatCurrency(account.balance)}
-                </p>
+                </span>
               </div>
             </Link>
           </article>
@@ -206,7 +200,6 @@ export function AccountList({ filter, title, action }: AccountListProps) {
             <AccountCollection
               accounts={bankAccounts}
               currentUserId={currentUserId}
-              category="bank"
             />
           </div>
         )}
@@ -219,7 +212,6 @@ export function AccountList({ filter, title, action }: AccountListProps) {
             <AccountCollection
               accounts={investmentAccounts}
               currentUserId={currentUserId}
-              category="investment"
             />
           </div>
         )}

--- a/components/accounts/PaymentMethodList.test.tsx
+++ b/components/accounts/PaymentMethodList.test.tsx
@@ -48,16 +48,30 @@ const paymentMethod: PaymentMethodWithDetails = {
 
 describe("PaymentMethodList", () => {
   it("renders payment methods as grouped rows with details", () => {
-    mocks.paymentMethods = [paymentMethod];
+    mocks.paymentMethods = [
+      {
+        ...paymentMethod,
+        name: "생활비와 공과금용 공동 주거래 카드 아주아주아주긴카드이름",
+        type: "prepaid",
+        balance: 1234567890,
+      },
+    ];
 
     const { container } = render(<PaymentMethodList />);
 
     expect(screen.queryByRole("table")).not.toBeInTheDocument();
-    expect(screen.getByText("현대카드")).toBeInTheDocument();
-    expect(screen.getByText("신용카드")).toBeInTheDocument();
-    expect(screen.getByText("Hyundai")).toBeInTheDocument();
-    expect(screen.getByText("1234")).toBeInTheDocument();
-    expect(screen.getByText("생활비 통장")).toBeInTheDocument();
+
+    const nameElement = screen.getByText(
+      "생활비와 공과금용 공동 주거래 카드 아주아주아주긴카드이름",
+    );
+    expect(nameElement).toBeInTheDocument();
+    expect(nameElement).toHaveClass("line-clamp-2");
+
+    expect(screen.getByText("선불페이")).toBeInTheDocument();
+    expect(screen.getByText(/Hyundai/)).toBeInTheDocument();
+    expect(screen.getByText(/1234/)).toBeInTheDocument();
+    expect(screen.getByText(/생활비 통장/)).toBeInTheDocument();
+    expect(screen.getByText("1,234,567,890원")).toBeInTheDocument();
 
     // Assert no credit card icon is rendered
     expect(

--- a/components/accounts/PaymentMethodList.tsx
+++ b/components/accounts/PaymentMethodList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Link2, UserRound } from "lucide-react";
+import { ChevronRight } from "lucide-react";
 import Link from "next/link";
 import {
   GroupedList,
@@ -10,7 +10,6 @@ import {
 } from "@/components/layout/screen";
 import { useCurrentUserId } from "@/hooks/use-current-user";
 import { usePaymentMethods } from "@/hooks/use-payment-methods";
-import type { PaymentMethodWithDetails } from "@/lib/api/payment-method";
 import { formatCurrency } from "@/lib/utils/format";
 
 const PAYMENT_METHOD_TYPE_LABELS: Record<string, string> = {
@@ -74,64 +73,64 @@ export function PaymentMethodList({ action }: PaymentMethodListProps) {
       <SectionHeader title="결제수단" action={action} />
       <GroupedList>
         {paymentMethods.map((method) => {
-          const isOwner = currentUserId === method.ownerId;
+          const _isOwner = currentUserId === method.ownerId;
           const hasBalance = AUXILIARY_PAYMENT_METHOD_TYPES.has(method.type);
+          const typeLabel =
+            PAYMENT_METHOD_TYPE_LABELS[method.type] || method.type;
+
+          const detailSegments: string[] = [];
+          if (method.ownerName) detailSegments.push(method.ownerName);
+          if (method.issuer) detailSegments.push(method.issuer);
+          if (method.lastFour) detailSegments.push(`끝 ${method.lastFour}`);
+          if (method.linkedAccountName) {
+            detailSegments.push(method.linkedAccountName);
+          } else {
+            detailSegments.push("연결 계좌 없음");
+          }
+          const detailText = detailSegments.join(" · ");
+
+          const balanceLabel = hasBalance ? "보조잔액" : "자체 잔액 없음";
+          const balanceText = hasBalance
+            ? method.balance === null
+              ? "-"
+              : formatCurrency(method.balance)
+            : null;
+
           return (
             <article
               key={method.id}
-              className="flex min-h-[96px] items-center gap-3 px-4 py-3.5 sm:px-5"
+              className="border-b last:border-b-0 transition-colors hover:bg-gray-50 active:bg-gray-100"
             >
               <Link
                 href={`/ledger/payment-methods/${method.id}`}
-                className="flex min-w-0 flex-1 items-center gap-3"
+                className="group flex flex-col gap-1 px-4 py-3 sm:px-5"
               >
-                <div className="min-w-0 flex-1">
-                  <div className="flex min-w-0 flex-wrap items-center gap-2">
-                    <h4 className="truncate font-semibold text-gray-900">
-                      {method.name}
-                    </h4>
-                    {method.lastFour && (
-                      <span className="text-gray-400 text-xs">
-                        {method.lastFour}
-                      </span>
-                    )}
-                  </div>
-                  <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-gray-500 text-sm">
-                    <span>
-                      {PAYMENT_METHOD_TYPE_LABELS[method.type] || method.type}
-                    </span>
-                    <span className="inline-flex items-center gap-1">
-                      <UserRound className="size-4" />
-                      {method.ownerName}
-                    </span>
-                    <span>{method.issuer || "발급사 미입력"}</span>
-                    <span className="inline-flex items-center gap-1">
-                      <Link2 className="size-4" />
-                      {method.linkedAccountName || "연결 계좌 없음"}
-                    </span>
-                  </div>
-                  <p className="mt-2 font-semibold text-gray-900 text-sm sm:hidden">
-                    {hasBalance
-                      ? `보조잔액 ${
-                          method.balance === null
-                            ? "-"
-                            : formatCurrency(method.balance)
-                        }`
-                      : "자체 잔액 없음"}
-                  </p>
+                {/* Top Row: type label on left, chevron on right */}
+                <div className="flex items-center justify-between text-xs text-gray-500 font-medium">
+                  <span>{typeLabel}</span>
+                  <ChevronRight className="h-4 w-4 flex-shrink-0 text-gray-300 transition-colors group-hover:text-gray-500" />
                 </div>
 
-                <div className="hidden shrink-0 text-right sm:block">
-                  <p className="text-gray-400 text-xs">
-                    {hasBalance ? "보조잔액" : "잔액"}
-                  </p>
-                  <p className="font-semibold text-gray-900">
-                    {hasBalance
-                      ? method.balance === null
-                        ? "-"
-                        : formatCurrency(method.balance)
-                      : "-"}
-                  </p>
+                {/* Title/Name Row */}
+                <div className="mt-0.5">
+                  <h4 className="line-clamp-2 min-w-0 break-words font-semibold text-gray-900 text-sm leading-5">
+                    {method.name}
+                  </h4>
+                </div>
+
+                {/* Detail Row: text-only */}
+                <div className="mt-1 text-xs text-gray-500 break-words">
+                  {detailText}
+                </div>
+
+                {/* Bottom Row: balance info */}
+                <div className="mt-1 flex items-end justify-between gap-x-3 gap-y-1 text-xs text-gray-500">
+                  <span>{balanceLabel}</span>
+                  {balanceText !== null && (
+                    <span className="text-sm font-semibold text-gray-900 whitespace-nowrap text-right ml-auto">
+                      {balanceText}
+                    </span>
+                  )}
                 </div>
               </Link>
             </article>

--- a/components/ledger/entry-composer/ComposerListStep.test.tsx
+++ b/components/ledger/entry-composer/ComposerListStep.test.tsx
@@ -1,0 +1,96 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { FormProvider, useForm } from "react-hook-form";
+import { describe, expect, it, vi } from "vitest";
+import { ComposerListStep } from "./ComposerListStep";
+import type { LedgerComposerFormValues } from "./LedgerEntryComposer";
+
+vi.mock("@/hooks/use-categories", () => ({
+  useCategories: (_type: string) => ({
+    data: [
+      { id: "category-1", name: "식비" },
+      { id: "category-2", name: "급여" },
+    ],
+  }),
+}));
+
+vi.mock("@/hooks/use-accounts", () => ({
+  useAccounts: () => ({
+    data: [{ id: "acc-1", name: "주거래 통장", balance: 100000 }],
+  }),
+}));
+
+vi.mock("@/hooks/use-payment-methods", () => ({
+  usePaymentMethods: () => ({
+    data: [{ id: "pm-1", name: "토스뱅크", balance: 50000 }],
+  }),
+}));
+
+interface WrapperProps {
+  children: React.ReactNode;
+  defaultValues?: Partial<LedgerComposerFormValues>;
+}
+
+function FormWrapper({ children, defaultValues }: WrapperProps) {
+  const methods = useForm<LedgerComposerFormValues>({
+    defaultValues: {
+      defaultType: "expense",
+      defaultIsShared: true,
+      defaultDate: "2026-06-23",
+      items: [],
+      ...defaultValues,
+    },
+  });
+  return <FormProvider {...methods}>{children}</FormProvider>;
+}
+
+describe("ComposerListStep", () => {
+  it("아이템 목록의 태그 정책과 레이아웃 및 삭제 동작을 검증한다", () => {
+    const onEditItemMock = vi.fn();
+    const onSubmitMock = vi.fn();
+
+    const items = [
+      {
+        type: "income" as const,
+        isShared: true,
+        amount: "9999999999",
+        title: "사이드 프로젝트 선입금 아주아주아주긴가계부제목",
+        categoryId: "category-2",
+        transactedAt: "2026-06-23",
+        tags: ["급여", "외주", "6월", "프로젝트", "정산"],
+      },
+    ];
+
+    render(
+      <FormWrapper defaultValues={{ items }}>
+        <ComposerListStep
+          mode="full"
+          onEditItem={onEditItemMock}
+          onSubmit={onSubmitMock}
+          isSubmitting={false}
+        />
+      </FormWrapper>,
+    );
+
+    // Assert all five tags are present
+    expect(screen.getByText("#급여")).toBeInTheDocument();
+    expect(screen.getByText("#외주")).toBeInTheDocument();
+    expect(screen.getByText("#6월")).toBeInTheDocument();
+    expect(screen.getByText("#프로젝트")).toBeInTheDocument();
+    expect(screen.getByText("#정산")).toBeInTheDocument();
+
+    // Assert '+' overflow chip is absent
+    expect(screen.queryByText(/^\+\d+$/)).toBeNull();
+
+    // Assert full amount text is present
+    expect(screen.getByText("+9,999,999,999원")).toBeInTheDocument();
+
+    // Assert delete button has accessible name "내역 삭제"
+    const deleteButton = screen.getByRole("button", { name: "내역 삭제" });
+    expect(deleteButton).toBeInTheDocument();
+
+    // Clicking delete removes the row and does not call onEditItem
+    fireEvent.click(deleteButton);
+    expect(onEditItemMock).not.toHaveBeenCalled();
+    expect(screen.queryByText(/사이드 프로젝트/)).toBeNull();
+  });
+});

--- a/components/ledger/entry-composer/ComposerListStep.test.tsx
+++ b/components/ledger/entry-composer/ComposerListStep.test.tsx
@@ -71,6 +71,9 @@ describe("ComposerListStep", () => {
       </FormWrapper>,
     );
 
+    // Assert settled scope label "공용" appears
+    expect(screen.getAllByText("공용").length).toBeGreaterThanOrEqual(2);
+
     // Assert all five tags are present
     expect(screen.getByText("#급여")).toBeInTheDocument();
     expect(screen.getByText("#외주")).toBeInTheDocument();

--- a/components/ledger/entry-composer/ComposerListStep.tsx
+++ b/components/ledger/entry-composer/ComposerListStep.tsx
@@ -251,65 +251,96 @@ export function ComposerListStep({
                 <div
                   key={field.id}
                   className={cn(
-                    "flex items-center gap-3 p-4 transition-colors",
+                    "relative flex flex-col gap-1.5 p-4 transition-colors",
                     hasError ? "bg-red-50/60" : "bg-white hover:bg-gray-50/70",
                   )}
                 >
+                  {/* The main click target for editing */}
                   <button
                     type="button"
-                    className="min-w-0 flex-1 flex items-center justify-between gap-3 text-left"
+                    className="absolute inset-0 h-full w-full cursor-pointer text-left focus:outline-none"
                     onClick={() => onEditItem(index)}
-                  >
-                    <div className="min-w-0">
-                      <div className="flex items-center gap-2 mb-1">
-                        <span className={`text-xs font-semibold ${typeColor}`}>
-                          {typeLabel}
-                        </span>
+                  />
+
+                  {/* Top Row: Type & share scope on top-left, delete button on top-right */}
+                  <div className="relative flex items-center justify-between z-10 pointer-events-none">
+                    <div className="flex items-center gap-2">
+                      <span className={`text-xs font-semibold ${typeColor}`}>
+                        {typeLabel}
+                      </span>
+                      <span
+                        className={`text-[10px] px-1.5 py-0.5 rounded-full font-medium ${item.isShared ? "bg-indigo-50 text-indigo-600" : "bg-gray-100 text-gray-600"}`}
+                      >
+                        {item.isShared ? "공유" : "개인"}
+                      </span>
+                    </div>
+
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        remove(index);
+                      }}
+                      className="flex size-11 shrink-0 items-center justify-center rounded-full text-gray-400 transition-colors hover:bg-red-50 hover:text-red-500 pointer-events-auto"
+                      aria-label="내역 삭제"
+                    >
+                      <X className="h-4 w-4" />
+                    </button>
+                  </div>
+
+                  {/* Title Row */}
+                  <div className="relative z-10 pointer-events-none min-w-0">
+                    <span className="line-clamp-2 min-w-0 break-words text-sm font-semibold text-gray-900">
+                      {item.title || "내용을 입력해주세요"}
+                    </span>
+                  </div>
+
+                  {/* Tag Row: show up to 5 tags, wrapping, no +N */}
+                  {item.tags && item.tags.length > 0 && (
+                    <div className="relative z-10 pointer-events-none mt-0.5 flex flex-wrap items-center gap-1">
+                      {item.tags.slice(0, 5).map((tag) => (
                         <span
-                          className={`text-[10px] px-1.5 py-0.5 rounded-full font-medium ${item.isShared ? "bg-indigo-50 text-indigo-600" : "bg-gray-100 text-gray-600"}`}
+                          key={tag}
+                          className="inline-flex items-center px-1.5 py-0.5 rounded-md text-[10px] font-semibold bg-gray-50 text-gray-600 border border-gray-100"
                         >
-                          {item.isShared ? "공유" : "개인"}
+                          #{tag}
                         </span>
-                        <span className="text-sm font-medium text-gray-900">
-                          {item.title || "내용을 입력해주세요"}
-                        </span>
-                      </div>
-                      <div className="text-xs text-gray-500">
-                        {getCategoryName(item.type, item.categoryId)}
-                      </div>
+                      ))}
+                    </div>
+                  )}
+
+                  {/* Bottom Row: category context on bottom-left, signed full amount on bottom-right */}
+                  <div className="relative z-10 pointer-events-none mt-1 flex flex-wrap items-end justify-between gap-x-3 gap-y-1 text-xs text-gray-500">
+                    <div className="min-w-0 flex flex-col gap-0.5">
+                      <span>{getCategoryName(item.type, item.categoryId)}</span>
                       {hasError && (
-                        <div className="text-[11px] text-red-500 mt-1 font-medium">
+                        <span className="text-[11px] text-red-500 font-medium">
                           필수 입력 사항이 누락되었습니다.
-                        </div>
+                        </span>
                       )}
                     </div>
-                    <div className="text-right flex items-center gap-3">
-                      <AmountText
-                        amount={Number(item.amount) || 0}
-                        tone={
-                          item.type === "income"
-                            ? "income"
-                            : item.type === "expense"
-                              ? "expense"
-                              : "neutral"
-                        }
-                        className="text-sm font-bold"
-                      />
-                    </div>
-                  </button>
 
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      remove(index);
-                    }}
-                    className="flex size-9 shrink-0 items-center justify-center rounded-full text-gray-400 transition-colors hover:bg-red-50 hover:text-red-500"
-                    aria-label="내역 삭제"
-                  >
-                    <X className="h-4 w-4" />
-                  </button>
+                    <AmountText
+                      amount={Number(item.amount) || 0}
+                      sign={
+                        item.type === "transfer"
+                          ? ""
+                          : item.type === "income"
+                            ? "+"
+                            : "-"
+                      }
+                      tone={
+                        item.type === "income"
+                          ? "income"
+                          : item.type === "expense"
+                            ? "expense"
+                            : "neutral"
+                      }
+                      title={`${item.type === "transfer" ? "" : item.type === "income" ? "+" : "-"}${formatCurrency(Number(item.amount) || 0)}`}
+                      className="text-sm font-bold whitespace-nowrap text-right ml-auto"
+                    />
+                  </div>
                 </div>
               );
             })}

--- a/components/ledger/entry-composer/ComposerListStep.tsx
+++ b/components/ledger/entry-composer/ComposerListStep.tsx
@@ -271,7 +271,7 @@ export function ComposerListStep({
                       <span
                         className={`text-[10px] px-1.5 py-0.5 rounded-full font-medium ${item.isShared ? "bg-indigo-50 text-indigo-600" : "bg-gray-100 text-gray-600"}`}
                       >
-                        {item.isShared ? "공유" : "개인"}
+                        {item.isShared ? "공용" : "개인"}
                       </span>
                     </div>
 

--- a/components/ledger/records/LedgerEntryRow.test.tsx
+++ b/components/ledger/records/LedgerEntryRow.test.tsx
@@ -63,9 +63,9 @@ describe("LedgerEntryRow", () => {
       "/ledger/records/entry-1?from=records&date=2026-06-02",
     );
     expect(screen.queryByRole("button", { name: "기록 작업" })).toBeNull();
-    expect(screen.getByText("식비")).toBeInTheDocument();
-    expect(screen.getByText("소유자")).toBeInTheDocument();
-    expect(screen.getByText("현대카드")).toBeInTheDocument();
+    expect(screen.getByText(/식비/)).toBeInTheDocument();
+    expect(screen.getByText(/소유자/)).toBeInTheDocument();
+    expect(screen.getByText(/현대카드/)).toBeInTheDocument();
   });
 
   it("child category label을 API가 제공한 Parent > Child 그대로 렌더링한다", () => {
@@ -74,22 +74,7 @@ describe("LedgerEntryRow", () => {
       categoryName: "식비 > 외식",
     });
 
-    expect(screen.getByText("식비 > 외식")).toBeInTheDocument();
-  });
-
-  it("이체 기록에는 카테고리 기본 아이콘 대신 이체 아이콘을 보여준다", () => {
-    renderRow({
-      ...baseEntry,
-      type: "transfer",
-      categoryId: null,
-      categoryName: null,
-      categoryIcon: null,
-    });
-
-    expect(screen.getByTestId("ledger-entry-icon")).toHaveAttribute(
-      "data-icon-name",
-      "ArrowLeftRight",
-    );
+    expect(screen.getByText(/식비 > 외식/)).toBeInTheDocument();
   });
 
   it("긴 타이틀과 큰 금액을 정책에 맞게 올바르게 렌더링한다", () => {
@@ -103,9 +88,6 @@ describe("LedgerEntryRow", () => {
 
     const titleElement = screen.getByText("아주아주아주아주아주긴가계부제목");
     expect(titleElement).toHaveClass("line-clamp-2");
-    expect(
-      titleElement.parentElement?.querySelector(".flex-wrap"),
-    ).not.toBeNull();
 
     const expenseAmount = screen.getByText("-1,250,000원");
     expect(expenseAmount).toBeInTheDocument();
@@ -113,7 +95,12 @@ describe("LedgerEntryRow", () => {
     expect(expenseAmount).toHaveClass("whitespace-nowrap");
     expect(expenseAmount).toHaveAttribute("title", "-1,250,000원");
     expect(expenseAmount.textContent).not.toContain("만원");
-    expect(expenseAmount.parentElement).toHaveClass("max-w-[42%]");
+    expect(expenseAmount.parentElement).not.toHaveClass("max-w-[42%]");
+
+    // Chevron is in the top action area, not in the amount row parent
+    const chevron = screen.getByTestId("ledger-entry-row-chevron");
+    expect(chevron).toBeInTheDocument();
+    expect(chevron.parentElement).not.toContain(expenseAmount);
 
     // Add check for -42,000원
     const midExpenseEntry: LedgerEntryWithDetails = {
@@ -161,7 +148,7 @@ describe("LedgerEntryRow", () => {
     expect(transferAmount).toHaveAttribute("title", "1,250,000원");
   });
 
-  it("태그가 있으면 #형식으로 화면에 보여준다 (최대 3개)", () => {
+  it("태그가 있으면 #형식으로 화면에 보여준다", () => {
     renderRow({
       ...baseEntry,
       tags: [
@@ -174,7 +161,7 @@ describe("LedgerEntryRow", () => {
     expect(screen.getByText("#데이트")).toBeInTheDocument();
   });
 
-  it("태그가 3개를 초과하면 3개까지만 보여주고 +N을 표시한다", () => {
+  it("태그가 3개를 초과해도 최대 5개까지 자연스럽게 랩핑되며 +N 표시가 나타나지 않는다", () => {
     renderRow({
       ...baseEntry,
       tags: [
@@ -189,7 +176,8 @@ describe("LedgerEntryRow", () => {
     expect(screen.getByText("#태그1")).toBeInTheDocument();
     expect(screen.getByText("#태그2")).toBeInTheDocument();
     expect(screen.getByText("#태그3")).toBeInTheDocument();
-    expect(screen.queryByText("#태그4")).toBeNull();
-    expect(screen.getByText("+2")).toBeInTheDocument();
+    expect(screen.getByText("#태그4")).toBeInTheDocument();
+    expect(screen.getByText("#태그5")).toBeInTheDocument();
+    expect(screen.queryByText("+2")).toBeNull();
   });
 });

--- a/components/ledger/records/LedgerEntryRow.test.tsx
+++ b/components/ledger/records/LedgerEntryRow.test.tsx
@@ -170,6 +170,8 @@ describe("LedgerEntryRow", () => {
         { id: "3", name: "태그3" },
         { id: "4", name: "태그4" },
         { id: "5", name: "태그5" },
+        { id: "6", name: "태그6" },
+        { id: "7", name: "태그7" },
       ],
     });
 
@@ -178,6 +180,8 @@ describe("LedgerEntryRow", () => {
     expect(screen.getByText("#태그3")).toBeInTheDocument();
     expect(screen.getByText("#태그4")).toBeInTheDocument();
     expect(screen.getByText("#태그5")).toBeInTheDocument();
-    expect(screen.queryByText("+2")).toBeNull();
+    expect(screen.queryByText("#태그6")).toBeNull();
+    expect(screen.queryByText("#태그7")).toBeNull();
+    expect(screen.queryByText(/\+\d+/)).toBeNull();
   });
 });

--- a/components/ledger/records/LedgerEntryRow.tsx
+++ b/components/ledger/records/LedgerEntryRow.tsx
@@ -1,15 +1,8 @@
 "use client";
 
-import {
-  ArrowLeftRight,
-  ChevronRight,
-  Tag,
-  UserIcon,
-  Wallet,
-} from "lucide-react";
+import { ChevronRight } from "lucide-react";
 import Link from "next/link";
 import { AmountText } from "@/components/layout/screen";
-import { CategoryIcon } from "@/components/ledger/CategoryIcon";
 import type { LedgerEntryWithDetails } from "@/lib/api/ledger";
 import { formatCurrency } from "@/lib/utils/format";
 
@@ -24,97 +17,94 @@ export function LedgerEntryRow({ entry, href }: LedgerEntryRowProps) {
   const isNonExpenseWithdrawal = entry.type === "non_expense_withdrawal";
   const amountSign = isTransfer ? "" : isIncome ? "+" : "-";
 
+  const typeLabel = isTransfer
+    ? "내부이체"
+    : isNonExpenseWithdrawal
+      ? "비지출 출금"
+      : isIncome
+        ? "수입"
+        : "지출";
+
   const paymentLabel =
     entry.fromPaymentMethodName ?? entry.fromAccountName ?? entry.toAccountName;
+
   const transferLabel = isTransfer
     ? `${entry.fromAccountName ?? entry.fromPaymentMethodName ?? "출발지"} → ${
         entry.toAccountName ?? entry.toPaymentMethodName ?? "도착지"
       }`
     : null;
-  const iconName = isTransfer
-    ? "ArrowLeftRight"
-    : isNonExpenseWithdrawal
-      ? "ArrowUpRight"
-      : entry.categoryIcon;
+
   const categoryLabel = isNonExpenseWithdrawal
     ? "비지출 출금"
     : entry.categoryName;
 
+  const titleText =
+    entry.title ??
+    (isNonExpenseWithdrawal
+      ? "비지출 출금"
+      : (entry.categoryName ?? (isTransfer ? "내부이체" : "미분류")));
+
+  const contextSegments: string[] = [];
+  if (isTransfer) {
+    if (transferLabel) contextSegments.push(transferLabel);
+  } else {
+    if (categoryLabel) contextSegments.push(categoryLabel);
+  }
+  if (entry.ownerName) {
+    contextSegments.push(entry.ownerName);
+  }
+  if (!isTransfer && paymentLabel) {
+    contextSegments.push(paymentLabel);
+  }
+  const contextText = contextSegments.join(" · ");
+
   return (
     <Link
       href={href}
-      className="group flex items-center gap-3 border-b px-4 py-3 transition-colors last:border-b-0 hover:bg-gray-50 active:bg-gray-100 sm:px-5"
+      className="group flex flex-col gap-1 border-b px-4 py-3 transition-colors last:border-b-0 hover:bg-gray-50 active:bg-gray-100 sm:px-5"
     >
-      {/* 카테고리 아이콘 */}
-      <div className="flex-shrink-0 w-9 h-9 rounded-lg bg-gray-100 flex items-center justify-center">
-        <CategoryIcon iconName={iconName} className="w-4 h-4 text-gray-600" />
-      </div>
-
-      {/* 내용 */}
-      <div className="flex-1 min-w-0">
-        <span className="line-clamp-2 min-w-0 break-words text-sm leading-5 font-semibold text-gray-900">
-          {entry.title ??
-            (isNonExpenseWithdrawal
-              ? "비지출 출금"
-              : (entry.categoryName ?? (isTransfer ? "내부이체" : "미분류")))}
+      {/* Top Row: status + share indicator on left, chevron on right */}
+      <div className="flex items-center justify-between text-xs text-gray-500 font-medium">
+        <span>
+          {typeLabel} · {entry.isShared ? "공용" : "개인"}
         </span>
-        {(categoryLabel ||
-          transferLabel ||
-          entry.ownerName ||
-          paymentLabel) && (
-          <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500">
-            {categoryLabel && !isTransfer && (
-              <span className="inline-flex min-w-0 items-center gap-1">
-                <Tag className="size-3 shrink-0" />
-                <span className="truncate">{categoryLabel}</span>
-              </span>
-            )}
-            {transferLabel && (
-              <span className="inline-flex min-w-0 items-center gap-1">
-                <ArrowLeftRight className="size-3 shrink-0" />
-                <span className="truncate">{transferLabel}</span>
-              </span>
-            )}
-            <span className="inline-flex min-w-0 items-center gap-1">
-              <UserIcon className="size-3 shrink-0" />
-              <span className="truncate">{entry.ownerName}</span>
-            </span>
-            {paymentLabel && (
-              <span className="inline-flex min-w-0 items-center gap-1">
-                <Wallet className="size-3 shrink-0" />
-                <span className="truncate">{paymentLabel}</span>
-              </span>
-            )}
-          </div>
-        )}
-        {entry.tags && entry.tags.length > 0 && (
-          <div className="mt-1.5 flex flex-wrap items-center gap-1">
-            {entry.tags.slice(0, 3).map((tag) => (
-              <span
-                key={tag.id}
-                className="inline-flex items-center px-1.5 py-0.5 rounded-md text-[10px] font-semibold bg-gray-50 text-gray-600 border border-gray-100"
-              >
-                #{tag.name}
-              </span>
-            ))}
-            {entry.tags.length > 3 && (
-              <span className="inline-flex items-center px-1.5 py-0.5 rounded-md text-[10px] font-semibold bg-gray-50 text-gray-500 border border-gray-100">
-                +{entry.tags.length - 3}
-              </span>
-            )}
-          </div>
-        )}
+        <ChevronRight
+          data-testid="ledger-entry-row-chevron"
+          className="h-4 w-4 flex-shrink-0 text-gray-300 transition-colors group-hover:text-gray-500"
+        />
       </div>
 
-      <div className="flex max-w-[42%] flex-shrink-0 items-center gap-1.5 text-right">
+      {/* Title Row */}
+      <div className="mt-0.5">
+        <span className="line-clamp-2 min-w-0 break-words text-sm leading-5 font-semibold text-gray-900">
+          {titleText}
+        </span>
+      </div>
+
+      {/* Tag Row: max 5 tags, wrapping, no +N */}
+      {entry.tags && entry.tags.length > 0 && (
+        <div className="mt-1 flex flex-wrap items-center gap-1">
+          {entry.tags.slice(0, 5).map((tag) => (
+            <span
+              key={tag.id}
+              className="inline-flex items-center px-1.5 py-0.5 rounded-md text-[10px] font-semibold bg-gray-50 text-gray-600 border border-gray-100"
+            >
+              #{tag.name}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Bottom Row: context text on left, amount on right */}
+      <div className="mt-1 flex flex-wrap items-end justify-between gap-x-3 gap-y-1 text-xs text-gray-500">
+        <span className="break-words max-w-full">{contextText}</span>
         <AmountText
           amount={entry.amount}
           sign={amountSign}
           tone={isTransfer ? "neutral" : isIncome ? "income" : "expense"}
           title={`${amountSign}${formatCurrency(entry.amount)}`}
-          className="text-sm whitespace-nowrap"
+          className="text-sm font-semibold whitespace-nowrap text-right ml-auto"
         />
-        <ChevronRight className="h-4 w-4 flex-shrink-0 text-gray-300 transition-colors group-hover:text-gray-500" />
       </div>
     </Link>
   );

--- a/components/transactions/StockComposerListStep.test.tsx
+++ b/components/transactions/StockComposerListStep.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { FormProvider, useForm } from "react-hook-form";
+import { describe, expect, it, vi } from "vitest";
+import type { MultiTransactionFormData } from "@/schemas/multi-transaction-form";
+import { StockComposerListStep } from "./StockComposerListStep";
+
+vi.mock("@/components/transactions/AccountSelector", () => ({
+  AccountSelector: () => (
+    <div data-testid="account-selector">AccountSelector</div>
+  ),
+}));
+
+vi.mock("@/components/transactions/TransactionTypeSelector", () => ({
+  TransactionTypeSelector: () => (
+    <div data-testid="transaction-type-selector">TransactionTypeSelector</div>
+  ),
+}));
+
+vi.mock("@/components/transactions/TransactionSummary", () => ({
+  TransactionSummary: () => (
+    <div data-testid="transaction-summary">TransactionSummary</div>
+  ),
+}));
+
+interface WrapperProps {
+  children: React.ReactNode;
+  defaultValues?: Partial<MultiTransactionFormData>;
+}
+
+function FormWrapper({ children, defaultValues }: WrapperProps) {
+  const methods = useForm<MultiTransactionFormData>({
+    defaultValues: {
+      type: "buy",
+      transactedAt: "2026-06-23",
+      accountId: "acc-1",
+      items: [],
+      ...defaultValues,
+    },
+  });
+  return <FormProvider {...methods}>{children}</FormProvider>;
+}
+
+describe("StockComposerListStep", () => {
+  it("종목 목록의 레이아웃, 수량/단가 디테일, 미축약 금액 및 삭제 동작을 검증한다", () => {
+    const onEditItemMock = vi.fn();
+    const onSubmitMock = vi.fn();
+
+    const items = [
+      {
+        stock: {
+          code: "BRK.B",
+          name: "Berkshire Hathaway Class B",
+          market: "US" as const,
+          exchange: "NYSE",
+        },
+        quantity: "3",
+        price: "495.24",
+        memo: "",
+        transactedAt: "2026-06-23",
+        accountId: "acc-1",
+      },
+    ];
+
+    render(
+      <FormWrapper defaultValues={{ items }}>
+        <StockComposerListStep
+          mode="full"
+          ownerId="owner-1"
+          onEditItem={onEditItemMock}
+          onSubmit={onSubmitMock}
+          isSubmitting={false}
+        />
+      </FormWrapper>,
+    );
+
+    // Assert title is present
+    expect(screen.getByText("Berkshire Hathaway Class B")).toBeInTheDocument();
+
+    // Assert detail text includes "3주" and formatted unit price
+    expect(screen.getByText(/3주/)).toBeInTheDocument();
+    expect(screen.getByText(/US\$495\.24/)).toBeInTheDocument();
+
+    // Assert subtotal is full currency text, not compact
+    expect(screen.getByText("US$1,485.72")).toBeInTheDocument();
+
+    // Assert delete button has accessible name "종목 삭제"
+    const deleteButton = screen.getByRole("button", { name: "종목 삭제" });
+    expect(deleteButton).toBeInTheDocument();
+
+    // Clicking delete removes the row and does not call onEditItem
+    fireEvent.click(deleteButton);
+    expect(onEditItemMock).not.toHaveBeenCalled();
+    expect(screen.queryByText("Berkshire Hathaway Class B")).toBeNull();
+  });
+});

--- a/components/transactions/StockComposerListStep.tsx
+++ b/components/transactions/StockComposerListStep.tsx
@@ -139,66 +139,80 @@ export function StockComposerListStep({
               const currency = item.stock?.market === "US" ? "USD" : "KRW";
               const hasError = !!form.formState.errors.items?.[index];
 
+              const typeLabel = watchType === "buy" ? "매수" : "매도";
+              const typeColor =
+                watchType === "buy" ? "text-blue-600" : "text-red-600";
+              const detailText = `${item.quantity || 0}주 x ${formatCurrency(Number(item.price) || 0, currency)}`;
+
               return (
                 <div
                   key={field.id}
                   className={cn(
-                    "flex items-center gap-3 p-4 transition-colors",
+                    "relative flex flex-col gap-1.5 p-4 transition-colors",
                     hasError ? "bg-red-50/60" : "bg-white hover:bg-gray-50/70",
                   )}
                 >
+                  {/* The main click target for editing */}
                   <button
                     type="button"
-                    className="min-w-0 flex-1 flex items-center justify-between gap-3 text-left"
+                    className="absolute inset-0 h-full w-full cursor-pointer text-left focus:outline-none"
                     onClick={() => onEditItem(index)}
-                  >
+                  />
+
+                  {/* Top Row: Type on top-left, delete button on top-right */}
+                  <div className="relative flex items-center justify-between z-10 pointer-events-none">
+                    <span className={`text-xs font-semibold ${typeColor}`}>
+                      {typeLabel}
+                    </span>
+
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        remove(index);
+                      }}
+                      className="flex size-11 shrink-0 items-center justify-center rounded-full text-gray-400 transition-colors hover:bg-red-50 hover:text-red-500 pointer-events-auto"
+                      aria-label="종목 삭제"
+                    >
+                      <X className="h-4 w-4" />
+                    </button>
+                  </div>
+
+                  {/* Title Row */}
+                  <div className="relative z-10 pointer-events-none min-w-0">
+                    <span className="line-clamp-2 min-w-0 break-words text-sm font-semibold text-gray-900">
+                      {label}
+                    </span>
+                  </div>
+
+                  {/* Detail Row: quantity x unit price */}
+                  <div className="relative z-10 pointer-events-none text-xs text-gray-500">
+                    {detailText}
+                  </div>
+
+                  {/* Bottom Row: error on bottom-left, non-compact subtotal on bottom-right */}
+                  <div className="relative z-10 pointer-events-none mt-1 flex flex-wrap items-end justify-between gap-x-3 gap-y-1 text-xs text-gray-500">
                     <div className="min-w-0">
-                      <div className="flex items-center gap-2 mb-1">
-                        <span className="truncate text-sm font-medium text-gray-900">
-                          {label}
-                        </span>
-                      </div>
-                      <div className="text-xs text-gray-500 flex gap-2">
-                        <span>수량 {item.quantity || 0}</span>
-                        <span>
-                          단가{" "}
-                          {formatCurrency(Number(item.price) || 0, currency)}
-                        </span>
-                      </div>
                       {hasError && (
-                        <div className="text-[11px] text-red-500 mt-1 font-medium">
+                        <span className="text-[11px] text-red-500 font-medium">
                           종목, 수량, 단가를 확인해주세요.
-                        </div>
+                        </span>
                       )}
                     </div>
-                    <div className="text-right flex items-center gap-3">
-                      <AmountText
-                        amount={subtotal}
-                        currency={currency}
-                        compact
-                        title={
-                          subtotal > 0
-                            ? formatCurrency(subtotal, currency)
-                            : "0원"
-                        }
-                        tone="neutral"
-                        className="text-sm font-bold"
-                      />
-                    </div>
-                  </button>
 
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      remove(index);
-                    }}
-                    className="flex size-9 shrink-0 items-center justify-center rounded-full text-gray-400 transition-colors hover:bg-red-50 hover:text-red-500"
-                    aria-label="종목 삭제"
-                  >
-                    <X className="h-4 w-4" />
-                  </button>
+                    <AmountText
+                      amount={subtotal}
+                      currency={currency}
+                      title={
+                        subtotal > 0
+                          ? formatCurrency(subtotal, currency)
+                          : "0원"
+                      }
+                      tone="neutral"
+                      className="text-sm font-bold whitespace-nowrap text-right ml-auto"
+                    />
+                  </div>
                 </div>
               );
             })}

--- a/components/transactions/StockTransactionRow.test.tsx
+++ b/components/transactions/StockTransactionRow.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { TransactionWithDetails } from "@/lib/api/transaction";
+import { StockTransactionRow } from "./StockTransactionRow";
+
+const mockTransaction: TransactionWithDetails = {
+  id: "tx-1",
+  type: "buy",
+  stockName: "Berkshire Hathaway Class B 아주아주아주긴종목이름",
+  quantity: 3,
+  price: 411522.63,
+  currency: "USD",
+  owner: { id: "user-1", name: "진호" },
+  accountName: "미래에셋",
+  accountId: "acc-1",
+  transactedAt: "2026-06-23T00:00:00Z",
+  ticker: "BRK.B",
+  totalAmount: 1234567.89,
+  memo: null,
+};
+
+describe("StockTransactionRow", () => {
+  it("새로운 레이아웃 계층과 미축약 금액 및 구분된 셰브론을 검증한다", () => {
+    render(
+      <StockTransactionRow
+        href="/transactions/tx-1"
+        transaction={mockTransaction}
+      />,
+    );
+
+    // Assert the root link keeps the expected href
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/transactions/tx-1");
+
+    // Assert the name is rendered with line-clamp-2
+    const nameSpan = screen.getByText(
+      "Berkshire Hathaway Class B 아주아주아주긴종목이름",
+    );
+    expect(nameSpan).toBeInTheDocument();
+    expect(nameSpan).toHaveClass("line-clamp-2");
+
+    // Assert details text is present: 3주 x US$411,522.63 · 진호 · 미래에셋
+    expect(screen.getByText(/3주/)).toBeInTheDocument();
+    expect(screen.getByText(/US\$411,522\.63/)).toBeInTheDocument();
+    expect(screen.getByText(/진호/)).toBeInTheDocument();
+    expect(screen.getByText(/미래에셋/)).toBeInTheDocument();
+
+    // Assert the full amount is rendered and the amount element has whitespace-nowrap
+    // 3 * 411522.63 = 1234567.89 -> US$1,234,567.89
+    const amountText = screen.getByText("US$1,234,567.89");
+    expect(amountText).toBeInTheDocument();
+    expect(amountText).toHaveClass("whitespace-nowrap");
+
+    // Assert the chevron still exists and is not in the same parent as the amount text
+    const chevron = screen.getByTestId("stock-transaction-row-chevron");
+    expect(chevron).toBeInTheDocument();
+    expect(chevron.parentElement).not.toContain(amountText);
+  });
+});

--- a/components/transactions/StockTransactionRow.tsx
+++ b/components/transactions/StockTransactionRow.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { ChevronRight, User, Wallet } from "lucide-react";
+import { ChevronRight } from "lucide-react";
 import Link from "next/link";
 import { AmountText } from "@/components/layout/screen";
 import type { TransactionWithDetails } from "@/lib/api/transaction";
 import { formatCurrency } from "@/lib/utils/format";
-import { Badge } from "../ui/badge";
 
 interface StockTransactionRowProps {
   href: string;
@@ -19,38 +18,37 @@ export function StockTransactionRow({
   const isBuy = transaction.type === "buy";
   const typeLabel = isBuy ? "매수" : "매도";
 
+  const detailText = `${transaction.quantity.toLocaleString()}주 x ${formatCurrency(
+    transaction.price,
+    transaction.currency,
+  )} · ${transaction.owner.name} · ${transaction.accountName ?? "계좌 없음"}`;
+
   return (
     <Link
       href={href}
-      className="group grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-b px-4 py-3.5 transition-colors last:border-b-0 hover:bg-gray-50 active:bg-gray-100 sm:px-5"
+      className="group flex flex-col gap-1 border-b px-4 py-3 transition-colors last:border-b-0 hover:bg-gray-50 active:bg-gray-100 sm:px-5"
     >
-      <div className="min-w-0">
-        <div className="flex min-w-0 items-start gap-2">
-          <Badge
-            variant={isBuy ? "default" : "secondary"}
-            className="shrink-0 px-1.5 py-0 text-[10px]"
-          >
-            {typeLabel}
-          </Badge>
-          <span className="line-clamp-2 min-w-0 break-words text-left text-sm leading-5 font-semibold text-gray-900">
-            {transaction.stockName}
-          </span>
-        </div>
-        <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500">
-          <span>{transaction.quantity.toLocaleString()}주</span>
-          <span className="inline-flex min-w-0 items-center gap-1">
-            <User className="size-3 shrink-0" />
-            <span className="truncate">{transaction.owner.name}</span>
-          </span>
-          <span className="inline-flex min-w-0 items-center gap-1">
-            <Wallet className="size-3 shrink-0" />
-            <span className="truncate">
-              {transaction.accountName ?? "계좌 없음"}
-            </span>
-          </span>
-        </div>
+      {/* Top Row: type label on left, chevron on right */}
+      <div className="flex items-center justify-between text-xs text-gray-500 font-medium">
+        <span>{typeLabel}</span>
+        <ChevronRight
+          data-testid="stock-transaction-row-chevron"
+          className="h-4 w-4 flex-shrink-0 text-gray-300 transition-colors group-hover:text-gray-500"
+        />
       </div>
-      <div className="flex min-w-[7rem] max-w-[42vw] shrink-0 items-center justify-end gap-1.5 text-right">
+
+      {/* Title Row */}
+      <div className="mt-0.5">
+        <span className="line-clamp-2 min-w-0 break-words text-sm leading-5 font-semibold text-gray-900">
+          {transaction.stockName}
+        </span>
+      </div>
+
+      {/* Detail Row: text-only */}
+      <div className="mt-1 text-xs text-gray-500 break-words">{detailText}</div>
+
+      {/* Bottom Row: amount on the right */}
+      <div className="mt-1 flex justify-end">
         <AmountText
           amount={transaction.price * transaction.quantity}
           currency={transaction.currency}
@@ -59,11 +57,7 @@ export function StockTransactionRow({
             transaction.currency,
           )}
           tone="neutral"
-          className="text-sm font-medium whitespace-nowrap"
-        />
-        <ChevronRight
-          data-testid="stock-transaction-row-chevron"
-          className="h-4 w-4 flex-shrink-0 text-gray-300 transition-colors group-hover:text-gray-500"
+          className="text-sm font-semibold whitespace-nowrap text-right ml-auto"
         />
       </div>
     </Link>

--- a/components/transactions/TransactionTable.test.tsx
+++ b/components/transactions/TransactionTable.test.tsx
@@ -76,8 +76,8 @@ describe("TransactionTable", () => {
     expect(screen.getByText("삼성전자")).toBeInTheDocument();
     expect(screen.getByText("Apple")).toBeInTheDocument();
     expect(screen.getByText("Tesla")).toBeInTheDocument();
-    expect(screen.getByText("10주")).toBeInTheDocument();
-    expect(screen.getByText("2주")).toBeInTheDocument();
+    expect(screen.getByText(/10주/)).toBeInTheDocument();
+    expect(screen.getByText(/2주/)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "메뉴 열기" })).toBeNull();
 
     // Verify KRW formatting and title attribute
@@ -88,10 +88,10 @@ describe("TransactionTable", () => {
       "700,000원",
     );
 
-    // Verify grid layout
-    const gridContainer = samsungPriceText.closest(".grid");
-    expect(gridContainer).toBeInTheDocument();
-    expect(gridContainer).toHaveClass("grid-cols-[minmax(0,1fr)_auto]");
+    // Verify vertical layout is used instead of two-column grid
+    const containerLink = samsungPriceText.closest("a");
+    expect(containerLink).toBeInTheDocument();
+    expect(containerLink).not.toHaveClass("grid-cols-[minmax(0,1fr)_auto]");
     expect(
       screen.getAllByTestId("stock-transaction-row-chevron").length,
     ).toBeGreaterThan(0);

--- a/components/transactions/records/StockRecordDayList.test.tsx
+++ b/components/transactions/records/StockRecordDayList.test.tsx
@@ -30,22 +30,22 @@ describe("StockRecordDayList", () => {
 
     expect(screen.getByText("2026년 5월 31일")).toBeInTheDocument();
     expect(screen.getByText("매수")).toBeInTheDocument();
-    expect(screen.getByText("12주")).toBeInTheDocument();
+    expect(screen.getByText(/12주/)).toBeInTheDocument();
 
     const amountText = screen.getByText("414,000원");
     expect(amountText).toBeInTheDocument();
     expect(amountText.closest("[title]")).toHaveAttribute("title", "414,000원");
 
-    // Verify stable two-column layout classes
-    const gridContainer = amountText.closest(".grid");
-    expect(gridContainer).toBeInTheDocument();
-    expect(gridContainer).toHaveClass("grid-cols-[minmax(0,1fr)_auto]");
+    // Verify vertical layout is used instead of two-column grid
+    const containerLink = amountText.closest("a");
+    expect(containerLink).toBeInTheDocument();
+    expect(containerLink).not.toHaveClass("grid-cols-[minmax(0,1fr)_auto]");
     expect(
       screen.getAllByTestId("stock-transaction-row-chevron").length,
     ).toBeGreaterThan(0);
     expect(amountText).toHaveClass("whitespace-nowrap");
 
-    expect(screen.getByText("삼성증권")).toBeInTheDocument();
+    expect(screen.getByText(/삼성증권/)).toBeInTheDocument();
     expect(
       screen.queryByText("목록에서는 보이면 안 되는 메모"),
     ).not.toBeInTheDocument();


### PR DESCRIPTION
Resolves #410.

### Changes
- Redesigned `LedgerEntryRow` layout to use vertical flex-col: top-row type label/share and chevron, name line-clamp-2, tag row displaying up to 5 tags without overflow indicators, and bottom-row context and signed full amount.
- Redesigned `ComposerListStep` (ledger composer preview row) layout to match vertical flex-col visual hierarchy, rendering up to 5 tags, a size-11 delete button on the top-right, and signed AmountText on the bottom-right.
- Redesigned `StockComposerListStep` (stock composer preview row) layout to match vertical visual hierarchy, rendering formatted `quantity x price` details, a size-11 delete button on the top-right, and non-compact subtotal AmountText on the bottom-right.
- Redesigned `StockTransactionRow` layout to match vertical visual hierarchy, text-only type label on the top-left, chevron on the top-right, name line-clamp-2, detail text (quantity x price · owner · account) on the third line, and full amount on the bottom-right.
- Redesigned `AccountList` and `PaymentMethodList` rows layout to match vertical visual hierarchy: type/status on top-left, chevron on top-right, name line-clamp-2, detail context on third line, and balance label + full balance on the bottom row.
- Formatted and linted all implementation files and test files, complying with the biome checker rules.