### PR TITLE
[codex] Mark viewed notifications as read

### DIFF
--- a/app/(main)/assets/stock/records/page.tsx
+++ b/app/(main)/assets/stock/records/page.tsx
@@ -1,8 +1,10 @@
 import { PageContainer } from "@/components/layout";
 import { StockRecordsClient } from "@/components/transactions/records/StockRecordsClient";
+import { markNotificationsAsReadForLinkBestEffort } from "@/lib/api/notifications";
 import { getKstToday } from "@/lib/date";
 import { normalizeRecordDate } from "@/lib/stock-records/records";
 import { requireUser } from "@/lib/supabase/auth";
+import { createClient } from "@/lib/supabase/server";
 
 interface StockRecordsPageProps {
   searchParams: Promise<{
@@ -13,13 +15,20 @@ interface StockRecordsPageProps {
 export default async function StockRecordsPage({
   searchParams,
 }: StockRecordsPageProps) {
-  await requireUser();
+  const user = await requireUser();
   const { date } = await searchParams;
   const today = getKstToday();
+  const initialDate = normalizeRecordDate(date, today);
+  const supabase = await createClient();
+
+  await markNotificationsAsReadForLinkBestEffort(supabase, user.id, {
+    kind: "stock_record_date",
+    params: { date: initialDate },
+  });
 
   return (
     <PageContainer maxWidth="default">
-      <StockRecordsClient initialDate={normalizeRecordDate(date, today)} />
+      <StockRecordsClient initialDate={initialDate} />
     </PageContainer>
   );
 }

--- a/app/(main)/ledger/records/page.tsx
+++ b/app/(main)/ledger/records/page.tsx
@@ -20,12 +20,13 @@ export default async function LedgerRecordsPage({
   await requireUser();
   const { date, scope } = await searchParams;
   const today = getKstToday();
+  const initialDate = normalizeRecordDate(date, today);
   const initialScope = scope === "personal" ? "personal" : "shared";
 
   return (
     <PageContainer maxWidth="default">
       <LedgerRecordsClient
-        initialDate={normalizeRecordDate(date, today)}
+        initialDate={initialDate}
         initialScope={initialScope}
       />
     </PageContainer>

--- a/app/(main)/settings/household/page.tsx
+++ b/app/(main)/settings/household/page.tsx
@@ -1,13 +1,19 @@
 import { HouseholdMembersCard } from "@/components/household/HouseholdMembersCard";
 import { HouseholdSettings } from "@/components/household/HouseholdSettings";
 import { PageContainer } from "@/components/layout";
+import { NotificationReadCacheInvalidator } from "@/components/notifications/NotificationReadCacheInvalidator";
 import { getHouseholdWithMembers } from "@/lib/api/household";
+import { markNotificationsAsReadForLinkBestEffort } from "@/lib/api/notifications";
 import { requireUser } from "@/lib/supabase/auth";
 import { createClient } from "@/lib/supabase/server";
 
 export default async function HouseholdPage() {
   const user = await requireUser();
   const supabase = await createClient();
+  await markNotificationsAsReadForLinkBestEffort(supabase, user.id, {
+    kind: "household_settings",
+  });
+
   const household = await getHouseholdWithMembers(supabase, user.id);
 
   const isOwner =
@@ -15,6 +21,7 @@ export default async function HouseholdPage() {
 
   return (
     <PageContainer maxWidth="medium">
+      <NotificationReadCacheInvalidator />
       {household ? (
         <>
           <HouseholdSettings

--- a/app/(main)/settings/notifications/page.tsx
+++ b/app/(main)/settings/notifications/page.tsx
@@ -1,12 +1,21 @@
 import { PageContainer } from "@/components/layout";
 import { NotificationSettingsClient } from "@/components/notifications";
+import { NotificationReadCacheInvalidator } from "@/components/notifications/NotificationReadCacheInvalidator";
+import { markNotificationsAsReadForLinkBestEffort } from "@/lib/api/notifications";
 import { requireUser } from "@/lib/supabase/auth";
+import { createClient } from "@/lib/supabase/server";
 
 export default async function NotificationSettingsPage() {
-  await requireUser();
+  const user = await requireUser();
+  const supabase = await createClient();
+
+  await markNotificationsAsReadForLinkBestEffort(supabase, user.id, {
+    kind: "notification_settings",
+  });
 
   return (
     <PageContainer maxWidth="medium">
+      <NotificationReadCacheInvalidator />
       <NotificationSettingsClient />
     </PageContainer>
   );

--- a/app/api/ledger-entries/[id]/route.ts
+++ b/app/api/ledger-entries/[id]/route.ts
@@ -10,6 +10,7 @@ import {
   notifyLedgerEntryDeleted,
   notifyLedgerEntryUpdated,
 } from "@/lib/api/ledger-notifications";
+import { markNotificationsAsReadForLinkBestEffort } from "@/lib/api/notifications";
 import { createClient } from "@/lib/supabase/server";
 import { updateLedgerEntrySchema } from "@/schemas/ledger-entry";
 
@@ -46,6 +47,10 @@ export async function GET(_request: Request, { params }: RouteParams) {
     }
 
     const entry = await getLedgerEntryById(supabase, id, householdId);
+    await markNotificationsAsReadForLinkBestEffort(supabase, user.id, {
+      kind: "ledger_record_detail",
+      params: { entryId: id },
+    });
 
     return NextResponse.json({ data: entry });
   } catch (error) {

--- a/app/api/ledger-entries/route.ts
+++ b/app/api/ledger-entries/route.ts
@@ -7,6 +7,7 @@ import {
   getLedgerEntries,
 } from "@/lib/api/ledger";
 import { notifyLedgerEntryCreated } from "@/lib/api/ledger-notifications";
+import { markNotificationsAsReadForLinkBestEffort } from "@/lib/api/notifications";
 import { createClient } from "@/lib/supabase/server";
 import { createLedgerEntrySchema } from "@/schemas/ledger-entry";
 
@@ -72,6 +73,12 @@ export async function GET(request: NextRequest) {
     };
 
     const entries = await getLedgerEntries(supabase, householdId, options);
+    if (dateParam) {
+      await markNotificationsAsReadForLinkBestEffort(supabase, user.id, {
+        kind: "ledger_record_date",
+        params: { date: dateParam },
+      });
+    }
 
     return NextResponse.json({ data: entries });
   } catch (error) {

--- a/app/api/record-change-requests/[id]/route.ts
+++ b/app/api/record-change-requests/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { APIError, toErrorResponse } from "@/lib/api/error";
+import { markNotificationsAsReadForLinkBestEffort } from "@/lib/api/notifications";
 import { getRecordChangeRequestById } from "@/lib/api/record-change-requests";
 import { createClient } from "@/lib/supabase/server";
 
@@ -21,6 +22,11 @@ export async function GET(_request: Request, { params }: RouteParams) {
     }
 
     const data = await getRecordChangeRequestById(supabase, user.id, id);
+    await markNotificationsAsReadForLinkBestEffort(supabase, user.id, {
+      kind: "record_change_request_detail",
+      params: { requestId: id },
+    });
+
     return NextResponse.json({ data });
   } catch (error) {
     if (error instanceof APIError) {

--- a/app/api/transactions/[id]/route.ts
+++ b/app/api/transactions/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { APIError, toErrorResponse } from "@/lib/api/error";
 import { getUserHouseholdId } from "@/lib/api/invitation";
+import { markNotificationsAsReadForLinkBestEffort } from "@/lib/api/notifications";
 import {
   notifyStockTransactionDeleted,
   notifyStockTransactionUpdated,
@@ -53,6 +54,10 @@ export async function GET(_request: Request, { params }: RouteParams) {
       id,
       householdId,
     );
+    await markNotificationsAsReadForLinkBestEffort(supabase, user.id, {
+      kind: "stock_transaction_detail",
+      params: { transactionId: id },
+    });
 
     return NextResponse.json({ data: transaction });
   } catch (error) {

--- a/components/notifications/NotificationInboxClient.tsx
+++ b/components/notifications/NotificationInboxClient.tsx
@@ -112,12 +112,6 @@ function NotificationItemRow({
   const config = NOTIFICATION_TYPE_CONFIG[notification.type];
   const isUnread = !notification.readAt;
 
-  const handleClick = () => {
-    if (isUnread) {
-      markRead.mutate(notification.id);
-    }
-  };
-
   const handleMarkRead = () => {
     if (isUnread) {
       markRead.mutate(notification.id);
@@ -131,7 +125,7 @@ function NotificationItemRow({
         isUnread && "bg-primary/[0.02] hover:bg-primary/[0.04]",
       )}
     >
-      <Link href={href} onClick={handleClick} className="block p-4 pr-12">
+      <Link href={href} className="block p-4 pr-12">
         <div className="flex items-start gap-3">
           <span
             className={cn(

--- a/components/notifications/NotificationReadCacheInvalidator.tsx
+++ b/components/notifications/NotificationReadCacheInvalidator.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
+import { queries } from "@/lib/queries/keys";
+
+export function NotificationReadCacheInvalidator() {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    void queryClient.invalidateQueries({
+      queryKey: queries.notifications._def,
+    });
+  }, [queryClient]);
+
+  return null;
+}

--- a/components/transactions/records/StockRecordsClient.tsx
+++ b/components/transactions/records/StockRecordsClient.tsx
@@ -5,7 +5,7 @@ import { addMonths, getYear, startOfMonth, subMonths } from "date-fns";
 import { ChevronLeft, ChevronRight, Plus } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -55,6 +55,12 @@ export function StockRecordsClient({ initialDate }: StockRecordsClientProps) {
     startOfMonth(initial),
   );
   const [selectedDate, setSelectedDate] = useState<Date>(initial);
+
+  useEffect(() => {
+    void queryClient.invalidateQueries({
+      queryKey: queries.notifications._def,
+    });
+  }, [queryClient]);
 
   const prevMonth = useMemo(() => subMonths(currentMonth, 1), [currentMonth]);
   const nextMonth = useMemo(() => addMonths(currentMonth, 1), [currentMonth]);

--- a/hooks/use-ledger-entries.ts
+++ b/hooks/use-ledger-entries.ts
@@ -82,10 +82,21 @@ async function fetchLedgerEntries(
 }
 
 export function useLedgerEntries(params?: LedgerEntriesParams) {
+  const queryClient = useQueryClient();
+
   return useQuery({
     queryKey: queries.ledgerEntries.list(params).queryKey,
-    queryFn: () => fetchLedgerEntries(params),
+    queryFn: async () => {
+      const entries = await fetchLedgerEntries(params);
+      if (params?.date) {
+        void queryClient.invalidateQueries({
+          queryKey: queries.notifications._def,
+        });
+      }
+      return entries;
+    },
     staleTime: 1000 * 60 * 5,
+    refetchOnMount: params?.date ? "always" : undefined,
   });
 }
 
@@ -94,10 +105,19 @@ async function fetchLedgerEntry(id: string): Promise<LedgerEntryWithDetails> {
 }
 
 export function useLedgerEntry(id: string) {
+  const queryClient = useQueryClient();
+
   return useQuery({
     queryKey: queries.ledgerEntries.detail(id).queryKey,
-    queryFn: () => fetchLedgerEntry(id),
+    queryFn: async () => {
+      const entry = await fetchLedgerEntry(id);
+      void queryClient.invalidateQueries({
+        queryKey: queries.notifications._def,
+      });
+      return entry;
+    },
     staleTime: 1000 * 60 * 5,
+    refetchOnMount: "always",
   });
 }
 

--- a/hooks/use-record-change-requests.ts
+++ b/hooks/use-record-change-requests.ts
@@ -71,10 +71,19 @@ async function resolveRecordChangeRequest({
 }
 
 export function useRecordChangeRequest(id: string) {
+  const queryClient = useQueryClient();
+
   return useQuery({
     queryKey: queries.recordChangeRequests.detail(id).queryKey,
-    queryFn: () =>
-      fetchApiData<RecordChangeRequest>(`/api/record-change-requests/${id}`),
+    queryFn: async () => {
+      const request = await fetchApiData<RecordChangeRequest>(
+        `/api/record-change-requests/${id}`,
+      );
+      void queryClient.invalidateQueries({
+        queryKey: queries.notifications._def,
+      });
+      return request;
+    },
   });
 }
 

--- a/hooks/use-transaction.ts
+++ b/hooks/use-transaction.ts
@@ -77,10 +77,19 @@ async function fetchTransaction(id: string): Promise<TransactionWithDetails> {
 }
 
 export function useTransaction(id: string) {
+  const queryClient = useQueryClient();
+
   return useQuery({
     queryKey: queries.transactions.detail(id).queryKey,
-    queryFn: () => fetchTransaction(id),
+    queryFn: async () => {
+      const transaction = await fetchTransaction(id);
+      void queryClient.invalidateQueries({
+        queryKey: queries.notifications._def,
+      });
+      return transaction;
+    },
     staleTime: 1000 * 60 * 5,
+    refetchOnMount: "always",
   });
 }
 

--- a/lib/api/notifications.test.ts
+++ b/lib/api/notifications.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { markNotificationsAsReadForLink } from "./notifications";
+
+function createNotificationReadSupabaseMock() {
+  const builder = {
+    update: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    is: vi.fn().mockReturnThis(),
+    contains: vi.fn().mockReturnThis(),
+    select: vi.fn().mockResolvedValue({
+      data: [{ id: "notification-1" }, { id: "notification-2" }],
+      error: null,
+    }),
+  };
+
+  return {
+    from: vi.fn((table: string) => {
+      if (table !== "notifications") {
+        throw new Error(`Unexpected table: ${table}`);
+      }
+      return builder;
+    }),
+    builder,
+  };
+}
+
+describe("notification read helpers", () => {
+  it("marks unread notifications for the visited link target as read", async () => {
+    const supabase = createNotificationReadSupabaseMock();
+
+    const count = await markNotificationsAsReadForLink(
+      supabase as never,
+      "user-1",
+      {
+        kind: "ledger_record_date",
+        params: { date: "2026-06-16" },
+      },
+    );
+
+    expect(count).toBe(2);
+    expect(supabase.from).toHaveBeenCalledWith("notifications");
+    expect(supabase.builder.update).toHaveBeenCalledWith({
+      read_at: expect.any(String),
+    });
+    expect(supabase.builder.eq).toHaveBeenCalledWith("recipient_id", "user-1");
+    expect(supabase.builder.eq).toHaveBeenCalledWith(
+      "link_kind",
+      "ledger_record_date",
+    );
+    expect(supabase.builder.is).toHaveBeenCalledWith("read_at", null);
+    expect(supabase.builder.contains).toHaveBeenCalledWith("link_params", {
+      date: "2026-06-16",
+    });
+    expect(supabase.builder.select).toHaveBeenCalledWith("id");
+  });
+
+  it("uses an empty params object for parameterless notification links", async () => {
+    const supabase = createNotificationReadSupabaseMock();
+
+    await markNotificationsAsReadForLink(supabase as never, "user-1", {
+      kind: "household_settings",
+    });
+
+    expect(supabase.builder.contains).toHaveBeenCalledWith("link_params", {});
+  });
+});

--- a/lib/api/notifications.ts
+++ b/lib/api/notifications.ts
@@ -206,6 +206,44 @@ export async function markAllNotificationsAsRead(
   return data?.length ?? 0;
 }
 
+export async function markNotificationsAsReadForLink(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+  link: NotificationLink,
+): Promise<number> {
+  const normalizedLink = normalizeNotificationLink(link);
+  if (!normalizedLink.linkKind) {
+    return 0;
+  }
+
+  const { data, error } = await supabase
+    .from("notifications")
+    .update({ read_at: new Date().toISOString() })
+    .eq("recipient_id", userId)
+    .eq("link_kind", normalizedLink.linkKind)
+    .is("read_at", null)
+    .contains("link_params", normalizedLink.linkParams)
+    .select("id");
+
+  if (error) {
+    throw error;
+  }
+
+  return data?.length ?? 0;
+}
+
+export async function markNotificationsAsReadForLinkBestEffort(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+  link: NotificationLink,
+): Promise<void> {
+  try {
+    await markNotificationsAsReadForLink(supabase, userId, link);
+  } catch (error) {
+    console.error("Linked notification read error:", error);
+  }
+}
+
 export async function getNotificationPreferences(
   supabase: SupabaseClient<Database>,
   userId: string,


### PR DESCRIPTION
## Summary

- Mark linked notifications as read from the successful record/detail GET APIs where those reads already happen.
- Keep page-level read handling only where there is no matching data fetch, such as stock record date and settings pages.
- Remove the notification inbox row-click read request so navigation does not add a separate client request.
- Add regression coverage for link-target read updates.

## Validation

- pnpm test components/notifications/NotificationInboxClient.test.tsx lib/api/notifications.test.ts
- pnpm type-check
- pnpm check
- git diff --check

Note: `pnpm check` exited 0 but reported existing lint warnings outside this change.
